### PR TITLE
feat(state): judge buffer annotations against the file on disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,14 @@ Each entry records the git blob it was captured against. On reload:
   still worth sending and only its line anchor is untrustworthy. A stale entry never
   travels as an `@ref`; its code is inlined instead.
 
+Each kind is judged against whatever its blob was actually taken from. A review annotation
+is judged against the diff on screen, and a file the current scope does not include is not
+evidence that anything changed — so it is left alone. An annotation captured from a buffer
+has no scope behind it and is judged against the file on disk, at any scope and with no
+review open. That distinction matters in a `staged` review, where the diff shows the index
+and a buffer capture holds the working tree: judging one by the other would flag a note
+about a file nobody has touched.
+
 ## Development
 
 ```sh

--- a/lua/codereview/capture.lua
+++ b/lua/codereview/capture.lua
@@ -117,6 +117,10 @@ function M.target(buf, range)
     -- Hashed at capture time, exactly as the review path hashes a diffed file. This is
     -- what buys staleness detection later; an entry without it can go quietly wrong.
     blob = git.blob(rel, nil, root),
+    -- Records *what* that blob is: the working tree, not a ref. A review annotation's blob
+    -- can be an index or commit blob depending on the scope it was captured in, so this is
+    -- what lets staleness judge each kind against the thing it was actually taken from.
+    worktree = true,
     inline = false,
   }
 

--- a/lua/codereview/queue.lua
+++ b/lua/codereview/queue.lua
@@ -12,6 +12,8 @@ local M = {}
 ---@field path string           Repository-relative
 ---@field abs_path string
 ---@field blob string|nil       File content hash when captured; the staleness key
+---@field worktree boolean|nil  `blob` is the working tree's hash rather than a ref's, so
+---                             staleness judges it against the file on disk at any scope
 ---@field key string            Anchor key from render.line_key / render.file_key
 ---@field first integer|nil
 ---@field last integer|nil

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -93,14 +93,19 @@ end
 ---Separate from `restore`, which needs a view and a scope to put reviewed marks back.
 ---The queue needs neither: it is what you submit, not what you are looking at.
 ---@param root string
+---@return integer staled
 function M.restore_queue(root)
   if queue.count() > 0 then
-    return
+    return 0
   end
   local data = M.load(root)
   if data.queue and #data.queue > 0 then
     queue.replace(data.queue)
   end
+  -- Judged as it comes back. This is the window staleness exists to cover: the file was
+  -- free to change while nothing was watching it, and a restored note that still claims a
+  -- line span is exactly the silent wrongness one queue was supposed to remove.
+  return M.reconcile_queue(root)
 end
 
 ---Restore saved progress into a freshly opened view.
@@ -120,6 +125,43 @@ function M.restore(view, scope_key)
   if data.queue and #data.queue > 0 and queue.count() == 0 then
     queue.replace(data.queue)
   end
+end
+
+---Judge working-tree annotations against the files on disk.
+---
+---These are the captures that have no scope behind them, so the diff-based rule never
+---reaches them: it only judges what the current scope includes, which is correct for a
+---review annotation and means a buffer annotation about an unrelated file would never be
+---checked at all. Judged here at any scope, and with no view open.
+---@param root string
+---@return integer staled
+function M.reconcile_queue(root)
+  local git = require("codereview.git")
+
+  local paths = {}
+  for _, item in ipairs(queue.all()) do
+    if item.worktree and item.path then
+      paths[#paths + 1] = item.path
+    end
+  end
+  if #paths == 0 then
+    return 0
+  end
+
+  local hashes = git.hash_worktree(paths, root)
+  local staled = 0
+  for _, item in ipairs(queue.all()) do
+    if item.worktree and item.path then
+      -- A file that has been deleted hashes to nothing, which is at least as stale as one
+      -- that merely changed: the lines the note names are gone either way.
+      local moved = hashes[item.path] ~= (item.blob or "")
+      item.stale = moved or nil
+      if moved then
+        staled = staled + 1
+      end
+    end
+  end
+  return staled
 end
 
 ---Reconcile restored state against the diff that is actually on screen.
@@ -147,7 +189,11 @@ function M.reconcile(view)
 
   local staled = 0
   for _, item in ipairs(queue.all()) do
-    local file = by_path[item.path]
+    -- A working-tree capture is judged below instead, against the file on disk. Judging it
+    -- here as well would compare it against whichever blob this scope happens to show --
+    -- the index, in a staged review -- and flag an annotation about a file nobody has
+    -- touched since it was captured. Two rules that disagree, applied to one entry.
+    local file = not item.worktree and by_path[item.path]
     if file then
       local moved = (file.blob or "") ~= (item.blob or "")
       item.stale = moved or nil
@@ -157,7 +203,7 @@ function M.reconcile(view)
     end
   end
 
-  return unmarked, staled
+  return unmarked, staled + M.reconcile_queue(view.root)
 end
 
 ---Forget everything saved for a repository.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -233,8 +233,14 @@ function M.ensure_queue()
   end
   queue_restored = true
   local root = ambient_root()
-  if root then
-    require("codereview.state").restore_queue(root)
+  if not root then
+    return
+  end
+  local staled = require("codereview.state").restore_queue(root)
+  if staled > 0 then
+    -- Worded exactly as the review view reports it. With no view open this is the only
+    -- moment a restored annotation's staleness would otherwise go unmentioned.
+    info(("%d annotation%s now stale"):format(staled, staled == 1 and "" or "s"))
   end
 end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, blob, composer, diagnostics, restart, one queue |
+| `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `interactive_spec` | The insert-mode leak, in a real pty-backed Neovim |

--- a/tests/codereview/staleness_spec.lua
+++ b/tests/codereview/staleness_spec.lua
@@ -1,0 +1,234 @@
+-- Staleness for annotations captured from a buffer.
+--
+-- A review annotation is judged against the diff on screen, which is right for it: a file
+-- the scope does not include is not evidence that anything changed. A buffer annotation
+-- has no scope behind it, so that rule never judges it at all -- it would keep claiming a
+-- line span that may now point at unrelated code, with nothing saying so.
+--
+-- Its own spec rather than an extension of capture_spec, because it rewrites fixture files
+-- on disk and every spec file gets its own Neovim and its own throwaway repository.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+local codereview = require("codereview")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local payload = require("codereview.payload")
+local config = require("codereview.config")
+
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "the note")
+  end,
+})
+
+local root = assert(vim.uv.fs_realpath(fixture))
+
+---@param rel string
+---@return integer buf
+local function edit(rel)
+  vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, rel)))
+  return vim.api.nvim_get_current_buf()
+end
+
+---Rewrite a fixture file on disk, which is what moves its blob.
+---@param rel string
+---@param lines string[]
+local function rewrite(rel, lines)
+  vim.fn.writefile(lines, vim.fs.joinpath(root, rel))
+end
+
+---@return string
+local function render()
+  return payload.render(queue.all(), root, { types = config.get().types })
+end
+
+describe("a whole-file buffer annotation", function()
+  queue.clear()
+  edit("src/fresh.lua")
+  codereview.annotate("bug")
+  local entry = queue.all()[1]
+
+  it("is not flagged while the file is untouched", function()
+    state.reconcile_queue(root)
+    assert.is_nil(entry.stale)
+  end)
+
+  it("still travels as a reference", function()
+    assert.is_truthy(render():find("@src/fresh.lua", 1, true), render())
+  end)
+
+  it("is flagged once the file on disk changes", function()
+    rewrite("src/fresh.lua", { "local function fresh() end", "local added = true" })
+    state.reconcile_queue(root)
+    assert.is_true(entry.stale)
+  end)
+
+  it("stops travelling as a reference", function()
+    assert.is_nil(render():find("@src/fresh.lua", 1, true), render())
+  end)
+end)
+
+vim.keymap.set({ "n", "x" }, "<F5>", function()
+  codereview.annotate("bug")
+end, { desc = "staleness_spec: annotate as bug" })
+
+describe("a range buffer annotation", function()
+  queue.clear()
+  edit("src/newname.lua")
+  h.feed("1GVj<F5>")
+  local entry = queue.all()[1]
+
+  it("travels as a reference while the file is untouched", function()
+    state.reconcile_queue(root)
+    assert.is_nil(entry.stale)
+    assert.is_truthy(render():find("@src/newname.lua#L1-2", 1, true), render())
+  end)
+
+  it("is flagged once the file on disk changes", function()
+    rewrite("src/newname.lua", { 'local name = "changed"', "local second = 2", "local third = 3" })
+    state.reconcile_queue(root)
+    assert.is_true(entry.stale)
+  end)
+
+  it("inlines its code rather than pointing at lines it can no longer vouch for", function()
+    local text = render()
+    assert.is_nil(text:find("@src/newname.lua", 1, true), text)
+    assert.is_truthy(text:find("```diff", 1, true), text)
+    assert.is_truthy(text:find("line numbers may be stale", 1, true), text)
+  end)
+
+  -- The whole point of inlining: the agent reads what the reviewer was looking at, not
+  -- whatever now occupies those line numbers.
+  it("inlines the lines as captured, not as they are now", function()
+    local text = render()
+    assert.is_truthy(text:find('local name = "new"', 1, true), text)
+    assert.is_nil(text:find('local name = "changed"', 1, true), text)
+  end)
+end)
+
+-- Two rules could reach the same entry here, and they disagree. The diff-based rule would
+-- compare a working-tree capture against the *index* blob the staged scope shows, and flag
+-- an annotation about a file nobody has touched since it was captured.
+describe("a buffer annotation about a file that is also in the diff", function()
+  local view = require("codereview.view")
+  queue.clear()
+  edit("src/routes.lua")
+  codereview.annotate("bug")
+  local entry = queue.all()[1]
+
+  -- Guards the premise: if the fixture ever stops staging a change on top of an unstaged
+  -- one, these blobs converge and this whole case quietly stops testing anything.
+  it("is a file whose index and working-tree blobs genuinely differ", function()
+    local indexed = h.git_lines(root, { "rev-parse", ":0:src/routes.lua" })[1]
+    local working = h.git_lines(root, { "hash-object", "src/routes.lua" })[1]
+    assert.is_true(indexed ~= working, "the fixture no longer distinguishes index from worktree")
+  end)
+
+  view.open("staged")
+  local V = assert(view.current(), "the staged review did not open")
+
+  it("is a file the open scope includes", function()
+    assert.is_truthy(h.file_index(V, "src/routes.lua"), "routes.lua is not in the staged scope")
+  end)
+
+  it("is judged against the working tree it came from, not the diff it overlaps", function()
+    assert.is_nil(entry.stale, "a worktree capture was judged against the index blob")
+  end)
+
+  it("still travels as a reference", function()
+    assert.is_truthy(render():find("@src/routes.lua", 1, true), render())
+  end)
+
+  view.close()
+end)
+
+describe("restoring a queue whose file has moved on", function()
+  queue.clear()
+  state.clear(root)
+  edit("src/nonl.md")
+  codereview.annotate("bug")
+  rewrite("src/nonl.md", { "# rewritten after the note was written" })
+
+  -- What a new session does: nothing in memory, the queue on disk.
+  queue.clear()
+  local staled = state.restore_queue(root)
+
+  it("restores the annotation", function()
+    assert.same(1, queue.count())
+    assert.same("src/nonl.md", queue.all()[1].path)
+  end)
+
+  -- Without this surviving the round trip through JSON, a restored capture would never be
+  -- judged again -- which is precisely the window staleness exists to cover.
+  it("kept the record of what its blob was taken against", function()
+    assert.is_true(queue.all()[1].worktree)
+  end)
+
+  it("flags it stale on restore", function()
+    assert.is_true(queue.all()[1].stale)
+  end)
+
+  it("reports how many went stale", function()
+    assert.same(1, staled)
+  end)
+end)
+
+describe("telling the user", function()
+  local view = require("codereview.view")
+  queue.clear()
+  edit("src/main.lua")
+  codereview.annotate("bug")
+  rewrite("src/main.lua", { "local app = require('app')", "local cfg = load_config()", "local extra = true" })
+
+  local msgs, restore_notify = h.capture_notify()
+  view.open("branch")
+  restore_notify()
+
+  it("counts it in the same message review staleness is reported by", function()
+    assert.is_true(h.notified(msgs, "1 annotation now stale"), vim.inspect(msgs))
+  end)
+
+  it("leaves reviewed marks alone", function()
+    local V = assert(view.current())
+    assert.same({}, V.reviewed)
+  end)
+
+  view.close()
+end)
+
+-- The gap this slice exists to close. `ignored.txt` is gitignored, so no scope will ever
+-- contain it, and the diff-based rule would never reach the annotation at all.
+describe("a buffer annotation about a file no scope includes", function()
+  local view = require("codereview.view")
+  queue.clear()
+  edit("ignored.txt")
+  codereview.annotate("nitpick")
+  local entry = queue.all()[1]
+
+  view.open("branch")
+  local V = assert(view.current(), "the branch review did not open")
+
+  it("is about a file the review genuinely does not show", function()
+    assert.is_nil(h.file_index(V, "ignored.txt"), "the fixture stopped ignoring ignored.txt")
+  end)
+
+  it("survives the review opening rather than being discarded", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("is not flagged while its file is untouched", function()
+    assert.is_nil(entry.stale)
+  end)
+
+  it("is judged on its own terms once its file changes", function()
+    rewrite("ignored.txt", { "secret, but different" })
+    view.refresh()
+    assert.is_true(entry.stale)
+  end)
+
+  view.close()
+end)


### PR DESCRIPTION
Closes #5.

Reconciliation only ever judged annotations whose path appeared in the current scope. That
is right for a review annotation — a file the scope does not include is not evidence that
anything changed — but it meant an annotation captured from a buffer was never judged at
all. It kept claiming a line span that could point at unrelated code, with nothing saying
so.

An entry now records *what* its blob was taken from. A capture holds the working tree's
hash, so it is judged against the file on disk: at any scope, and with no review view open.
A review annotation keeps being judged against the diff, unchanged.

### The case that made this more than a gap

In a `staged` review the diff shows **index** blobs, while a buffer capture holds the
**working tree**. The old rule would have judged one by the other and flagged an annotation
about a file nobody had touched since capturing it — two rules disagreeing over one entry.
Working-tree captures are now excluded from the diff-based pass rather than judged twice.

`staleness_spec` pins this with the fixture's `src/routes.lua`, which has a staged change
and an unstaged one on top, so its index and worktree blobs genuinely differ. That premise
is itself asserted, so the case cannot quietly stop testing anything if the fixture changes.

### Where it is judged

- On restore, which is the window this exists to cover: the file was free to change while
  nothing was watching it. `restore_queue` now reconciles and returns what went stale.
- On opening or refreshing a review, folded into the existing count so it is reported in
  the same words review staleness already uses.
- With no view open, `ensure_queue` reports it — otherwise a restored annotation's
  staleness would go unmentioned entirely.

The consequence is the one that matters: a stale entry stops travelling as a reference and
inlines the code it was written about. `staleness_spec` asserts the inlined text is the
line **as captured**, not as it is now — the agent reads what the reviewer saw.

### Notes

- 342 cases, from 320. New spec file rather than an extension of `capture_spec`, because it
  rewrites fixture files on disk and each spec gets its own repository.
- The `worktree` marker was mutation-tested by removing it: five assertions go red.
- Review staleness and reviewed marks are asserted unchanged, and the rest of the suite —
  `state_spec`, `payload_spec`, `viewless_spec` — passes untouched.
