### PR TITLE
chore: license the plugin mit and open it to contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Something in the plugin does not behave as documented
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: `make all` on `master` should be green. If it is not, say so — that
+        is a different and more interesting bug.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you got, and what you expected instead.
+      placeholder: |
+        Opened `:CodeReview` on a branch with a renamed file. The rename rendered as an
+        add plus a delete. I expected one entry marked as a rename.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: >
+        The steps, ideally from a fresh repository. A shell snippet that builds the
+        repository shape beats a description of it — see `tests/fixtures/` for the style.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: nvim-version
+    attributes:
+      label: Neovim version
+      description: The first line of `nvim --version`. 0.12+ is the floor.
+      placeholder: NVIM v0.12.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Your configuration
+      description: >
+        The `opts` table you pass to the plugin, including any `send`, `pick_target` or
+        `compose` adapters. Reduce them to stubs if the bug reproduces without them.
+      render: lua
+      placeholder: |
+        {
+          context = 3,
+          untracked = true,
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: errors
+    attributes:
+      label: Errors or messages
+      description: Anything from `:messages`, plus the stack trace if there was one.
+      render: text
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I reproduced this on the latest `master`.
+          required: true
+        - label: I searched existing issues for this.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or usage help
+    url: https://github.com/felipeva/codereview-annotator.nvim/discussions
+    about: Ask here rather than opening an issue — how to configure, wire an adapter, or bind a key.
+  - name: Report a security issue
+    url: https://github.com/felipeva/codereview-annotator.nvim/security/advisories/new
+    about: Report privately as a draft advisory. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Propose a change to what the plugin does
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Search open issues first — if this is already filed, add your use case there rather
+        than opening a duplicate. A second person describing a different reason for wanting
+        the same thing is worth more than a second issue.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: >
+        What review workflow does this unblock? Describe the situation you hit, not the
+        feature you already decided on — the useful design often is not the first one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you have in mind
+      description: The behaviour you want, including keys, commands or config if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you tried instead
+      description: >
+        Existing keys, adapters or config that get partway there, and where they fall
+        short. The plugin has no opinion about delivery — a lot of "features" are an
+        adapter you can already write.
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This belongs in the plugin rather than in a `send`/`pick_target`/`compose` adapter.
+        - label: I am willing to open a PR for it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+The PR title is a Conventional Commits subject — it becomes the squash commit.
+e.g. feat(panel): fold a directory subtree from the tree
+-->
+
+## Why
+
+<!-- The problem this solves. The diff already says what changed. -->
+
+Closes #
+
+## Notes for the reviewer
+
+<!--
+Anything non-obvious: a constraint you hit, an approach you rejected, a design note in the
+README this touches. Delete if there is nothing.
+-->
+
+## Checklist
+
+- [ ] `make all` passes (lint + suite).
+- [ ] New behaviour has a spec under `tests/codereview/`.
+- [ ] `README.md` and `doc/codereview.txt` updated, if user-facing behaviour changed.
+- [ ] Commits follow Conventional Commits (`make hooks` validates them).

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .tests/
 *.log
+doc/tags

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ Both PRD skills are `disable-model-invocation: true` — **the user invokes them
 Straight-to-`master` is only for what has no issue behind it: docs corrections,
 formatting, CI plumbing. Anything a PRD was written for gets a branch and a PR.
 
+`CONTRIBUTING.md` is the same workflow written for outside contributors. Change both when
+one moves, or they drift.
+
 ## Commits
 
 **Conventional Commits, enforced by `.githooks/commit-msg`.** Install it once per clone —
@@ -53,7 +56,7 @@ five seconds. See `tests/README.md` for the layout and the traps.
 
 ### Issue tracker
 
-Issues live in this repo's GitHub Issues (`felipeva/codereview-annotator.nvim`), via the `gh` CLI. External PRs are **not** a triage surface. See `docs/agents/issue-tracker.md`.
+Issues live in this repo's GitHub Issues (`felipeva/codereview-annotator.nvim`), via the `gh` CLI. The repo is public, so external PRs **are** a triage surface — an outside contributor often states a request as a PR and never files an issue. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**jfelipevalr@gmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,137 @@
+# Contributing
+
+Contributions are welcome — bug reports, fixes, features, docs. This file is the whole
+process; there is nothing else to sign or join.
+
+## Getting set up
+
+```sh
+git clone https://github.com/felipeva/codereview-annotator.nvim
+cd codereview-annotator.nvim
+make hooks   # once per clone: enables the commit-msg hook (git does not version hooks)
+make deps    # clones plenary into .tests/
+make all     # lint + the full suite, ~5s
+```
+
+You need Neovim **0.12+**, `git`, and [`stylua`](https://github.com/JohnnyMorganz/StyLua)
+for linting. Nothing else — the test suite deliberately depends on plenary alone.
+
+To run the plugin from your checkout, point your plugin manager at the directory:
+
+```lua
+{ dir = "~/path/to/codereview-annotator.nvim", cmd = "CodeReview", opts = {} }
+```
+
+## Before you write code
+
+**Open an issue first** for anything with a design decision behind it. The
+[Design notes](README.md#design-notes) section of the README exists because several
+obvious-looking approaches here are wrong for non-obvious reasons — a short conversation
+on an issue is cheaper than a rewritten PR.
+
+Typo fixes, doc corrections and obviously-correct one-line bug fixes can go straight to a
+PR.
+
+## Tests
+
+`make all` before every commit that touches `lua/`. It takes about five seconds.
+
+```sh
+make test                                            # the whole suite
+make test-file FILE=tests/codereview/diff_spec.lua   # one spec, in-process
+make lint                                            # stylua --check
+make format                                          # stylua, in place
+make perf                                            # open-time report, not part of CI
+```
+
+New behaviour needs a spec. [`tests/README.md`](tests/README.md) covers the layout, the
+fixture scripts, what is deliberately not covered, and the traps worth knowing before you
+change a fixture — read it before adding one. The short version:
+
+- Each spec file gets its own Neovim and builds its own throwaway git fixture.
+- Use `make test-file`, never `:PlenaryBustedFile` — that command spawns a child without
+  `-u` and loads your real config instead of `tests/minimal_init.lua`.
+- Fixtures are Lua and Markdown on purpose: Neovim core ships those parsers and their
+  `highlights` queries, so CI needs no nvim-treesitter and no compiler.
+
+CI runs the suite on Neovim stable and nightly, plus `stylua --check`.
+
+## Commits
+
+**Conventional Commits**, validated by `.githooks/commit-msg` (installed by `make hooks`).
+
+```
+<type>(<optional scope>)!: <description>
+```
+
+- types: `build` `chore` `ci` `docs` `feat` `fix` `perf` `refactor` `revert` `style` `test`
+- description: lowercase imperative, no trailing period
+- subject at most 72 characters, blank line before the body
+- the body explains **why** — the diff already says what
+
+Branch off the issue: `<type>/<issue>-<slug>`, e.g. `feat/12-single-annotation-queue`. The
+`<type>` is the same Conventional Commits type the work will land under, so the branch, the
+commits and the PR title all agree.
+
+## Pull requests
+
+- The title is a Conventional Commits subject — it becomes the squash commit.
+- The body closes the issue (`Closes #12`) and says why, not what.
+- Keep it to one vertical slice. Two unrelated changes are two PRs.
+- Update `README.md` and `doc/codereview.txt` when you change user-facing behaviour; both
+  are hand-written and neither is generated from the other.
+
+## Code style
+
+`stylua.toml` is the whole style guide — `make format` settles every formatting question.
+It sets `syntax = "Lua52"`, which is what allows `goto`/`::label::`.
+
+Beyond formatting, the two things worth matching:
+
+- **Comments explain why.** The codebase is dense with rationale comments on the parts that
+  look wrong until you know the constraint. Keep that ratio; do not narrate what the line
+  does.
+- **`require("codereview").annotate(type)` is the public capture seam.** Extend it rather
+  than adding a parallel entry point, so a keybinding never has to reach into an internal
+  module.
+
+## Built with Claude Code
+
+This plugin was written with [Claude Code](https://claude.com/claude-code), and the repo is
+set up to keep working that way. That is stated plainly for two reasons: so you know what
+you are reading, and so you know agent-assisted contributions are welcome here rather than
+merely tolerated.
+
+What is in the repo for that:
+
+| File | What it does |
+| --- | --- |
+| [`CLAUDE.md`](CLAUDE.md) | Operating instructions an agent reads on entering the repo — the workflow above, in imperative form |
+| [`docs/agents/`](docs/agents/) | Where issues live, the triage label vocabulary, and the domain-doc layout |
+| [`README.md`](README.md#design-notes) § Design notes | Every non-obvious constraint that cost real debugging time |
+| [`tests/README.md`](tests/README.md) | The suite's layout, and the fixture traps that will otherwise cost an afternoon |
+
+Point your agent at `CLAUDE.md` and it will follow the same branch, commit and PR
+conventions this file describes.
+
+**The bar is identical either way.** However a change was produced, you are the author of
+what you open: the tests pass, the design notes were read, the rationale in the PR body is
+yours, and you can answer questions about it in review. A PR that reads as an unreviewed
+model dump — invented APIs, tests that assert nothing, a diff twice the size of the
+problem — gets sent back regardless of who or what typed it. There is no requirement to
+disclose tool use, and no penalty for it.
+
+## Reporting bugs
+
+Use the issue template. The parts that actually determine whether a bug is reproducible:
+`nvim --version`, your `opts` table, the repository shape (branch scope? untracked files? a
+rename?), and what you expected instead. A minimal fixture beats a description.
+
+## Security
+
+See [`SECURITY.md`](SECURITY.md).
+
+## License
+
+By contributing you agree that your contributions are licensed under the
+[MIT License](LICENSE), the same terms that cover the project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Felipe Valencia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # codereview-annotator.nvim
 
+[![test](https://github.com/felipeva/codereview-annotator.nvim/actions/workflows/test.yml/badge.svg?branch=master&event=push)](https://github.com/felipeva/codereview-annotator.nvim/actions/workflows/test.yml?query=branch%3Amaster)
+[![Neovim 0.12+](https://img.shields.io/badge/Neovim-0.12%2B-57A143?logo=neovim&logoColor=white)](https://neovim.io)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 A code review surface for Neovim: one unified, syntax-highlighted diff of everything a
 branch changed, with vim-native navigation, typed annotations that queue up, reviewed-file
 collapsing, and a batch submit that hands the whole review to an agent as a single message.
@@ -331,6 +335,9 @@ git fixture. CI runs them on Neovim stable and nightly with plenary as the only 
 parsers ship with Neovim. See [`tests/README.md`](tests/README.md) for the layout, what is
 deliberately not covered, and the traps worth knowing before changing a fixture.
 
+[`CONTRIBUTING.md`](CONTRIBUTING.md) covers the rest: the commit convention, the branch and
+PR shape, and how to run a single spec.
+
 ## Design notes
 
 Things that are non-obvious and cost real debugging time.
@@ -417,3 +424,36 @@ back to the diff window, so choosing an agent from the queue float dumped the cu
 the diff — where `<C-s>` hits the *main* buffer's mapping, which submits the batch but
 leaves the float open behind it. It also has to drive its own repaint: the picker is
 asynchronous, so anything run after the call returns paints before a target exists.
+
+## Built with Claude Code
+
+This plugin was written with [Claude Code](https://claude.com/claude-code), and it is set
+up so anyone can keep working on it that way. Said plainly for two reasons: so you know
+what you are reading, and so you know agent-assisted contributions are welcome here rather
+than merely tolerated.
+
+The repo carries what an agent needs to be useful in it rather than merely fast:
+[`CLAUDE.md`](CLAUDE.md) holds the workflow in imperative form, [`docs/agents/`](docs/agents/)
+records where issues live and how they are labelled, and the *Design notes* above exist
+because several obvious-looking approaches here are wrong for reasons no amount of reading
+the code reveals. Point an agent at `CLAUDE.md` and it will follow the same branch, commit
+and PR conventions a human contributor does.
+
+The bar is the same either way — the tests pass, the design notes were read, and you can
+answer questions about the change in review. There is no requirement to disclose tool use,
+and no penalty for it.
+
+## Contributing
+
+Issues and pull requests are welcome. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) —
+setup is `make hooks && make deps && make all`, and it takes about five seconds to know
+whether the suite is green.
+
+Open an issue first for anything with a design decision behind it; typo fixes and
+obviously-correct one-liners can go straight to a PR. Participation is under the
+[Code of Conduct](CODE_OF_CONDUCT.md); security reports go through
+[`SECURITY.md`](SECURITY.md), not the issue tracker.
+
+## License
+
+[MIT](LICENSE) © Felipe Valencia

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+This project has no release branches. Fixes land on `master`; update to the latest commit.
+
+## Reporting a vulnerability
+
+Report privately — **do not open a public issue**.
+
+- Preferred: [open a draft security advisory](https://github.com/felipeva/codereview-annotator.nvim/security/advisories/new)
+- Or email **jfelipevalr@gmail.com**
+
+Include what an attacker can do, the repository or configuration shape needed to reach it,
+and a reproduction if you have one. Expect an acknowledgement within a week.
+
+## What is in scope
+
+The plugin runs `git` subprocesses over the repository you open it in, reads and writes
+state under `stdpath("state")/codereview/`, and renders untrusted repository content into a
+Neovim buffer. Things worth reporting:
+
+- A repository whose contents (branch names, paths, diff bodies, file content) can cause
+  command injection, path traversal outside the repository root, or an unexpected write.
+- Persisted state under `stdpath("state")` that can be crafted to execute code or escape
+  its directory when loaded.
+- A crafted diff that makes the renderer or the treesitter replay execute repository
+  content rather than display it.
+
+## What is out of scope
+
+- The behaviour of any `send`, `pick_target` or `compose` adapter you supply. The plugin
+  hands the rendered payload to your function and has no opinion about where it goes;
+  what that function does with it is yours to secure.
+- The plugin makes no network requests of its own, and reads no credentials.

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -13,6 +13,7 @@ CONTENTS                                                          *codereview*
   8. Highlights ........................... |codereview-highlights|
   9. Persistence .......................... |codereview-persistence|
  10. Lua API .............................. |codereview-api|
+ 11. License .............................. |codereview-license|
 
 ==============================================================================
 1. INTRODUCTION                                    *codereview-introduction*
@@ -266,5 +267,14 @@ require("codereview").submit()                         *codereview.submit()*
 require("codereview").count()                           *codereview.count()*
         Number of queued annotations -- useful in a statusline.
 require("codereview").is_open()                       *codereview.is_open()*
+
+==============================================================================
+11. LICENSE                                               *codereview-license*
+
+MIT. Copyright (c) 2026 Felipe Valencia. See the LICENSE file in the plugin
+root for the full text.
+
+Written with Claude Code; agent-assisted contributions are welcome. See
+CONTRIBUTING.md.
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -17,7 +17,9 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 ## Pull requests as a triage surface
 
-**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+**PRs as a request surface: yes.** _(Set to `no` if this repo does not treat external PRs as feature requests; `/triage` reads this flag.)_
+
+The repo is public, so an external PR is often the first and only statement of a request. Triage it like an issue rather than waiting for one to be filed separately.
 
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 


### PR DESCRIPTION
## Why

The repo is going public. Nothing in it said who may use the plugin or on what terms, and the only statement of the workflow lived in `CLAUDE.md` — written at an agent, not at a person arriving from a plugin list.

**MIT.** The whole design premise is that people vendor, fork and adapt a review surface to their own delivery target; a copyleft term would make the adapter seam useless.

**`CONTRIBUTING.md` restates the `CLAUDE.md` workflow for humans**, so both audiences get the same branch, commit and PR conventions. `CLAUDE.md` now says to change both when one moves, since they will otherwise drift.

**Provenance is stated outright** in the README and `CONTRIBUTING.md` rather than left to be inferred from commit trailers. It tells a reader what they are looking at, and makes agent-assisted PRs explicitly welcome instead of something a contributor has to guess about. The review bar is unchanged either way, and that is said in the same breath.

**External PRs become a triage surface for the first time.** A contributor arriving from a plugin list often states a request as a PR and never files an issue, so `docs/agents/issue-tracker.md` flips its flag and `CLAUDE.md` follows.

## What is in it

| File | |
| --- | --- |
| `LICENSE` | MIT, © 2026 Felipe Valencia |
| `CONTRIBUTING.md` | Setup, tests, commits, PR shape, code style, provenance |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
| `SECURITY.md` | Private reporting; scope is the git subprocesses, the persisted state and the renderer — adapters are explicitly out |
| `.github/ISSUE_TEMPLATE/` | Bug and feature forms, plus a config linking questions to Discussions and security to a draft advisory |
| `.github/PULL_REQUEST_TEMPLATE.md` | Why + reviewer notes + the `make all` checklist |
| `README.md` | CI / Neovim / license badges, and closing Built-with / Contributing / License sections |
| `doc/codereview.txt` | A `*codereview-license*` section, so `:help` answers it too |
| `.gitignore` | `doc/tags` |

## Nothing points at `docs/agents/HANDOFF.md`

It is a maintainer's working notes — a ranked backlog, a machine-specific config wiring, decisions still mid-flight. Citing it from a feature-request form or the README would make an outside contributor responsible for reading a document nobody wrote for them, and would put it under a documentation-freshness obligation it was never meant to carry.

The three references that existed in an earlier revision of this branch are gone, and the file itself is untouched by this PR. What a contributor is pointed at instead: `CLAUDE.md` for the workflow, `docs/agents/` for where issues live and how they are labelled, `README.md` § *Design notes* for the constraints, and `tests/README.md` for the fixture traps.

## The CI badge

Pinned with `?branch=master&event=push`. The workflow fires on pushes to master *and* on every pull request, so an unpinned badge can display a PR run rather than the state of master. Pinned, it means what a reader assumes it means. The link carries the matching `?query=branch%3Amaster` so clicking through lands on the same filtered history.

It renders as "no status" while the repo is private — GitHub does not serve badge SVGs for private repos — and starts resolving on the visibility flip.

## Notes for the reviewer

- Rebased onto `1647043`. One commit, +531/-2. The only non-additive lines are one in `CLAUDE.md` and one in `docs/agents/issue-tracker.md`, both rewrites of a sentence that is about to become false.
- Scoped to open-sourcing only. No Lua changes; the suite is untouched by this branch.
- Every commit was scanned for keys, tokens and absolute local paths before the branch was pushed — none found, in the history or the tree.
- Discussions is enabled on the repo, so the issue-template contact link resolves. Topics are set.