### PR TITLE
feat(capture): annotate a selection, with diagnostics riding along

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,23 +63,43 @@ Annotating does not need a review open. `:CodeReviewAnnotate bug` queues a note 
 file you are looking at; with no type it offers the same picker `aa` does.
 
 ```lua
-require("codereview").annotate("bug")  -- the whole current file
+require("codereview").annotate("bug")  -- the selection, or the whole file
 require("codereview").annotate()       -- pick the type from a menu
 ```
 
 That is the entry point to bind a key to — nothing needs to reach into the plugin's
-internal modules to capture:
+internal modules to capture. Bind it in both modes and the selection decides the scope:
 
 ```lua
-vim.keymap.set("n", "<leader>ab", function()
+vim.keymap.set({ "n", "x" }, "<leader>ab", function()
   require("codereview").annotate("bug")
-end, { desc = "Annotate this file as a bug" })
+end, { desc = "Annotate as a bug" })
+```
+
+| Where you are | What gets captured |
+| --- | --- |
+| Normal mode | The whole file |
+| A visual selection | Exactly those lines |
+| `:'<,'>CodeReviewAnnotate bug` | Exactly those lines |
+| `:12,20CodeReviewAnnotate bug` | Lines 12 to 20 |
+
+Errors and warnings overlapping what you captured ride along with the note, so they stop
+being retyped by hand. Hints and info are left out — they are rarely why you are
+annotating, and they bury the diagnostic that is.
+
+```
+why is this branch unreachable?
+
+Diagnostics:
+- ERROR L12 undefined global `foo` (lua_ls)
+- WARN  L14 unused local `bar` (lua_ls)
 ```
 
 What it queues is an ordinary annotation: it records the file's blob, so it goes stale the
 same way, it appears in the same queue float next to anything captured during a review, it
 groups under its type in the same payload, and it goes out in the same batch to the same
-target. The buffer itself is never touched.
+target. A selection travels as `@path#L12-20` when the delivery target can resolve the
+path, and inlines its code when it cannot. The buffer itself is never touched.
 
 ### Inside the view
 

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -316,7 +316,9 @@ end
 ---persistence call and the wording of the confirmation.
 ---@param entry CRAnnotation
 ---@param type_def CRType
-function M.queue_entry(entry, type_def)
+---@param opts? { note_suffix?: string } Appended below the collected note. Buffer capture
+---       uses it to carry diagnostics; the review path has nothing to add.
+function M.queue_entry(entry, type_def, opts)
   entry.type = type_def.name
   -- Before anything is added, not after: persisting writes the in-memory queue over the
   -- document, so queueing into a queue this session has never read back would drop
@@ -332,7 +334,8 @@ function M.queue_entry(entry, type_def)
     },
     "queue",
     function(text)
-      entry.note = text
+      local suffix = opts and opts.note_suffix
+      entry.note = (suffix and suffix ~= "") and (text .. "\n\n" .. suffix) or text
       queue.add(entry)
       local view = require("codereview.view")
       view.paint()

--- a/lua/codereview/capture.lua
+++ b/lua/codereview/capture.lua
@@ -17,11 +17,77 @@ local function warn(msg)
   vim.notify(msg, vim.log.levels.WARN, { title = "Code review" })
 end
 
+local SEVERITY = {
+  [vim.diagnostic.severity.ERROR] = "ERROR",
+  [vim.diagnostic.severity.WARN] = "WARN",
+}
+
+---Errors and warnings overlapping the captured lines, as text to append to the note.
+---
+---The point is to stop error messages being retyped into notes by hand. Hints and info
+---are deliberately left out: they are rarely why you are annotating, and a wall of them
+---buries the diagnostic that is.
+---@param buf integer
+---@param first integer|nil 1-based; nil means the whole buffer
+---@param last integer|nil
+---@return string|nil
+local function diagnostics_note(buf, first, last)
+  local hits = {}
+  for _, d in ipairs(vim.diagnostic.get(buf, { severity = { min = vim.diagnostic.severity.WARN } })) do
+    -- A diagnostic spanning several lines counts if any part of it is inside the capture.
+    local from, to = d.lnum + 1, (d.end_lnum or d.lnum) + 1
+    if not first or (from <= last and to >= first) then
+      hits[#hits + 1] = d
+    end
+  end
+  if #hits == 0 then
+    return nil
+  end
+
+  -- By position, then severity: reading order, worst first where they collide.
+  table.sort(hits, function(a, b)
+    if a.lnum ~= b.lnum then
+      return a.lnum < b.lnum
+    end
+    return (a.severity or 0) < (b.severity or 0)
+  end)
+
+  local out = { "Diagnostics:" }
+  for _, d in ipairs(hits) do
+    -- Flattened to one line: a multi-line message would break the list apart.
+    local message = vim.trim((d.message or ""):gsub("%s+", " "))
+    out[#out + 1] = ("- %-5s L%d %s%s"):format(
+      SEVERITY[d.severity] or "WARN",
+      d.lnum + 1,
+      message,
+      d.source and (" (%s)"):format(d.source) or ""
+    )
+  end
+  return table.concat(out, "\n")
+end
+
+---Rows of the live visual selection, or nothing in normal mode.
+---
+---`v` (selection anchor) and `.` (cursor) are read while visual mode is still live: the
+---`'<`/`'>` marks are only rewritten when visual mode *exits*, so reading them from a
+---mapping would return the previous selection instead of this one.
+---@return integer|nil first, integer|nil last
+local function selected_rows()
+  local mode = vim.fn.mode()
+  if mode ~= "v" and mode ~= "V" and mode ~= "\22" then
+    return nil, nil
+  end
+  local a, b = vim.fn.line("v"), vim.fn.line(".")
+  return math.min(a, b), math.max(a, b)
+end
+
 ---Resolve a buffer into an annotation entry, minus its type and note.
 ---
 ---@param buf integer|nil Defaults to the current buffer
+---@param range { first: integer, last: integer }|nil Explicit lines; otherwise the live
+---       visual selection, and failing that the whole file
 ---@return CRAnnotation|nil entry, string|nil err
-function M.target(buf)
+function M.target(buf, range)
   buf = (buf == nil or buf == 0) and vim.api.nvim_get_current_buf() or buf
 
   local name = vim.api.nvim_buf_get_name(buf)
@@ -45,22 +111,52 @@ function M.target(buf)
     return nil, "not inside a git repository"
   end
 
-  return {
-    kind = "file",
+  local entry = {
     path = rel,
     abs_path = abs,
     -- Hashed at capture time, exactly as the review path hashes a diffed file. This is
     -- what buys staleness detection later; an entry without it can go quietly wrong.
     blob = git.blob(rel, nil, root),
-    key = render.file_key(rel),
-    tag = "whole file",
     inline = false,
   }
+
+  local first, last = range and range.first, range and range.last
+  if not first then
+    first, last = selected_rows()
+  end
+  if not first then
+    entry.kind = "file"
+    entry.key = render.file_key(rel)
+    entry.tag = "whole file"
+    return entry
+  end
+
+  -- A range that runs past the end of the buffer describes lines that do not exist.
+  local total = vim.api.nvim_buf_line_count(buf)
+  first = math.max(1, math.min(first, total))
+  last = math.max(first, math.min(last or first, total))
+
+  entry.first = first
+  entry.last = last
+  -- One line is a `line`, more is a `range`, matching what the review path produces. The
+  -- payload and the float both switch on kind, and a buffer capture must not present as a
+  -- different sort of thing than the same selection made during a review.
+  entry.kind = first == last and "line" or "range"
+  entry.key = render.line_key(rel, { new = first })
+  -- Carried even though this normally travels as an `@ref`: a batch routed to an agent
+  -- whose cwd does not contain the file cannot use a ref at all, and the fallback has to
+  -- inline the exact lines rather than approximate them. Space-prefixed, so the block is
+  -- valid diff context once the renderer fences it.
+  entry.lines = vim.tbl_map(function(text)
+    return " " .. text
+  end, vim.api.nvim_buf_get_lines(buf, first - 1, last, false))
+  return entry
 end
 
----Annotate the whole of the current buffer's file.
+---Annotate the current buffer: the visual selection if there is one, else the whole file.
 ---@param type_name string|nil Falls back to the same picker the review view offers
-function M.annotate(type_name)
+---@param range { first: integer, last: integer }|nil Explicit lines, e.g. a command range
+function M.annotate(type_name, range)
   local cfg = config.get()
 
   local type_def = type_name and types.get(cfg.types, type_name)
@@ -72,15 +168,28 @@ function M.annotate(type_name)
   -- Resolved before the picker opens, not inside its callback: `vim.ui.select` is
   -- asynchronous, and the annotation is about the buffer the user was in when they asked
   -- -- not about wherever the cursor happens to be once a menu has come and gone.
-  local entry, err = M.target(0)
+  local buf = vim.api.nvim_get_current_buf()
+  local entry, err = M.target(buf, range)
   if not entry then
     warn(err)
     return
   end
 
+  -- The selection has already been read, so leave visual mode before anything else opens.
+  -- The review path does the same: a composer entered with a selection still live is one
+  -- the user cannot type into cleanly, and the picker below would inherit it too.
+  if vim.fn.mode():match("[vV\22]") then
+    vim.cmd("normal! \27")
+  end
+
+  -- Read now rather than in the callback: both the composer and the picker are
+  -- asynchronous, and a language server can republish diagnostics while either is open.
+  -- What rides along should be what was on screen when the note was started.
+  local opts = { note_suffix = diagnostics_note(buf, entry.first, entry.last) }
+
   local annotate = require("codereview.annotate")
   if type_def then
-    annotate.queue_entry(entry, type_def)
+    annotate.queue_entry(entry, type_def, opts)
     return
   end
 
@@ -91,7 +200,7 @@ function M.annotate(type_name)
     if not index then
       return
     end
-    annotate.queue_entry(entry, cfg.types[index])
+    annotate.queue_entry(entry, cfg.types[index], opts)
   end)
 end
 

--- a/lua/codereview/init.lua
+++ b/lua/codereview/init.lua
@@ -25,10 +25,15 @@ function M.setup(opts)
   })
 
   vim.api.nvim_create_user_command("CodeReviewAnnotate", function(cmd)
-    M.annotate(cmd.args ~= "" and cmd.args or nil)
+    -- `cmd.range` counts the addresses given, not the lines covered. Reading line1/line2
+    -- unconditionally would turn a bare `:CodeReviewAnnotate` into a one-line capture of
+    -- wherever the cursor happened to be, instead of the whole file.
+    local range = cmd.range > 0 and { first = cmd.line1, last = cmd.line2 } or nil
+    M.annotate(cmd.args ~= "" and cmd.args or nil, range)
   end, {
     nargs = "?",
-    desc = "Annotate the current file (annotation type, or the picker with none)",
+    range = true,
+    desc = "Annotate the current file, or a given range (type, or the picker with none)",
     -- Completed from the configured list, not the built-in five: a host that replaced the
     -- vocabulary would otherwise be offered types that no longer exist.
     complete = function(lead)
@@ -56,9 +61,11 @@ end
 ---
 ---The one entry point a host config needs for capture: no review view has to be open, and
 ---nothing reaches into the queue, annotate or state modules to do it.
+---With a visual selection live, captures those lines; otherwise the whole file.
 ---@param type_name string|nil Falls back to the type picker
-function M.annotate(type_name)
-  require("codereview.capture").annotate(type_name)
+---@param range { first: integer, last: integer }|nil Explicit lines, overriding both
+function M.annotate(type_name, range)
+  require("codereview.capture").annotate(type_name, range)
 end
 
 ---Open the queue for review, with drop / route / submit.

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,7 +40,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit |
-| `capture_spec` | Annotating from an ordinary buffer: types, blob, composer, restart, one queue |
+| `capture_spec` | Annotating from an ordinary buffer: scope, types, blob, composer, diagnostics, restart, one queue |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `interactive_spec` | The insert-mode leak, in a real pty-backed Neovim |
@@ -77,6 +77,17 @@ so the out-of-core language path is still checked locally without ever failing C
   across a genuine restart; calling `state.load()` twice in one process proves nothing
   about what reached the disk. `state_child.lua` writes, the spec restarts and reads. Do
   not collapse it into one process.
+- **A filter test needs a fixture only that filter can reject.** `capture_spec` asserts
+  that hints and info never ride along with an annotation. Those diagnostics originally sat
+  on a line *outside* the captured range, so the range filter rejected them and the
+  assertion passed with the severity filter deleted — it was measuring the wrong thing.
+  They now sit inside the selection. Where two filters could reject the same fixture, place
+  it so only the one under test can.
+- **Visual-mode capture has to be driven through a mapping.** `capture` reads `mode()` and
+  `line("v")` while the selection is still live, because `'<`/`'>` are only rewritten once
+  visual mode exits. Calling the entry point directly after a selection therefore captures
+  the whole file instead. Feed the keys and the mapping together (`h.feed("1GVj<F5>")`), as
+  `annotate_spec` does for the review path.
 - **The queue is restored once per session, so a second session means a second process.**
   `view.ensure_queue()` latches after the first read, which is what stops a statusline
   calling `count()` from hitting the disk on every redraw. Clearing the queue in-process

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -21,7 +21,9 @@ local sent = {}
 codereview.setup({
   syntax = false,
   compose = function(ctx, on_accept, label)
-    composed[#composed + 1] = { ctx = ctx, label = label }
+    -- The mode the composer is entered in is part of its contract: a composer opened with
+    -- a selection still active gets a buffer it cannot type into cleanly.
+    composed[#composed + 1] = { ctx = ctx, label = label, mode = vim.fn.mode() }
     on_accept(nil, "the note")
   end,
   pick_target = function(cb)
@@ -356,6 +358,205 @@ describe("what the composer is handed", function()
     assert.is_true(h.notified(msgs, "Queued suggestion"), vim.inspect(msgs))
     assert.is_true(h.notified(msgs, "src/routes.lua"), vim.inspect(msgs))
     assert.is_true(h.notified(msgs, "(1 in queue)"), vim.inspect(msgs))
+  end)
+end)
+
+-- Fired from a mapping rather than called directly, because the selection has to still be
+-- live when capture reads it -- which is only true from inside a visual-mode mapping.
+vim.keymap.set({ "n", "x" }, "<F5>", function()
+  codereview.annotate("bug")
+end, { desc = "capture_spec: annotate as bug" })
+
+describe("annotating a visual selection", function()
+  queue.clear()
+  edit("src/main.lua")
+  h.feed("1GVj<F5>")
+  local e = queue.all()[1]
+
+  it("queues one annotation", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("records it as a range", function()
+    assert.same("range", e.kind)
+  end)
+
+  it("spans exactly the selected lines", function()
+    assert.same(1, e.first)
+    assert.same(2, e.last)
+  end)
+
+  it("carries the selected lines themselves", function()
+    local source = vim.fn.readfile(vim.fs.joinpath(root, "src/main.lua"))
+    assert.same({ " " .. source[1], " " .. source[2] }, e.lines)
+  end)
+
+  -- The review path escapes visual mode before opening the composer. Capture has to do
+  -- the same, or the composer is entered with a selection still live.
+  it("leaves visual mode before the composer opens", function()
+    assert.same("n", composed[#composed].mode)
+  end)
+
+  it("travels as a reference the target can resolve", function()
+    local text = require("codereview.payload").render(queue.all(), root, {
+      types = require("codereview.config").get().types,
+    })
+    assert.is_truthy(text:find("@src/main.lua#L1-2", 1, true), text)
+  end)
+
+  -- An agent whose cwd does not contain the file cannot follow a ref at all, so the code
+  -- has to travel with the note instead.
+  it("inlines its code when the file is outside the target's tree", function()
+    local text = require("codereview.payload").render(queue.all(), "/nowhere/else", {
+      types = require("codereview.config").get().types,
+    })
+    assert.is_nil(text:find("@src/main.lua", 1, true), text)
+    assert.is_truthy(text:find("```diff", 1, true), text)
+    local source = vim.fn.readfile(vim.fs.joinpath(root, "src/main.lua"))
+    assert.is_truthy(text:find(source[1], 1, true), text)
+  end)
+end)
+
+-- The command line drops visual mode before running the command, so `:'<,'>` has to come
+-- through as a range or the selection is silently lost and the whole file captured.
+describe("the user command given a range", function()
+  queue.clear()
+  edit("src/main.lua")
+  vim.cmd("1,2CodeReviewAnnotate nitpick")
+  local e = queue.all()[1]
+
+  it("captures exactly those lines", function()
+    assert.same("range", e.kind)
+    assert.same(1, e.first)
+    assert.same(2, e.last)
+  end)
+
+  it("captures a single-line range as a line, as the review path does", function()
+    queue.clear()
+    vim.cmd("2CodeReviewAnnotate nitpick")
+    local one = queue.all()[1]
+    assert.same("line", one.kind)
+    assert.same(2, one.first)
+    assert.same(2, one.last)
+  end)
+
+  it("still captures the whole file when given no range", function()
+    queue.clear()
+    vim.cmd("CodeReviewAnnotate nitpick")
+    assert.same("file", queue.all()[1].kind)
+  end)
+end)
+
+describe("diagnostics riding along", function()
+  local ns = vim.api.nvim_create_namespace("capture_spec_diagnostics")
+  local buf = edit("src/main.lua")
+  local S = vim.diagnostic.severity
+
+  ---@param lnum integer 0-based, as `vim.diagnostic` reports them
+  local function diag(lnum, severity, message)
+    return { lnum = lnum, col = 0, severity = severity, message = message, source = "lua_ls" }
+  end
+
+  vim.diagnostic.set(ns, buf, {
+    diag(0, S.ERROR, "undefined global `app`"),
+    diag(1, S.WARN, "unused local `cfg`"),
+    diag(2, S.ERROR, "past the selection"),
+    -- Inside the selection on purpose, so the severity filter is what excludes these and
+    -- not the line range. Parked on line 3 they passed either way, measuring nothing.
+    diag(0, S.HINT, "a hint nobody asked for"),
+    diag(1, S.INFO, "merely informational"),
+  })
+
+  queue.clear()
+  h.feed("1GVj<F5>")
+  local ranged = queue.all()[1].note
+
+  it("keeps the note the composer collected first", function()
+    assert.is_truthy(ranged:find("^the note"), ranged)
+  end)
+
+  it("appends the errors and warnings overlapping the selection", function()
+    assert.is_truthy(ranged:find("Diagnostics:", 1, true), ranged)
+    assert.is_truthy(ranged:find("ERROR", 1, true), ranged)
+    assert.is_truthy(ranged:find("undefined global `app`", 1, true), ranged)
+    assert.is_truthy(ranged:find("WARN", 1, true), ranged)
+    assert.is_truthy(ranged:find("unused local `cfg`", 1, true), ranged)
+  end)
+
+  it("names the line and the source of each", function()
+    assert.is_truthy(ranged:find("L1", 1, true), ranged)
+    assert.is_truthy(ranged:find("L2", 1, true), ranged)
+    assert.is_truthy(ranged:find("(lua_ls)", 1, true), ranged)
+  end)
+
+  it("leaves out one that does not overlap the selection", function()
+    assert.is_nil(ranged:find("past the selection", 1, true), ranged)
+  end)
+
+  it("leaves out hints and info", function()
+    assert.is_nil(ranged:find("a hint nobody asked for", 1, true), ranged)
+    assert.is_nil(ranged:find("merely informational", 1, true), ranged)
+  end)
+
+  queue.clear()
+  codereview.annotate("bug")
+  local whole = queue.all()[1].note
+
+  it("rides along with a whole-file capture too", function()
+    assert.is_truthy(whole:find("undefined global `app`", 1, true), whole)
+    assert.is_truthy(whole:find("unused local `cfg`", 1, true), whole)
+    assert.is_truthy(whole:find("past the selection", 1, true), whole)
+  end)
+
+  it("still leaves out hints and info for a whole file", function()
+    assert.is_nil(whole:find("a hint nobody asked for", 1, true), whole)
+    assert.is_nil(whole:find("merely informational", 1, true), whole)
+  end)
+
+  -- A clean buffer must not grow an empty heading.
+  it("adds nothing when there is nothing to add", function()
+    vim.diagnostic.reset(ns, buf)
+    queue.clear()
+    codereview.annotate("bug")
+    assert.same("the note", queue.all()[1].note)
+  end)
+end)
+
+describe("a range and a whole file together", function()
+  local view = require("codereview.view")
+  queue.clear()
+  local before_sent = #sent
+
+  local buf = edit("src/main.lua")
+  local before_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  h.feed("1GVj<F5>")
+  vim.cmd("CodeReviewAnnotate nitpick")
+
+  it("queues both shapes", function()
+    assert.same(2, queue.count())
+    assert.same({ "range", "file" }, { queue.all()[1].kind, queue.all()[2].kind })
+  end)
+
+  -- Capturing a selection escapes visual mode, which is the one thing in either path that
+  -- touches the buffer's state at all.
+  it("leaves the source buffer untouched", function()
+    assert.same(before_lines, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+    assert.is_false(vim.bo[buf].modified)
+  end)
+
+  view.submit()
+
+  it("submits them in a single batch", function()
+    assert.same(before_sent + 1, #sent)
+    assert.same(0, queue.count())
+  end)
+
+  it("carries both in that one payload, each under its own type", function()
+    local text = sent[#sent].text
+    assert.is_truthy(text:find("@src/main.lua#L1%-2"), text)
+    assert.is_truthy(text:find("## Bugs", 1, true), text)
+    assert.is_truthy(text:find("## Nitpicks", 1, true), text)
+    assert.is_truthy(text:find("2 annotations", 1, true), text)
   end)
 end)
 


### PR DESCRIPTION
Closes #4.

Completes the pair of capture scopes. A live visual selection captures exactly those
lines; normal mode still captures the whole file. Errors and warnings overlapping either
ride along with the note.

### Scope

| Where you are | What gets captured |
| --- | --- |
| Normal mode | The whole file |
| A visual selection | Exactly those lines |
| `:'<,'>CodeReviewAnnotate bug` | Exactly those lines |
| `:12,20CodeReviewAnnotate bug` | Lines 12 to 20 |

The command needed the range. The command line drops visual mode *before* running the
command, so `:'<,'>CodeReviewAnnotate` without it would silently widen a selection to the
whole file — the worst kind of wrong, because it still queues something.

A range travels as `@path#L12-20` when the target can resolve the path and inlines its
code when it cannot, through the existing renderer. Single-line selections come out as
`line` and multi-line as `range`, matching what the review path produces for the same
selection — the payload and the float both switch on kind.

### Diagnostics

Appended under the note, errors and warnings only:

```
why is this branch unreachable?

Diagnostics:
- ERROR L12 undefined global `foo` (lua_ls)
- WARN  L14 unused local `bar` (lua_ls)
```

Hints and info are excluded per the issue. Both the lines and the diagnostics are read
before the composer opens, because the composer and the type picker are both asynchronous
and a language server can republish underneath either one; what rides along should be what
was on screen when the note was started.

The shared tail grew one optional `note_suffix` rather than learning about diagnostics —
the review path passes nothing.

### One test was measuring the wrong thing

Worth flagging since it would have survived review. `capture_spec`'s "leaves out hints and
info" originally parked its HINT and INFO diagnostics on a line outside the captured
range, so the *range* filter rejected them and the assertion passed with the severity
filter deleted. They now sit inside the selection, and deleting either filter fails a
distinct test. `tests/README.md` records the general rule: a filter test needs a fixture
only that filter can reject.

The severity filter and the overlap filter were each mutation-tested by reverting the code
they guard. The visual-mode exit was not reverted -- it failed on its own before the fix
existed and passed after, which is the same evidence by a different route.

### Notes

- 320 cases, from 298.
- `tests/README.md` also records that visual capture must be driven through a fed mapping
  — `mode()` and `line("v")` have to be read while the selection is live, so calling the
  entry point directly after a selection captures the whole file instead.
