### PR TITLE
feat(capture): annotate the current file from any buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,30 @@ only delivery falls back (the batch lands in the `+` register).
 `:CodeReview` opens the branch review. `:CodeReview staged`, `unstaged`, `worktree`, or any
 git revspec (`:CodeReview HEAD~3`, `:CodeReview main...feature`) opens that instead.
 
+### From any buffer
+
+Annotating does not need a review open. `:CodeReviewAnnotate bug` queues a note about the
+file you are looking at; with no type it offers the same picker `aa` does.
+
+```lua
+require("codereview").annotate("bug")  -- the whole current file
+require("codereview").annotate()       -- pick the type from a menu
+```
+
+That is the entry point to bind a key to — nothing needs to reach into the plugin's
+internal modules to capture:
+
+```lua
+vim.keymap.set("n", "<leader>ab", function()
+  require("codereview").annotate("bug")
+end, { desc = "Annotate this file as a bug" })
+```
+
+What it queues is an ordinary annotation: it records the file's blob, so it goes stale the
+same way, it appears in the same queue float next to anything captured during a review, it
+groups under its type in the same payload, and it goes out in the same batch to the same
+target. The buffer itself is never touched.
+
 ### Inside the view
 
 | Key | Action |

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -98,7 +98,7 @@ There are two, and they share nothing.
 | | This plugin | A host config's own queue |
 | --- | --- | --- |
 | Where | `lua/codereview/queue.lua` | e.g. `~/.config/nvim/lua/util/claude_queue.lua` |
-| Fed by | `<leader>r` — the review view | `<leader>a` — buffer/visual annotation |
+| Fed by | the review view, and `codereview.annotate()` from any buffer | `<leader>a` — buffer/visual annotation |
 | Reviewed with | `require("codereview").queue()` | that config's own picker |
 | Persisted | **yes**, with git blob hashes | typically not — session only |
 | Survives a restart | yes; a moved file's note is flagged stale | no |
@@ -108,10 +108,15 @@ an already-rendered batch, at the very end — it is a delivery hook, not a queu
 `send` to a host config's delivery path does not route anything through that config's
 queue, and the two never see each other's entries.
 
-That means annotations captured in the review view are only ever reviewed and submitted
-through `:CodeReview`'s own float, and a host config's separate annotation flow keeps its
-own list. Deliberate — it lets an existing flow keep working untouched — but worth knowing
-before wondering why `<leader>a`'s queue looks empty after a review session.
+That means annotations captured through the plugin — in the review view or from any buffer
+with `codereview.annotate()` — are only ever reviewed and submitted through
+`:CodeReview`'s own float, and a host config's separate annotation flow keeps its own list.
+Deliberate — it lets an existing flow keep working untouched — but worth knowing before
+wondering why `<leader>a`'s queue looks empty after a review session.
+
+The two converge only when a host repoints its own capture keymap at
+`require("codereview").annotate()`, at which point its queue module has nothing left
+feeding it.
 
 Persistence is the practical difference. The plugin records the git blob each entry was
 captured against, so after a restart a note whose file has changed comes back flagged

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -308,21 +308,21 @@ function M.annotate_pick()
   end)
 end
 
----Annotate a target that was resolved earlier.
----@param V CRView
----@param target CRTarget
----@param type_name string
-function M.annotate_target(V, target, type_name)
-  local cfg = config.get()
-  local type_def = types.get(cfg.types, type_name)
-  if not type_def then
-    return
-  end
-  if target.clamped then
-    info(("Selection spans more than one file — clamped to %s"):format(target.file.path))
-  end
-  local entry = build(V, target)
+---Collect a note for an already-built entry, queue it, and report.
+---
+---Shared by the review path and by buffer capture, rather than each growing its own tail:
+---an annotation has to be indistinguishable once queued regardless of how it was
+---captured, and that is only true if one piece of code decides the composer context, the
+---persistence call and the wording of the confirmation.
+---@param entry CRAnnotation
+---@param type_def CRType
+function M.queue_entry(entry, type_def)
   entry.type = type_def.name
+  -- Before anything is added, not after: persisting writes the in-memory queue over the
+  -- document, so queueing into a queue this session has never read back would drop
+  -- whatever the last session left. A review view has already restored by the time it
+  -- gets here; capture from a buffer can be the very first thing a session does.
+  require("codereview.view").ensure_queue()
   collect(
     {
       scope = "none",
@@ -340,6 +340,22 @@ function M.annotate_target(V, target, type_name)
       info(("Queued %s %s (%d in queue)"):format(type_def.name, M.describe(entry), queue.count()))
     end
   )
+end
+
+---Annotate a target that was resolved earlier.
+---@param V CRView
+---@param target CRTarget
+---@param type_name string
+function M.annotate_target(V, target, type_name)
+  local cfg = config.get()
+  local type_def = types.get(cfg.types, type_name)
+  if not type_def then
+    return
+  end
+  if target.clamped then
+    info(("Selection spans more than one file — clamped to %s"):format(target.file.path))
+  end
+  M.queue_entry(build(V, target), type_def)
 end
 
 ---Drop the annotation the cursor is sitting on.

--- a/lua/codereview/capture.lua
+++ b/lua/codereview/capture.lua
@@ -1,0 +1,98 @@
+---Capturing an annotation about the buffer you are in, with no review view involved.
+---
+---The review path resolves its target from a rendered diff and its anchor map. There is
+---no diff here, so the target is resolved from the buffer itself -- but the entry it
+---produces is the same shape, goes into the same queue and is rendered by the same code.
+---A queued annotation must not remember which way it was captured.
+local config = require("codereview.config")
+local git = require("codereview.git")
+local payload = require("codereview.payload")
+local render = require("codereview.render")
+local types = require("codereview.types")
+
+local M = {}
+
+---@param msg string
+local function warn(msg)
+  vim.notify(msg, vim.log.levels.WARN, { title = "Code review" })
+end
+
+---Resolve a buffer into an annotation entry, minus its type and note.
+---
+---@param buf integer|nil Defaults to the current buffer
+---@return CRAnnotation|nil entry, string|nil err
+function M.target(buf)
+  buf = (buf == nil or buf == 0) and vim.api.nvim_get_current_buf() or buf
+
+  local name = vim.api.nvim_buf_get_name(buf)
+  -- A scratch buffer, the review view's own buffer, or anything else with no file behind
+  -- it. A bare thought with no path is a real capture shape, but it is its own slice.
+  if name == "" then
+    return nil, "no file in this buffer"
+  end
+
+  -- Realpath rather than the buffer's name: `git rev-parse --show-toplevel` answers in
+  -- resolved form, and on macOS a path under /var is a symlink into /private/var. Compare
+  -- the two unresolved and the file looks like it lives outside its own repository.
+  local abs = vim.uv.fs_realpath(name)
+  if not abs then
+    return nil, ("%s is not a file on disk"):format(vim.fn.fnamemodify(name, ":t"))
+  end
+
+  local root = git.root(vim.fs.dirname(abs))
+  local rel = root and payload.relative_to(abs, root)
+  if not rel then
+    return nil, "not inside a git repository"
+  end
+
+  return {
+    kind = "file",
+    path = rel,
+    abs_path = abs,
+    -- Hashed at capture time, exactly as the review path hashes a diffed file. This is
+    -- what buys staleness detection later; an entry without it can go quietly wrong.
+    blob = git.blob(rel, nil, root),
+    key = render.file_key(rel),
+    tag = "whole file",
+    inline = false,
+  }
+end
+
+---Annotate the whole of the current buffer's file.
+---@param type_name string|nil Falls back to the same picker the review view offers
+function M.annotate(type_name)
+  local cfg = config.get()
+
+  local type_def = type_name and types.get(cfg.types, type_name)
+  if type_name and not type_def then
+    warn(("unknown annotation type: %s"):format(type_name))
+    return
+  end
+
+  -- Resolved before the picker opens, not inside its callback: `vim.ui.select` is
+  -- asynchronous, and the annotation is about the buffer the user was in when they asked
+  -- -- not about wherever the cursor happens to be once a menu has come and gone.
+  local entry, err = M.target(0)
+  if not entry then
+    warn(err)
+    return
+  end
+
+  local annotate = require("codereview.annotate")
+  if type_def then
+    annotate.queue_entry(entry, type_def)
+    return
+  end
+
+  local labels = vim.tbl_map(function(t)
+    return ("%s  %s"):format(t.icon, t.name)
+  end, cfg.types)
+  vim.ui.select(labels, { prompt = "Annotation type:" }, function(_, index)
+    if not index then
+      return
+    end
+    annotate.queue_entry(entry, cfg.types[index])
+  end)
+end
+
+return M

--- a/lua/codereview/init.lua
+++ b/lua/codereview/init.lua
@@ -23,6 +23,24 @@ function M.setup(opts)
       end, vim.deepcopy(require("codereview.git").CYCLE))
     end,
   })
+
+  vim.api.nvim_create_user_command("CodeReviewAnnotate", function(cmd)
+    M.annotate(cmd.args ~= "" and cmd.args or nil)
+  end, {
+    nargs = "?",
+    desc = "Annotate the current file (annotation type, or the picker with none)",
+    -- Completed from the configured list, not the built-in five: a host that replaced the
+    -- vocabulary would otherwise be offered types that no longer exist.
+    complete = function(lead)
+      local names = {}
+      for _, t in ipairs(config.get().types) do
+        if t.name:sub(1, #lead) == lead then
+          names[#names + 1] = t.name
+        end
+      end
+      return names
+    end,
+  })
 end
 
 ---@param spec string|nil "branch"|"staged"|"unstaged"|"worktree"|any git revspec
@@ -32,6 +50,15 @@ end
 
 function M.close()
   require("codereview.view").close()
+end
+
+---Annotate the file in the current buffer, from anywhere.
+---
+---The one entry point a host config needs for capture: no review view has to be open, and
+---nothing reaches into the queue, annotate or state modules to do it.
+---@param type_name string|nil Falls back to the type picker
+function M.annotate(type_name)
+  require("codereview.capture").annotate(type_name)
 end
 
 ---Open the queue for review, with drop / route / submit.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -222,7 +222,12 @@ end
 local queue_restored = false
 
 ---Load the persisted queue if this session has not seen it yet.
-local function ensure_queue()
+---
+---Public because adding to the queue has to be able to demand it, not just reading it:
+---`persist_queue` writes memory over the document, so anything that queues an annotation
+---before the session has read the queue back would silently drop what the last session
+---left. Capture makes that reachable as the very first thing a session does.
+function M.ensure_queue()
   if queue_restored then
     return
   end
@@ -813,7 +818,7 @@ function M.submit()
   local queue = require("codereview.queue")
   local cfg = config.get()
 
-  ensure_queue()
+  M.ensure_queue()
   if queue.count() == 0 then
     info("Queue is empty — annotate something first")
     return
@@ -875,7 +880,7 @@ end
 ---List the queued annotations, drop any of them, then submit the batch.
 function M.review_queue()
   local queue = require("codereview.queue")
-  ensure_queue()
+  M.ensure_queue()
   if queue.count() == 0 then
     info("Queue is empty — annotate something first")
     return

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
+| `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The composer stub `interactive_spec` drives — deliberately not a spec. |
 | `perf.lua` | Open-time report on a 60-file diff. Not part of `make test`. |
 
@@ -39,6 +40,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit |
+| `capture_spec` | Annotating from an ordinary buffer: types, blob, composer, restart, one queue |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `interactive_spec` | The insert-mode leak, in a real pty-backed Neovim |
@@ -51,8 +53,8 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mkfixture.sh`** — flat `src/`-only repo covering every file status at once:
   modified, deleted, added, renamed-and-edited, staged, unstaged, untracked, untracked
   binary, gitignored, and a file with no trailing newline on either side. Used by
-  `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`
-  and `interactive_spec`.
+  `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
+  `viewless_spec`, `capture_spec` and `interactive_spec`.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec` and `focus_spec`.
@@ -75,6 +77,15 @@ so the out-of-core language path is still checked locally without ever failing C
   across a genuine restart; calling `state.load()` twice in one process proves nothing
   about what reached the disk. `state_child.lua` writes, the spec restarts and reads. Do
   not collapse it into one process.
+- **The queue is restored once per session, so a second session means a second process.**
+  `view.ensure_queue()` latches after the first read, which is what stops a statusline
+  calling `count()` from hitting the disk on every redraw. Clearing the queue in-process
+  therefore does *not* simulate a restart — the latch is still set, nothing reloads, and an
+  assertion about restoring is measuring nothing. `capture_spec` spawns
+  `capture_child.lua` twice for this reason.
+- **`nvim -l` sends `print` to stderr, not stdout.** A child spawned with `-l` that reports
+  its result through `print` has to be read from `stderr`, or from both streams. Asserting
+  against `stdout` alone silently never matches.
 - **git config is neutralised.** Both the fixture scripts and `minimal_init.lua` set
   `GIT_CONFIG_GLOBAL=/dev/null`. Inherited settings quietly change what a fixture means:
   `diff.renames = false` turns the rename case into an unrelated add plus delete, and

--- a/tests/codereview/capture_child.lua
+++ b/tests/codereview/capture_child.lua
@@ -1,0 +1,39 @@
+-- One session of capture_spec's restart case, in its own process.
+--
+-- Captures a single annotation from an ordinary buffer through the public entry point,
+-- reports the resulting queue size and exits. The spec runs it twice: persistence is only
+-- meaningfully tested across a genuine restart, and the queue is restored once per
+-- session, so "a later session does not clobber an earlier one" cannot be observed from
+-- inside the process that already restored.
+--
+-- Parameterised by environment rather than argv, because `-l` hands script arguments to
+-- Neovim itself. Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it,
+-- and it must NOT load tests/minimal_init.lua, which would mint its own state directory.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+local file = assert(vim.env.CAPTURE_FILE, "CAPTURE_FILE is not set")
+local note = assert(vim.env.CAPTURE_NOTE, "CAPTURE_NOTE is not set")
+local type_name = assert(vim.env.CAPTURE_TYPE, "CAPTURE_TYPE is not set")
+
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+local codereview = require("codereview")
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, note)
+  end,
+})
+
+local queue = require("codereview.queue")
+
+vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, file)))
+codereview.annotate(type_name)
+
+-- The count is the whole point of the second run: it can only include the first session's
+-- annotation if capture restored the persisted queue before adding to it.
+print("queued: " .. queue.count())
+vim.cmd("qa!")

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -1,0 +1,443 @@
+-- Capturing an annotation from an ordinary buffer, with no review view involved.
+--
+-- The tracer bullet for "the plugin owns capture": one public entry point cuts through
+-- type resolution, blob hashing, the composer, the queue, the float, payload rendering
+-- and submit -- for the simplest capture shape there is, a whole file.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+local codereview = require("codereview")
+local queue = require("codereview.queue")
+
+-- Resolved before setup: the target's `cwd` is what `@ref`s are rendered against, and a
+-- /var path that has not been through realpath does not contain its own /private/var
+-- files as far as the renderer is concerned.
+local root = assert(vim.uv.fs_realpath(fixture))
+
+local composed = {}
+local sent = {}
+codereview.setup({
+  syntax = false,
+  compose = function(ctx, on_accept, label)
+    composed[#composed + 1] = { ctx = ctx, label = label }
+    on_accept(nil, "the note")
+  end,
+  pick_target = function(cb)
+    cb({ short = "agent", pane_id = "wV:p3", cwd = root })
+  end,
+  send = function(text, target)
+    sent[#sent + 1] = { text = text, target = target }
+  end,
+})
+
+---Open a real file from the fixture, the way a user browsing code would.
+---@param rel string
+---@return integer buf
+local function edit(rel)
+  vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, rel)))
+  return vim.api.nvim_get_current_buf()
+end
+
+describe("annotating the current file", function()
+  queue.clear()
+  edit("src/main.lua")
+  codereview.annotate("bug")
+
+  it("queues one annotation", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("records it as a whole-file annotation for that buffer", function()
+    local entry = queue.all()[1]
+    assert.same("file", entry.kind)
+    assert.same("src/main.lua", entry.path)
+    assert.same(vim.fs.joinpath(root, "src/main.lua"), entry.abs_path)
+  end)
+
+  it("carries the type it was given", function()
+    assert.same("bug", queue.all()[1].type)
+  end)
+
+  it("carries the note the composer collected", function()
+    assert.same("the note", queue.all()[1].note)
+  end)
+
+  -- The staleness key. Derived from git rather than hardcoded, so it cannot drift when
+  -- the fixture changes.
+  it("records the blob of the file as captured", function()
+    local expected = h.git_lines(root, { "hash-object", "src/main.lua" })[1]
+    assert.same(expected, queue.all()[1].blob)
+  end)
+end)
+
+describe("the buffer it was captured from", function()
+  local buf = edit("src/main.lua")
+  local before = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  queue.clear()
+  codereview.annotate("bug")
+
+  it("is left with its contents untouched", function()
+    assert.same(before, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+  end)
+
+  it("is not left modified", function()
+    assert.is_false(vim.bo[buf].modified)
+  end)
+end)
+
+describe("with no type given", function()
+  local offered, prompt
+  local orig = vim.ui.select
+  vim.ui.select = function(items, opts, cb)
+    offered, prompt = items, opts.prompt
+    cb(items[2], 2)
+  end
+
+  queue.clear()
+  edit("src/main.lua")
+  codereview.annotate()
+  vim.ui.select = orig
+
+  it("offers the type picker", function()
+    assert.is_truthy(prompt, "no picker was offered")
+    assert.same(#require("codereview.config").get().types, #offered)
+  end)
+
+  it("queues with the type that was picked", function()
+    assert.same(1, queue.count())
+    assert.same("fix", queue.all()[1].type)
+  end)
+end)
+
+describe("an unrecognised type", function()
+  queue.clear()
+  edit("src/main.lua")
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("nonsense")
+  restore()
+
+  it("queues nothing", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("names the type it did not recognise", function()
+    assert.is_true(h.notified(msgs, "unknown annotation type: nonsense"))
+  end)
+end)
+
+-- The review view's own buffer is one of these, which is what the user hits by calling
+-- the entry point while focused inside a review. A bare thought with no file is a real
+-- capture shape, but it is a later slice; refusing beats queueing something malformed.
+describe("a buffer with no file behind it", function()
+  queue.clear()
+  vim.cmd("enew")
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("bug")
+  restore()
+
+  it("queues nothing", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("says there is no file", function()
+    assert.is_true(h.notified(msgs, "no file in this buffer"))
+  end)
+end)
+
+describe("the user command", function()
+  queue.clear()
+  edit("src/routes.lua")
+  vim.cmd("CodeReviewAnnotate suggestion")
+
+  it("queues an annotation for the current file", function()
+    assert.same(1, queue.count())
+    assert.same("src/routes.lua", queue.all()[1].path)
+  end)
+
+  it("takes the annotation type as its argument", function()
+    assert.same("suggestion", queue.all()[1].type)
+  end)
+
+  it("completes the configured type names", function()
+    local command = vim.api.nvim_get_commands({})["CodeReviewAnnotate"]
+    assert.is_truthy(command, "the command is not defined")
+    local completions = vim.fn.getcompletion("CodeReviewAnnotate ni", "cmdline")
+    assert.same({ "nitpick" }, completions)
+  end)
+end)
+
+describe("capturing across a restart", function()
+  local state = require("codereview.state")
+
+  ---One capture, in a process of its own.
+  ---@param file string
+  ---@param type_name string
+  ---@param note string
+  local function session(file, type_name, note)
+    return vim
+      .system({
+        vim.v.progpath,
+        "--clean",
+        "-l",
+        vim.fs.joinpath(h.root, "tests", "codereview", "capture_child.lua"),
+      }, {
+        cwd = fixture,
+        text = true,
+        env = {
+          XDG_STATE_HOME = vim.env.XDG_STATE_HOME,
+          FIXTURE = fixture,
+          CAPTURE_FILE = file,
+          CAPTURE_TYPE = type_name,
+          CAPTURE_NOTE = note,
+        },
+      })
+      :wait(60000)
+  end
+
+  -- A clean slate on both sides, so what the two sessions write is all that is on disk.
+  queue.clear()
+  state.clear(root)
+
+  local first = session("src/main.lua", "bug", "from an earlier session")
+  local second = session("src/routes.lua", "nitpick", "from a later session")
+
+  it("both sessions exit cleanly", function()
+    assert.same(0, first.code, (first.stderr or "") .. (first.stdout or ""))
+    assert.same(0, second.code, (second.stderr or "") .. (second.stdout or ""))
+  end)
+
+  -- `nvim -l` sends `print` to stderr, so the child's report is read from both streams
+  -- rather than from stdout alone.
+  ---@param child table
+  ---@return string
+  local function output(child)
+    return (child.stdout or "") .. (child.stderr or "")
+  end
+
+  it("the first session persisted its annotation", function()
+    assert.is_true(output(first):find("queued: 1", 1, true) ~= nil, output(first))
+  end)
+
+  -- The restore half. The second session captured one annotation and ended up holding
+  -- two, which is only possible if it read the first session's queue off disk first.
+  it("the second session restored the first one's annotation before adding its own", function()
+    assert.is_true(output(second):find("queued: 2", 1, true) ~= nil, output(second))
+  end)
+
+  -- The trap this case exists for. `persist_queue` writes whatever is in memory over the
+  -- document's queue, so capturing as the first action of a session -- before anything has
+  -- read the queue back -- would silently drop everything the last session left.
+  it("kept both annotations on disk, in the order they were captured", function()
+    local saved = state.load(root).queue
+    assert.same({ "from an earlier session", "from a later session" }, {
+      saved[1] and saved[1].note,
+      saved[2] and saved[2].note,
+    })
+    assert.same({ "src/main.lua", "src/routes.lua" }, {
+      saved[1] and saved[1].path,
+      saved[2] and saved[2].path,
+    })
+  end)
+
+  it("persisted each one's type and blob", function()
+    local saved = state.load(root).queue
+    assert.same({ "bug", "nitpick" }, { saved[1].type, saved[2].type })
+    assert.same(h.git_lines(root, { "hash-object", "src/main.lua" })[1], saved[1].blob)
+    assert.same(h.git_lines(root, { "hash-object", "src/routes.lua" })[1], saved[2].blob)
+  end)
+end)
+
+-- The whole point of the feature: once queued, a buffer annotation is indistinguishable
+-- from one captured during a review. One queue, one float, one payload, one batch.
+describe("alongside a review annotation", function()
+  local view = require("codereview.view")
+  local annotate = require("codereview.annotate")
+
+  queue.clear()
+  require("codereview.state").clear(root)
+
+  -- A review annotation, captured the way the review view captures one.
+  view.open("branch")
+  local V = assert(view.current(), "the review view did not open")
+  local row = assert(h.line_row(V, "src/main.lua"), "no diff line for src/main.lua")
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  annotate.annotate("bug")
+
+  -- ...and a buffer annotation captured with that review still open, in its own tab so
+  -- the review view keeps its window.
+  vim.cmd("tabedit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/fresh.lua")))
+  codereview.annotate("nitpick")
+
+  it("captures from a buffer while a review view is open", function()
+    assert.same(2, queue.count())
+    assert.is_not_nil(view.current(), "capturing closed the review view")
+  end)
+
+  it("is counted by the public API", function()
+    assert.same(2, codereview.count())
+  end)
+
+  local float
+  view.review_queue()
+  do
+    local win = assert(V.queue_win, "the queue float did not open")
+    float = table.concat(vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, -1, false), "\n")
+    vim.api.nvim_win_close(win, true)
+    V.queue_win = nil
+  end
+
+  it("appears in the queue float alongside the review annotation", function()
+    assert.is_truthy(float:find("src/main.lua", 1, true), float)
+    assert.is_truthy(float:find("src/fresh.lua", 1, true), float)
+  end)
+
+  it("is listed under its own type's heading in the float", function()
+    assert.is_truthy(float:find("## Bugs", 1, true), float)
+    assert.is_truthy(float:find("## Nitpicks", 1, true), float)
+  end)
+
+  view.pick_target()
+  view.submit()
+
+  it("submits as one batch, through one adapter call, to the chosen target", function()
+    assert.same(1, #sent)
+    assert.same("wV:p3", sent[1].target.pane_id)
+    assert.same(0, queue.count())
+  end)
+
+  it("groups under its type in the payload, in the configured type order", function()
+    local text = sent[1].text
+    local bugs = assert(text:find("## Bugs", 1, true), text)
+    local nitpicks = assert(text:find("## Nitpicks", 1, true), text)
+    assert.is_true(bugs < nitpicks, "nitpicks came before bugs")
+  end)
+
+  it("travels in that payload as a reference to its own file", function()
+    assert.is_truthy(sent[1].text:find("@src/fresh.lua", 1, true), sent[1].text)
+  end)
+
+  view.close()
+end)
+
+-- The composer seam is what a host config wires. It has to receive the same shape here as
+-- it does from the review path, or a host composer works in one place and not the other.
+describe("what the composer is handed", function()
+  queue.clear()
+  edit("src/routes.lua")
+  local before = #composed
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("suggestion")
+  restore()
+
+  local call = composed[#composed]
+
+  it("calls the composer once", function()
+    assert.same(before + 1, #composed)
+  end)
+
+  it("names the file both ways the review path does", function()
+    assert.same("src/routes.lua", call.ctx.rel_path)
+    assert.same(vim.fs.joinpath(root, "src/routes.lua"), call.ctx.file_path)
+  end)
+
+  it("titles it from the type and the target", function()
+    assert.same("none", call.ctx.scope)
+    assert.is_truthy(call.ctx.label:find("Suggestion", 1, true), call.ctx.label)
+    assert.is_truthy(call.ctx.label:find("src/routes.lua", 1, true), call.ctx.label)
+  end)
+
+  it("passes the same `queue` label the review path passes", function()
+    assert.same("queue", call.label)
+  end)
+
+  it("reports what was queued and how many are now in the batch", function()
+    assert.is_true(h.notified(msgs, "Queued suggestion"), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, "src/routes.lua"), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, "(1 in queue)"), vim.inspect(msgs))
+  end)
+end)
+
+-- The two cases below reconfigure the plugin, so they come last.
+
+describe("with no composer wired", function()
+  codereview.setup({ syntax = false })
+  queue.clear()
+  edit("src/main.lua")
+
+  local prompt
+  local orig = vim.ui.input
+  vim.ui.input = function(opts, cb)
+    prompt = opts.prompt
+    cb("typed into the fallback")
+  end
+  codereview.annotate("bug")
+  vim.ui.input = orig
+
+  it("falls back to the built-in prompt", function()
+    assert.is_truthy(prompt, "vim.ui.input was never called")
+    assert.is_truthy(prompt:find("src/main.lua", 1, true), prompt)
+  end)
+
+  it("queues the note that prompt collected", function()
+    assert.same(1, queue.count())
+    assert.same("typed into the fallback", queue.all()[1].note)
+  end)
+end)
+
+-- Nothing in capture may assume the built-in five exist: the vocabulary is the host's.
+describe("with a custom type vocabulary", function()
+  codereview.setup({
+    syntax = false,
+    types = {
+      { name = "blocker", key = "b" },
+      { name = "praise", key = "p" },
+    },
+    compose = function(_, on_accept)
+      on_accept(nil, "a custom note")
+    end,
+  })
+  queue.clear()
+  edit("src/main.lua")
+  codereview.annotate("blocker")
+
+  it("resolves a type only the host defines", function()
+    assert.same(1, queue.count())
+    assert.same("blocker", queue.all()[1].type)
+  end)
+
+  it("refuses a built-in type the host replaced", function()
+    local msgs, restore = h.capture_notify()
+    codereview.annotate("bug")
+    restore()
+    assert.same(1, queue.count())
+    assert.is_true(h.notified(msgs, "unknown annotation type: bug"))
+  end)
+
+  it("completes the host's names rather than the built-ins", function()
+    assert.same({ "blocker" }, vim.fn.getcompletion("CodeReviewAnnotate bl", "cmdline"))
+    assert.same({}, vim.fn.getcompletion("CodeReviewAnnotate nit", "cmdline"))
+  end)
+
+  it("groups it under the label derived from the host's name", function()
+    local text = require("codereview.payload").render(queue.all(), root, {
+      types = require("codereview.config").get().types,
+    })
+    assert.is_truthy(text:find("## Blockers", 1, true), text)
+  end)
+
+  it("offers the host's types to the picker", function()
+    local offered
+    local orig = vim.ui.select
+    vim.ui.select = function(items, _, cb)
+      offered = items
+      cb(nil, nil)
+    end
+    codereview.annotate()
+    vim.ui.select = orig
+
+    assert.same(2, #offered)
+    assert.is_truthy(offered[1]:find("blocker", 1, true), vim.inspect(offered))
+  end)
+end)


### PR DESCRIPTION
Closes #3.

The tracer bullet for "the plugin owns capture". `codereview.annotate(type)` and
`:CodeReviewAnnotate [type]` queue an annotation about the current buffer's file from
anywhere, with no review view involved.

What comes out is an ordinary annotation. It records the file's blob, so staleness works
the same way; it shows up in the same queue float next to review annotations; it groups
under its type in the same payload in the configured order; and it goes out in the same
batch, through the same adapter, to the same target. The queue, the float, the payload
renderer and submit are unchanged — they already operated on a list of annotations rather
than on a view.

### The seam

One public entry point, per the PRD's decision: a host binds a key to
`require("codereview").annotate("bug")` and reaches into no internal module. Types resolve
through the configured list, so a host that replaced the vocabulary gets its own types
here and in the command's completion.

### Two things worth a second look

**The review path's tail is now shared rather than copied.** Both paths build an entry and
hand it to `annotate.queue_entry`, which decides the composer context, the persistence
call and the wording of the confirmation. A queued annotation must not remember how it was
captured, and that only stays true if one piece of code owns those decisions.

**Queueing now restores the persisted queue before adding to it.** `persist_queue` writes
the in-memory queue over the document, so capturing as the very first action of a session
— which only became reachable with this change — dropped everything the previous session
had left. `view.ensure_queue()` is public for that reason. The bug is pinned by two
spawned sessions rather than an in-process reset: the restore latches once per session, so
clearing the queue in-process does not simulate a restart and an assertion about restoring
would be measuring nothing.

### Notes

- Scope is this slice's: normal mode, a file on disk, inside a repository. A buffer with no
  file behind it — the review view's own buffer included — warns and queues nothing, which
  is #6's territory. Visual selections are #4.
- `capture_spec` adds 40 cases (298 total, from 258). The blob assertion and the
  no-clobber guard were both mutation-tested by reverting the code they claim to guard and
  confirming they go red.
- `tests/README.md` records the once-per-session restore latch and that `nvim -l` sends
  `print` to stderr — both cost time here.
