### PR TITLE
feat(queue): persist and restore the queue without a review view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,29 @@
 
 Operating instructions for agents working in `codereview-annotator.nvim`.
 
+## Workflow for new changes
+
+Anything with a feature or design decision behind it runs through the skill chain below,
+in order. Do not skip to code.
+
+1. **`/to-prd`** — synthesises the conversation into a PRD and publishes it to the issue
+   tracker (a GitHub issue here) labelled `ready-for-agent`. It does not interview; it
+   works from what has already been discussed, so do that discussion first.
+2. **`/to-issues`** — breaks the PRD into independently-grabbable issues, one per vertical
+   slice.
+3. **Branch off the issue id**: `<type>/<issue>-<slug>`, e.g.
+   `feat/12-single-annotation-queue`. `<type>` is the Conventional Commits type the work
+   will land under, so the branch, the commits and the PR title all agree.
+4. **Commit** per the rules below. The `commit-msg` hook validates every one.
+5. **Open the PR** with `gh pr create`. The title is a Conventional Commits subject; the
+   body closes the issue (`Closes #12`).
+
+Both PRD skills are `disable-model-invocation: true` — **the user invokes them.** Ask for
+`/to-prd` rather than trying to run it, and never hand-roll a PRD to work around that.
+
+Straight-to-`master` is only for what has no issue behind it: docs corrections,
+formatting, CI plumbing. Anything a PRD was written for gets a branch and a PR.
+
 ## Commits
 
 **Conventional Commits, enforced by `.githooks/commit-msg`.** Install it once per clone —

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ opts = {
 }
 ```
 
+`scope = "none"` and `prerendered = true` are both load-bearing, and `pick_target`'s `cwd`
+is what decides whether refs survive. [`docs/herdr.md`](docs/herdr.md) explains why, and
+spells out which queue is which.
+
 </details>
 
 ## Configuration

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -1,0 +1,128 @@
+# Integrating with herdr
+
+A worked example of the three adapters, wiring a review batch to a Claude session running
+in another [herdr](https://github.com/herdr) tab.
+
+Nothing here is special-cased in the plugin — it is what `opts.send`, `opts.pick_target`
+and `opts.compose` are for. Read it as the reference integration; the same shape works for
+any transport.
+
+## Why an agent in another tab is the hard case
+
+A herdr agent is a **separate Claude process on its own IDE connection**. At-mentions
+cannot reach it — they broadcast over the local session's WebSocket and would land in the
+wrong Claude. So the payload has to be self-contained text, and every `@path` in it has to
+resolve against *that agent's* working directory rather than this Neovim's.
+
+That constraint is the reason `pick_target` hands back a `cwd`, and the reason refs are
+resolved at submit time instead of when a note is captured.
+
+## The wiring
+
+```lua
+{
+  dir = vim.fn.expand("~/Codes/lua/codereview-annotator.nvim"),
+  cmd = "CodeReview",
+  opts = {
+    -- Every adapter is wrapped in a closure so util.claude is not required while lazy
+    -- evaluates this spec.
+    send = function(payload, target)
+      require("util.claude").deliver({ scope = "none", prerendered = true }, target, payload)
+    end,
+    pick_target = function(cb)
+      require("util.claude").pick_target(cb)
+    end,
+    compose = function(ctx, on_accept, label)
+      require("util.claude").compose(ctx, on_accept, label)
+    end,
+  },
+}
+```
+
+`util.claude` here is a host-config module that already owns herdr routing, the `@file`
+composer and the delivery ordering. The point of the adapters is that none of that is
+reimplemented.
+
+## `send(payload, target)`
+
+`payload` is the fully rendered batch; `target` is whatever `pick_target` produced, or
+`nil` for local delivery. Two flags in the example are load-bearing and neither is
+obvious:
+
+**`scope = "none"`** — the batch already carries every path, range and diff block inline.
+Without it the delivery layer tries to prepend a context mention for a single file, which
+a batch does not have.
+
+**`prerendered = true`** — turns off the single-note reference deduper. That deduper
+exists because pressing `@` while annotating the file you are looking at yields a
+redundant whole-file ref; over a batch, though, repeated references to one file are
+normal and correct, and deduping would silently strip every mention after the first.
+
+Without a `send` adapter the payload goes to the `+` register instead, and the queue is
+kept rather than cleared — nothing consumed it, so dropping it would lose the review.
+
+## `pick_target(cb)`
+
+Call back with a table carrying at least `short` (shown in the winbar and the queue
+float's footer) and `cwd`. Call back with `nil` for "deliver locally".
+
+**`cwd` is the contract that matters.** At submit time every annotation's absolute path is
+re-resolved against it: inside that tree an entry becomes `@path#L12`, outside it degrades
+to an absolute path with its code inlined. Get `cwd` wrong and refs silently stop being
+emitted — the batch still arrives and still reads correctly, it just gets bulkier and
+loses its clickability.
+
+One sharp edge: `git rev-parse --show-toplevel` returns the canonical path, so on macOS a
+repo reached through `/var/...` has a root of `/private/var/...`. If an agent reports the
+symlinked form, the prefix match fails and every ref degrades. A `vim.uv.fs_realpath()` on
+both sides fixes it.
+
+## `compose(ctx, on_accept, label)`
+
+Collect note text and call `on_accept(target, text)`. Without it the plugin falls back to
+`vim.ui.input`.
+
+`ctx` carries `scope = "none"`, a `label` for the prompt (`"Bug · src/main.lua:12"`),
+`rel_path` and `file_path`.
+
+**The plugin ignores the `target` argument you pass to `on_accept`.** If your composer
+offers its own routing picker, that choice does not survive — routing is a property of the
+whole batch, not of one note, and is set with `<C-t>` on the review buffer instead. This
+is deliberate: a batch goes to one agent, and picking per note would raise the question of
+what to do when two notes disagree.
+
+## Which queue is which
+
+There are two, and they share nothing.
+
+| | This plugin | A host config's own queue |
+| --- | --- | --- |
+| Where | `lua/codereview/queue.lua` | e.g. `~/.config/nvim/lua/util/claude_queue.lua` |
+| Fed by | `<leader>r` — the review view | `<leader>a` — buffer/visual annotation |
+| Reviewed with | `require("codereview").queue()` | that config's own picker |
+| Persisted | **yes**, with git blob hashes | typically not — session only |
+| Survives a restart | yes; a moved file's note is flagged stale | no |
+
+**The queue the review view uses is the plugin's own.** The `send` adapter is called with
+an already-rendered batch, at the very end — it is a delivery hook, not a queue. Wiring
+`send` to a host config's delivery path does not route anything through that config's
+queue, and the two never see each other's entries.
+
+That means annotations captured in the review view are only ever reviewed and submitted
+through `:CodeReview`'s own float, and a host config's separate annotation flow keeps its
+own list. Deliberate — it lets an existing flow keep working untouched — but worth knowing
+before wondering why `<leader>a`'s queue looks empty after a review session.
+
+Persistence is the practical difference. The plugin records the git blob each entry was
+captured against, so after a restart a note whose file has changed comes back flagged
+`⚠ stale` and never travels as an `@ref`; its code is inlined instead. A session-scoped
+queue sidesteps that problem by not having it.
+
+## Failure modes worth knowing
+
+- **`herdr agent prompt` exits 0 even when it fails.** The error appears only in the JSON
+  body, so an integration that checks the exit code alone reports success on failure.
+- **`herdr` not on PATH** should degrade to local delivery, not an error on every submit.
+- **A long batch is one prompt.** Delivery waits for the agent to settle
+  (`--wait --until idle`), so a submit is not instant and the adapter should not block the
+  editor on it.

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -75,6 +75,34 @@ function M.persist(view)
   M.save(view.root, data)
 end
 
+---Write just the queue, leaving the rest of the document alone.
+---
+---For a capture made with no review view open. Such a capture has no `per_scope` to build
+---a scopes table from, so writing a whole document the way `persist` does would blank the
+---reviewed marks a review saved -- the queue would survive at the cost of the progress
+---next to it.
+---@param root string
+function M.persist_queue(root)
+  local data = M.load(root)
+  data.queue = queue.all()
+  M.save(root, data)
+end
+
+---Load the queue from disk when nothing has been captured in this session yet.
+---
+---Separate from `restore`, which needs a view and a scope to put reviewed marks back.
+---The queue needs neither: it is what you submit, not what you are looking at.
+---@param root string
+function M.restore_queue(root)
+  if queue.count() > 0 then
+    return
+  end
+  local data = M.load(root)
+  if data.queue and #data.queue > 0 then
+    queue.replace(data.queue)
+  end
+end
+
 ---Restore saved progress into a freshly opened view.
 ---@param view CRView
 ---@param scope_key string

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -192,11 +192,44 @@ function M.paint(keep_file)
   end
 end
 
+---The repository the queue belongs to when no view is open.
+---@return string|nil
+local function ambient_root()
+  return git.root(vim.fn.getcwd())
+end
+
 ---Write progress to disk. Called from every mutation rather than from `paint`, which
 ---also runs on resize and would turn a window drag into a stream of file writes.
+---
+---With a view, that means the reviewed marks and the queue together. Without one, only
+---the queue -- there are no marks to write, and writing the document anyway would blank
+---the ones a review left behind.
 function M.persist()
   if V then
     require("codereview.state").persist(V)
+    return
+  end
+  local root = ambient_root()
+  if root then
+    require("codereview.state").persist_queue(root)
+  end
+end
+
+-- Restored lazily, and once. `count()` is the sort of thing a statusline calls on every
+-- redraw, so reading the state file each time is not an option; and eagerly at startup is
+-- worse, because the working directory that decides which repository's queue to load may
+-- not be the one the user ends up in.
+local queue_restored = false
+
+---Load the persisted queue if this session has not seen it yet.
+local function ensure_queue()
+  if queue_restored then
+    return
+  end
+  queue_restored = true
+  local root = ambient_root()
+  if root then
+    require("codereview.state").restore_queue(root)
   end
 end
 
@@ -522,6 +555,7 @@ function M.set_scope(spec)
   V.reviewed = V.per_scope[key].reviewed
   V.expanded = V.per_scope[key].expanded
   require("codereview.state").restore(V, key)
+  queue_restored = true
   M.reconcile()
 
   if #files == 0 then
@@ -779,6 +813,7 @@ function M.submit()
   local queue = require("codereview.queue")
   local cfg = config.get()
 
+  ensure_queue()
   if queue.count() == 0 then
     info("Queue is empty — annotate something first")
     return
@@ -822,8 +857,10 @@ function M.submit()
   queue.clear()
   if M.current() then
     M.paint()
-    M.persist()
   end
+  -- Outside the `M.current()` guard: a batch submitted with no view still has to write the
+  -- emptied queue, or the entries it just sent come back on the next start.
+  M.persist()
   info(
     ("Submitted %d annotation%s to %s"):format(
       count,
@@ -838,6 +875,7 @@ end
 ---List the queued annotations, drop any of them, then submit the batch.
 function M.review_queue()
   local queue = require("codereview.queue")
+  ensure_queue()
   if queue.count() == 0 then
     info("Queue is empty — annotate something first")
     return
@@ -1226,6 +1264,7 @@ function M.open(spec)
   V.reviewed = V.per_scope[key].reviewed
   V.expanded = V.per_scope[key].expanded
   require("codereview.state").restore(V, key)
+  queue_restored = true
   M.reconcile()
 
   if cfg.panel.enabled then

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # open-time report, not a 
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 245 cases in ~5 seconds.
+The whole suite is about 258 cases in ~5 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -25,6 +25,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `fixtures/*.sh` | Build a fixture repository from scratch at a given path. Take a target path; safe to run by hand. |
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
+| `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The composer stub `interactive_spec` drives — deliberately not a spec. |
 | `perf.lua` | Open-time report on a 60-file diff. Not part of `make test`. |
 
@@ -37,6 +38,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files |
+| `viewless_spec` | The queue with no review view open: persist, restore, submit |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `interactive_spec` | The insert-mode leak, in a real pty-backed Neovim |

--- a/tests/codereview/viewless_child.lua
+++ b/tests/codereview/viewless_child.lua
@@ -1,0 +1,58 @@
+-- The writing half of viewless_spec, in its own process.
+--
+-- Two phases, in this order on purpose:
+--   1. a normal review that leaves reviewed marks in the state file, so the viewless
+--      write in phase 2 has something it could clobber;
+--   2. queueing with no review view open at all.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. Spawned with
+-- XDG_STATE_HOME and FIXTURE in its environment, and must NOT load tests/minimal_init.lua,
+-- which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+require("codereview").setup({ syntax = false })
+
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+
+--- Phase 1: a review, so the state file carries reviewed marks -------------------
+view.open("branch")
+local V = assert(view.current(), "the view did not open")
+for i, file in ipairs(V.files) do
+  if file.path == "src/main.lua" then
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[i], 0 })
+    view.toggle_reviewed()
+  end
+end
+assert(V.reviewed["src/main.lua"], "src/main.lua was not marked reviewed")
+
+view.close()
+assert(view.current() == nil, "the view did not close")
+
+--- Phase 2: queue with nothing open ---------------------------------------------
+queue.clear()
+queue.add({
+  type = "bug",
+  kind = "file",
+  path = "src/routes.lua",
+  abs_path = vim.fs.joinpath(fixture, "src/routes.lua"),
+  key = "src/routes.lua:f:0",
+  note = "queued with no view",
+})
+queue.add({
+  type = "nitpick",
+  kind = "file",
+  path = "src/fresh.lua",
+  abs_path = vim.fs.joinpath(fixture, "src/fresh.lua"),
+  key = "src/fresh.lua:f:0",
+  note = "queued with no view either",
+})
+view.persist()
+
+print("queued: " .. queue.count())
+vim.cmd("qa!")

--- a/tests/codereview/viewless_spec.lua
+++ b/tests/codereview/viewless_spec.lua
@@ -1,0 +1,133 @@
+-- The queue without a review view.
+--
+-- The float, the target picker and the batch submit already work with nothing open; only
+-- persistence was tied to a view, which meant an annotation captured outside a review
+-- would queue, submit and then be lost on exit.
+--
+-- Two processes, like state_spec and for the same reason: persistence is only meaningfully
+-- tested across a genuine restart.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+
+local sent = {}
+require("codereview").setup({
+  syntax = false,
+  send = function(text, target)
+    sent[#sent + 1] = { text = text, target = target }
+  end,
+})
+
+local root = assert(vim.uv.fs_realpath(fixture))
+
+describe("the writing process", function()
+  local cmd = {
+    vim.v.progpath,
+    "--clean",
+    "-l",
+    vim.fs.joinpath(h.root, "tests", "codereview", "viewless_child.lua"),
+  }
+  local proc = vim.system(cmd, {
+    cwd = fixture,
+    text = true,
+    env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = fixture },
+  })
+  local child = proc:wait(60000)
+
+  it("exits cleanly", function()
+    assert.same(0, child.code, (child.stderr or "") .. (child.stdout or ""))
+  end)
+
+  it("writes the viewless queue to disk", function()
+    local data = state.load(root)
+    assert.same(2, #data.queue)
+  end)
+
+  -- The write happened with no view, so it had no `per_scope` to build a scopes table
+  -- from. Writing what it did have would have blanked the reviewed marks phase 1 saved.
+  it("does not clobber the reviewed marks it could not see", function()
+    local data = state.load(root)
+    assert.is_truthy(next(data.scopes), "every reviewed mark was lost")
+  end)
+end)
+
+describe("a cold start with no review view", function()
+  it("starts with nothing open and nothing in memory", function()
+    assert.is_nil(view.current())
+    assert.same(0, queue.count())
+  end)
+
+  it("restores the queue when the float is opened", function()
+    view.review_queue()
+    assert.same(2, queue.count())
+    assert.is_nil(view.current(), "opening the float should not open a review view")
+  end)
+
+  it("restores each annotation intact", function()
+    assert.same(
+      { "bug", "nitpick" },
+      vim.tbl_map(function(i)
+        return i.type
+      end, queue.all())
+    )
+    assert.same("queued with no view", queue.all()[1].note)
+    assert.same("src/routes.lua", queue.all()[1].path)
+  end)
+
+  it("continues ids past the restored entries", function()
+    local before = queue.count()
+    queue.add({ type = "bug", kind = "file", path = "x", key = "x:f:0", note = "n" })
+
+    local seen, dupes = {}, 0
+    for _, item in ipairs(queue.all()) do
+      dupes = dupes + (seen[item.id] and 1 or 0)
+      seen[item.id] = true
+    end
+
+    queue.remove(queue.all()[#queue.all()].id)
+    assert.same(0, dupes)
+    assert.same(before, queue.count())
+  end)
+end)
+
+describe("opening a review view afterwards", function()
+  view.open("branch")
+  local V = assert(view.current())
+
+  it("keeps the restored queue rather than discarding it", function()
+    assert.same(2, queue.count())
+  end)
+
+  it("still has the reviewed mark from the first process", function()
+    assert.is_not_nil(V.reviewed["src/main.lua"])
+  end)
+end)
+
+describe("submitting with no review view", function()
+  view.close()
+
+  it("closed the view", function()
+    assert.is_nil(view.current())
+  end)
+
+  it("sends the batch", function()
+    view.submit()
+    assert.same(1, #sent)
+    assert.same(0, queue.count())
+  end)
+
+  -- Submitting used to persist only when a view was open, so a viewless submit emptied
+  -- the queue in memory and left the old entries on disk to be restored next start.
+  it("clears the persisted queue too", function()
+    assert.same(0, #state.load(root).queue)
+  end)
+
+  it("still leaves the reviewed marks alone", function()
+    assert.is_truthy(next(state.load(root).scopes))
+  end)
+end)


### PR DESCRIPTION
Closes #2. First slice of #1.

The queue float, the target picker and submit already worked with nothing open. Persistence did not — it was reached only through the view, so an annotation captured outside a review would queue, submit, and be gone on exit. This splits the queue half of persistence from the reviewed-marks half.

No user-visible capture yet; this is the prefactor that makes #3 safe.

## Two things that were not obvious

**The viewless write has to merge.** With no view there is no `per_scope` to build a scopes table from, so writing a whole document the way the view path does would blank the reviewed marks a review had saved — the queue would survive at the cost of the progress beside it.

**Submitting only persisted when a view was open.** A viewless submit emptied the queue in memory and left the sent entries on disk, so they came back on the next start. Moved outside that guard.

Restoring is lazy and once per session. Eager restore at startup is worse than it looks — the working directory that decides which repository's queue to load may not be the one the user ends up in — and reading on every call is not an option, since `count()` is the sort of thing a statusline calls on each redraw.

## Verification

`make all` green: 258 cases, up 13.

New `viewless_spec` keeps `state_spec`'s two-process shape, because persistence is only meaningfully tested across a genuine restart. The child does a normal review first (so there are reviewed marks to protect), then queues with nothing open.

Both changes were mutation-checked rather than assumed:

| Reverted | Result |
| --- | --- |
| viewless persist | 4 failures |
| viewless submit-persist | 1 failure — the assertion that passed vacuously in the red run |

That second one matters: `clears the persisted queue too` passed before the implementation existed, because nothing had ever been written. It only became meaningful once the write did.

## Not included

An unrelated working-tree edit to `README.md` (dropping the *Why not diffs.com* section) is left uncommitted — it is not part of this slice.