### PR TITLE
feat(capture): annotate with no repository to anchor to

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ end, { desc = "Annotate as a bug" })
 | A visual selection | Exactly those lines |
 | `:'<,'>CodeReviewAnnotate bug` | Exactly those lines |
 | `:12,20CodeReviewAnnotate bug` | Lines 12 to 20 |
+| A file outside any checkout | The file, by absolute path |
+| A buffer with nothing on disk | A bare note, with no path at all |
+
+The last two are not second-class. They queue, submit and survive a restart like anything
+else — a scratch buffer is a fine place to leave a thought for the batch.
 
 Errors and warnings overlapping what you captured ride along with the note, so they stop
 being retyped by hand. Hints and info are left out — they are rarely why you are
@@ -302,6 +307,12 @@ Each entry records the git blob it was captured against. On reload:
 - an **annotation** whose blob moved is kept and flagged `⚠ stale`, because the prose is
   still worth sending and only its line anchor is untrustworthy. A stale entry never
   travels as an `@ref`; its code is inlined instead.
+
+Annotations with no repository behind them — a bare note, or a file outside any checkout —
+have nowhere repository-shaped to live, so they go to a single store beside the others.
+Nothing ever reconciles that store against a diff, so nothing would ever clear it: entries
+older than **seven days** are dropped when it is read. That bounds its growth but not its
+staleness, which is the accepted cost of not making those annotations second-class.
 
 Each kind is judged against whatever its blob was actually taken from. A review annotation
 is judged against the diff on screen, and a file the current scope does not include is not

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -201,11 +201,19 @@ end
 ---@param entry CRAnnotation
 ---@return string
 function M.describe(entry)
+  -- Nothing to name. Every branch below reads a path, and a bare thought has none, so
+  -- without this the composer title and the confirmation both say "nil:nil".
+  if entry.kind == "note" then
+    return "(no file)"
+  end
+  -- Outside a checkout there is no repository-relative path, and the absolute one is the
+  -- only name the file has.
+  local where = entry.path or entry.abs_path
   if entry.kind == "file" then
-    return ("%s (%s)"):format(entry.path, entry.tag or "whole file")
+    return ("%s (%s)"):format(where, entry.tag or "whole file")
   end
   local range = entry.first == entry.last and tostring(entry.first) or ("%d-%d"):format(entry.first, entry.last)
-  return entry.tag and ("%s:%s (%s)"):format(entry.path, range, entry.tag) or ("%s:%s"):format(entry.path, range)
+  return entry.tag and ("%s:%s (%s)"):format(where, range, entry.tag) or ("%s:%s"):format(where, range)
 end
 
 ---Leave insert mode once a composer hands control back.

--- a/lua/codereview/capture.lua
+++ b/lua/codereview/capture.lua
@@ -12,6 +12,14 @@ local types = require("codereview.types")
 
 local M = {}
 
+---Anchor key for an annotation with no file behind it.
+---
+---Every other key is built from a path, and a path is never empty, so this cannot collide
+---with one. Notes share it: nothing looks a note up by anchor -- the review view projects
+---annotations onto diff lines, and a note has none -- but `queue.by_key` needs a key it
+---can index, and nil is not one.
+local NOTE_KEY = "note:0"
+
 ---@param msg string
 local function warn(msg)
   vim.notify(msg, vim.log.levels.WARN, { title = "Code review" })
@@ -91,10 +99,16 @@ function M.target(buf, range)
   buf = (buf == nil or buf == 0) and vim.api.nvim_get_current_buf() or buf
 
   local name = vim.api.nvim_buf_get_name(buf)
-  -- A scratch buffer, the review view's own buffer, or anything else with no file behind
-  -- it. A bare thought with no path is a real capture shape, but it is its own slice.
+  -- Nothing on disk to anchor to: a scratch buffer, or a fresh unnamed one. That is a real
+  -- capture shape rather than an error -- a thought worth sending with no file behind it --
+  -- and it gets its own kind, because every other kind presupposes a file and both the
+  -- payload renderer and the queue float switch on kind.
+  --
+  -- A buffer that *has* a name which is not a file on disk still fails below. The review
+  -- view's own buffer is one of those, and turning `aa` in a review into a bare note would
+  -- be a worse answer than saying so.
   if name == "" then
-    return nil, "no file in this buffer"
+    return { kind = "note", key = NOTE_KEY, inline = false }
   end
 
   -- Realpath rather than the buffer's name: `git rev-parse --show-toplevel` answers in
@@ -107,22 +121,30 @@ function M.target(buf, range)
 
   local root = git.root(vim.fs.dirname(abs))
   local rel = root and payload.relative_to(abs, root)
-  if not rel then
-    return nil, "not inside a git repository"
-  end
 
   local entry = {
-    path = rel,
     abs_path = abs,
+    inline = false,
+  }
+
+  -- Outside any checkout there is no root to be relative to, nothing to hash against, and
+  -- nowhere repository-shaped to persist. The entry keeps its absolute path and goes on
+  -- exactly as any other; the absence of `path` is what later routes it to the store that
+  -- is not tied to a repository.
+  if rel then
+    entry.path = rel
     -- Hashed at capture time, exactly as the review path hashes a diffed file. This is
     -- what buys staleness detection later; an entry without it can go quietly wrong.
-    blob = git.blob(rel, nil, root),
+    entry.blob = git.blob(rel, nil, root)
     -- Records *what* that blob is: the working tree, not a ref. A review annotation's blob
     -- can be an index or commit blob depending on the scope it was captured in, so this is
     -- what lets staleness judge each kind against the thing it was actually taken from.
-    worktree = true,
-    inline = false,
-  }
+    entry.worktree = true
+  end
+
+  -- Keys off whichever path it has. A repository-relative one where there is a repository,
+  -- so it matches the review view's anchors; the absolute one otherwise.
+  local anchor = rel or abs
 
   local first, last = range and range.first, range and range.last
   if not first then
@@ -130,7 +152,7 @@ function M.target(buf, range)
   end
   if not first then
     entry.kind = "file"
-    entry.key = render.file_key(rel)
+    entry.key = render.file_key(anchor)
     entry.tag = "whole file"
     return entry
   end
@@ -146,7 +168,7 @@ function M.target(buf, range)
   -- payload and the float both switch on kind, and a buffer capture must not present as a
   -- different sort of thing than the same selection made during a review.
   entry.kind = first == last and "line" or "range"
-  entry.key = render.line_key(rel, { new = first })
+  entry.key = render.line_key(anchor, { new = first })
   -- Carried even though this normally travels as an `@ref`: a batch routed to an agent
   -- whose cwd does not contain the file cannot use a ref at all, and the fallback has to
   -- inline the exact lines rather than approximate them. Space-prefixed, so the block is

--- a/lua/codereview/payload.lua
+++ b/lua/codereview/payload.lua
@@ -45,6 +45,13 @@ end
 ---@param base string
 ---@return string heading, string[]|nil block
 local function describe(entry, base)
+  -- A thought with no file behind it. There is no location to resolve, so there is nothing
+  -- for the `@ref`-versus-inline rules below to decide -- and every one of them would be
+  -- reading a path that is not there.
+  if entry.kind == "note" then
+    return "(no file)", nil
+  end
+
   local rel = M.relative_to(entry.abs_path, base)
   local where = rel or entry.abs_path or entry.path
 

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -61,10 +61,98 @@ function M.save(root, data)
   return pcall(vim.fn.writefile, { encoded }, file)
 end
 
+--- The store for annotations with no repository ---------------------------------
+
+---How long an annotation with no repository behind it survives.
+---
+---Nothing else will ever remove one. The per-repository store is reconciled against a
+---diff, which is the moment an entry can be judged obsolete; this store never is, so
+---without a sweep it grows for the life of the editor's state directory. Matches the
+---window the host config's draft store uses, for the same reason.
+local GLOBAL_TTL_SECONDS = 7 * 24 * 60 * 60
+
+---@return string
+function M.global_path()
+  return vim.fs.joinpath(vim.fn.stdpath("state"), "codereview", "no-repository.json")
+end
+
+---Split the queue by whether an entry belongs to a repository.
+---
+---Having a repository-relative path *is* the test: a capture outside a checkout and a bare
+---thought both lack one, and both are exactly the entries with nowhere repository-shaped
+---to live. No extra field to set, and nothing to keep in sync with reality.
+---@param items CRAnnotation[]
+---@return CRAnnotation[] owned, CRAnnotation[] loose
+local function partition(items)
+  local owned, loose = {}, {}
+  for _, item in ipairs(items) do
+    table.insert(item.path and owned or loose, item)
+  end
+  return owned, loose
+end
+
+---@return CRAnnotation[]
+function M.load_global()
+  local file = M.global_path()
+  if vim.fn.filereadable(file) == 0 then
+    return {}
+  end
+  local ok, decoded = pcall(function()
+    return vim.json.decode(table.concat(vim.fn.readfile(file), "\n"), {
+      luanil = { object = true, array = true },
+    })
+  end)
+  if not ok or type(decoded) ~= "table" or decoded.version ~= VERSION then
+    return {}
+  end
+
+  -- The sweep, on load rather than on a timer: this is the only moment the store is
+  -- read, so it is the only moment anything is in a position to drop from it.
+  local now, fresh = os.time(), {}
+  for _, item in ipairs(decoded.queue or {}) do
+    if type(item) == "table" and (now - (item.at or 0)) < GLOBAL_TTL_SECONDS then
+      fresh[#fresh + 1] = item
+    end
+  end
+  return fresh
+end
+
+---@param items CRAnnotation[]
+---@return boolean ok
+function M.save_global(items)
+  local file = M.global_path()
+  vim.fn.mkdir(vim.fs.dirname(file), "p")
+
+  local now = os.time()
+  for _, item in ipairs(items) do
+    -- Stamped once and then left alone. Refreshing it on every write would restart the
+    -- clock each time anything else was queued, and nothing would ever age out.
+    item.at = item.at or now
+  end
+
+  local ok, encoded = pcall(vim.json.encode, { version = VERSION, queue = items })
+  if not ok then
+    return false
+  end
+  return pcall(vim.fn.writefile, { encoded }, file)
+end
+
+---Forget every annotation with no repository behind it.
+function M.clear_global()
+  local file = M.global_path()
+  if vim.fn.filereadable(file) == 1 then
+    vim.fn.delete(file)
+  end
+end
+
+--- Writing and reading ----------------------------------------------------------
+
 ---Write the view's progress and the current queue.
 ---@param view CRView
 function M.persist(view)
-  local data = { version = VERSION, scopes = {}, queue = queue.all() }
+  local owned, loose = partition(queue.all())
+  M.save_global(loose)
+  local data = { version = VERSION, scopes = {}, queue = owned }
   for key, entry in pairs(view.per_scope) do
     -- `expanded` is deliberately not persisted: it is a transient way of peeking at a
     -- file, and restoring it would contradict the reviewed marks that drive collapse.
@@ -81,10 +169,16 @@ end
 ---a scopes table from, so writing a whole document the way `persist` does would blank the
 ---reviewed marks a review saved -- the queue would survive at the cost of the progress
 ---next to it.
----@param root string
+---@param root string|nil nil when the working directory is not inside a repository, in
+---       which case there is only the global store to write
 function M.persist_queue(root)
+  local owned, loose = partition(queue.all())
+  M.save_global(loose)
+  if not root then
+    return
+  end
   local data = M.load(root)
-  data.queue = queue.all()
+  data.queue = owned
   M.save(root, data)
 end
 
@@ -92,15 +186,21 @@ end
 ---
 ---Separate from `restore`, which needs a view and a scope to put reviewed marks back.
 ---The queue needs neither: it is what you submit, not what you are looking at.
----@param root string
+---@param root string|nil nil outside a repository, where only the global store applies
 ---@return integer staled
 function M.restore_queue(root)
   if queue.count() > 0 then
     return 0
   end
-  local data = M.load(root)
-  if data.queue and #data.queue > 0 then
-    queue.replace(data.queue)
+  -- Both stores, as one queue. Which store an entry came from is a persistence detail; the
+  -- queue is the queue.
+  local items = root and M.load(root).queue or {}
+  vim.list_extend(items, M.load_global())
+  if #items > 0 then
+    queue.replace(items)
+  end
+  if not root then
+    return 0
   end
   -- Judged as it comes back. This is the window staleness exists to cover: the file was
   -- free to change while nothing was watching it, and a restored note that still claims a

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -209,10 +209,9 @@ function M.persist()
     require("codereview.state").persist(V)
     return
   end
-  local root = ambient_root()
-  if root then
-    require("codereview.state").persist_queue(root)
-  end
+  -- Passed even when nil: there may still be annotations with no repository to write, and
+  -- skipping would leave a submitted batch's entries on disk to come back next start.
+  require("codereview.state").persist_queue(ambient_root())
 end
 
 -- Restored lazily, and once. `count()` is the sort of thing a statusline calls on every
@@ -232,11 +231,9 @@ function M.ensure_queue()
     return
   end
   queue_restored = true
-  local root = ambient_root()
-  if not root then
-    return
-  end
-  local staled = require("codereview.state").restore_queue(root)
+  -- No root is not a reason to skip: annotations with no repository behind them live in a
+  -- store that does not need one, and they would otherwise never come back.
+  local staled = require("codereview.state").restore_queue(ambient_root())
   if staled > 0 then
     -- Worded exactly as the review view reports it. With no view open this is the only
     -- moment a restored annotation's staleness would otherwise go unmentioned.

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
+| `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The composer stub `interactive_spec` drives — deliberately not a spec. |
 | `perf.lua` | Open-time report on a 60-file diff. Not part of `make test`. |
 
@@ -42,6 +43,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `viewless_spec` | The queue with no review view open: persist, restore, submit |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, blob, composer, diagnostics, restart, one queue |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
+| `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `interactive_spec` | The insert-mode leak, in a real pty-backed Neovim |
@@ -78,6 +80,9 @@ so the out-of-core language path is still checked locally without ever failing C
   across a genuine restart; calling `state.load()` twice in one process proves nothing
   about what reached the disk. `state_child.lua` writes, the spec restarts and reads. Do
   not collapse it into one process.
+- **`norepo_spec` needs a directory that is genuinely outside a checkout**, and asserts it
+  rather than assuming it. If the temp directory ever sits inside a repository, every case
+  about a "loose" file silently becomes a test of the ordinary in-repository path.
 - **A filter test needs a fixture only that filter can reject.** `capture_spec` asserts
   that hints and info never ride along with an annotation. Those diagnostics originally sat
   on a line *outside* the captured range, so the range filter rejected them and the

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -129,12 +129,14 @@ describe("an unrecognised type", function()
   end)
 end)
 
--- The review view's own buffer is one of these, which is what the user hits by calling
--- the entry point while focused inside a review. A bare thought with no file is a real
--- capture shape, but it is a later slice; refusing beats queueing something malformed.
-describe("a buffer with no file behind it", function()
+-- An *unnamed* buffer is a bare thought, and queues one -- see `norepo_spec`. A buffer
+-- whose name is not a file on disk is a different thing: it claims to be something, and
+-- the review view's own buffer is one of them. Turning `aa` inside a review into a bare
+-- note would be a worse answer than saying so.
+describe("a buffer whose name is not a file on disk", function()
   queue.clear()
   vim.cmd("enew")
+  vim.api.nvim_buf_set_name(0, "codereview://not-a-real-file")
   local msgs, restore = h.capture_notify()
   codereview.annotate("bug")
   restore()
@@ -143,8 +145,8 @@ describe("a buffer with no file behind it", function()
     assert.same(0, queue.count())
   end)
 
-  it("says there is no file", function()
-    assert.is_true(h.notified(msgs, "no file in this buffer"))
+  it("says so rather than inventing a note", function()
+    assert.is_true(h.notified(msgs, "is not a file on disk"), vim.inspect(msgs))
   end)
 end)
 

--- a/tests/codereview/norepo_child.lua
+++ b/tests/codereview/norepo_child.lua
@@ -1,0 +1,53 @@
+-- One session of norepo_spec's restart case, in its own process.
+--
+-- MODE=write captures three annotations of different provenance -- one inside the
+-- repository, one about a file outside any checkout, one with no file at all -- and lets
+-- persistence route them. MODE=read starts clean and reports what came back, which is the
+-- only honest way to show that a store survives a restart.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it, and it must NOT
+-- load tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+local loose = assert(vim.env.LOOSE_FILE, "LOOSE_FILE is not set")
+local mode = assert(vim.env.MODE, "MODE is not set")
+
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+local codereview = require("codereview")
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "from an earlier session")
+  end,
+})
+
+local queue = require("codereview.queue")
+local view = require("codereview.view")
+
+if mode == "write" then
+  vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/main.lua")))
+  codereview.annotate("bug")
+
+  vim.cmd("edit " .. vim.fn.fnameescape(loose))
+  codereview.annotate("fix")
+
+  vim.cmd("enew")
+  codereview.annotate("issue")
+
+  print("queued: " .. queue.count())
+else
+  -- What any new session does the first time it touches the queue.
+  view.ensure_queue()
+  local kinds = {}
+  for _, item in ipairs(queue.all()) do
+    kinds[#kinds + 1] = ("%s/%s"):format(item.type, item.kind)
+  end
+  print("restored: " .. queue.count())
+  print("kinds: " .. table.concat(kinds, ","))
+end
+
+vim.cmd("qa!")

--- a/tests/codereview/norepo_spec.lua
+++ b/tests/codereview/norepo_spec.lua
@@ -1,0 +1,303 @@
+-- Annotations with no repository behind them.
+--
+-- Two shapes, entangled because neither has a root to key persistence against: a bare
+-- thought with no file at all, and a file that lives outside any checkout. Both queue,
+-- submit and persist like anything else -- to a single store that is not tied to a
+-- repository, which prunes by age because nothing else will ever clear it.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+local codereview = require("codereview")
+local queue = require("codereview.queue")
+
+local sent = {}
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "the note")
+  end,
+  send = function(text, target)
+    sent[#sent + 1] = { text = text, target = target }
+  end,
+})
+
+local root = assert(vim.uv.fs_realpath(fixture))
+
+-- A directory that is genuinely not inside any checkout. Asserted rather than assumed:
+-- if the temp directory ever sits inside a repository, every case below silently becomes
+-- a test of the ordinary in-repository path.
+local outside = vim.fn.tempname() .. "-outside"
+vim.fn.mkdir(outside, "p")
+local outside_file = vim.fs.joinpath(outside, "loose.lua")
+vim.fn.writefile({ "local loose = true", "return loose" }, outside_file)
+
+describe("the fixture the rest of this spec depends on", function()
+  it("puts the loose file outside any repository", function()
+    assert.is_nil(require("codereview.git").root(outside), outside .. " is inside a checkout")
+  end)
+end)
+
+describe("a bare thought with no file at all", function()
+  queue.clear()
+  vim.cmd("enew")
+  codereview.annotate("issue")
+  local e = queue.all()[1]
+
+  it("queues it rather than refusing", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("records it as a note", function()
+    assert.same("note", e.kind)
+  end)
+
+  it("carries no path of any kind", function()
+    assert.is_nil(e.path)
+    assert.is_nil(e.abs_path)
+  end)
+
+  it("still carries its type and its text", function()
+    assert.same("issue", e.type)
+    assert.same("the note", e.note)
+  end)
+end)
+
+describe("describing an annotation with no file", function()
+  local view = require("codereview.view")
+  local payload = require("codereview.payload")
+  local config = require("codereview.config")
+
+  queue.clear()
+  vim.cmd("enew")
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("issue")
+  restore()
+
+  -- Every one of these would read "nil" somewhere if the location string were built from
+  -- a path that is not there, which is the whole hazard of a kind with no file.
+  it("reports it without a stray nil", function()
+    assert.is_true(h.notified(msgs, "Queued issue"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "nil"), vim.inspect(msgs))
+  end)
+
+  it("renders in the payload without a path, and without breaking the renderer", function()
+    local text = payload.render(queue.all(), root, { types = config.get().types })
+    assert.is_truthy(text:find("### 1.", 1, true), text)
+    assert.is_truthy(text:find("the note", 1, true), text)
+    assert.is_nil(text:find("nil", 1, true), text)
+  end)
+
+  it("renders in the queue float without a path", function()
+    view.review_queue()
+    -- With no review view open the float is simply the current window.
+    local float = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+    vim.api.nvim_win_close(0, true)
+
+    assert.is_truthy(float:find("## Issues", 1, true), float)
+    assert.is_truthy(float:find("the note", 1, true), float)
+    assert.is_nil(float:find("nil", 1, true), float)
+  end)
+end)
+
+describe("a file outside any checkout", function()
+  local payload = require("codereview.payload")
+  local config = require("codereview.config")
+  local loose = assert(vim.uv.fs_realpath(outside_file))
+
+  queue.clear()
+  vim.cmd("edit " .. vim.fn.fnameescape(outside_file))
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("bug")
+  restore()
+  local e = queue.all()[1]
+
+  it("queues it rather than refusing", function()
+    assert.same(1, queue.count())
+  end)
+
+  -- The confirmation names a file, and the only name this one has is the absolute path.
+  it("reports it by name rather than as nil", function()
+    assert.is_true(h.notified(msgs, "Queued bug"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "nil"), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, "loose.lua"), vim.inspect(msgs))
+  end)
+
+  it("is an ordinary file annotation", function()
+    assert.same("file", e.kind)
+    assert.same("bug", e.type)
+    assert.same("the note", e.note)
+  end)
+
+  it("carries its absolute path", function()
+    assert.same(loose, e.abs_path)
+  end)
+
+  -- No root to be relative to. Its absence is also what routes the entry away from a
+  -- repository's store later.
+  it("has no repository-relative path", function()
+    assert.is_nil(e.path)
+  end)
+
+  it("renders by absolute path, since no target tree contains it", function()
+    local text = payload.render(queue.all(), root, { types = config.get().types })
+    assert.is_truthy(text:find(loose, 1, true), text)
+    assert.is_nil(text:find("nil", 1, true), text)
+  end)
+end)
+
+describe("persisting across a restart", function()
+  local state = require("codereview.state")
+
+  ---@param mode "write"|"read"
+  local function session(mode)
+    return vim
+      .system({
+        vim.v.progpath,
+        "--clean",
+        "-l",
+        vim.fs.joinpath(h.root, "tests", "codereview", "norepo_child.lua"),
+      }, {
+        cwd = fixture,
+        text = true,
+        env = {
+          XDG_STATE_HOME = vim.env.XDG_STATE_HOME,
+          FIXTURE = fixture,
+          LOOSE_FILE = outside_file,
+          MODE = mode,
+        },
+      })
+      :wait(60000)
+  end
+
+  queue.clear()
+  state.clear(root)
+  state.clear_global()
+
+  local wrote = session("write")
+  local output = (wrote.stdout or "") .. (wrote.stderr or "")
+
+  it("the writing session exits cleanly having queued all three", function()
+    assert.same(0, wrote.code, output)
+    assert.is_true(output:find("queued: 3", 1, true) ~= nil, output)
+  end)
+
+  it("keeps only the repository's own annotation in the repository store", function()
+    local saved = state.load(root).queue
+    assert.same(1, #saved)
+    assert.same("src/main.lua", saved[1].path)
+  end)
+
+  it("routes the other two to the store that is not keyed to a repository", function()
+    local global = state.load_global()
+    assert.same(2, #global)
+    assert.same({ "fix", "issue" }, {
+      global[1] and global[1].type,
+      global[2] and global[2].type,
+    })
+  end)
+
+  it("keeps the loose file's absolute path, and gives the note no path at all", function()
+    local global = state.load_global()
+    assert.same(assert(vim.uv.fs_realpath(outside_file)), global[1].abs_path)
+    assert.is_nil(global[2].abs_path)
+    assert.same("note", global[2].kind)
+  end)
+
+  local read = session("read")
+  local restored = (read.stdout or "") .. (read.stderr or "")
+
+  it("restores all three in a genuinely new process", function()
+    assert.same(0, read.code, restored)
+    assert.is_true(restored:find("restored: 3", 1, true) ~= nil, restored)
+  end)
+
+  it("restores each with its kind intact", function()
+    assert.is_true(restored:find("bug/file", 1, true) ~= nil, restored)
+    assert.is_true(restored:find("fix/file", 1, true) ~= nil, restored)
+    assert.is_true(restored:find("issue/note", 1, true) ~= nil, restored)
+  end)
+end)
+
+-- Nothing ever reconciles this store against a diff, so no other moment could decide an
+-- entry is finished with. Without the sweep it grows for as long as the state directory
+-- lives.
+describe("the age sweep", function()
+  local state = require("codereview.state")
+  local week = 7 * 24 * 60 * 60
+  local now = os.time()
+
+  queue.clear()
+  state.clear_global()
+  state.save_global({
+    { type = "bug", kind = "note", key = "note:0", note = "long abandoned", at = now - week - 3600 },
+    { type = "fix", kind = "note", key = "note:0", note = "written today", at = now - 3600 },
+  })
+
+  local kept = vim.tbl_map(function(i)
+    return i.note
+  end, state.load_global())
+
+  it("drops what is past the window", function()
+    assert.is_false(vim.tbl_contains(kept, "long abandoned"), vim.inspect(kept))
+  end)
+
+  it("keeps what is inside it", function()
+    assert.same({ "written today" }, kept)
+  end)
+
+  it("does not hand a swept entry back to the queue", function()
+    queue.clear()
+    state.restore_queue(root)
+    local notes = vim.tbl_map(function(i)
+      return i.note
+    end, queue.all())
+    assert.is_true(vim.tbl_contains(notes, "written today"), vim.inspect(notes))
+    assert.is_false(vim.tbl_contains(notes, "long abandoned"), vim.inspect(notes))
+  end)
+end)
+
+describe("submitting a batch that mixes both", function()
+  local view = require("codereview.view")
+  local state = require("codereview.state")
+
+  queue.clear()
+  state.clear(root)
+  state.clear_global()
+
+  vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/main.lua")))
+  codereview.annotate("bug")
+  vim.cmd("edit " .. vim.fn.fnameescape(outside_file))
+  codereview.annotate("fix")
+  vim.cmd("enew")
+  codereview.annotate("issue")
+
+  it("queued all three into one queue", function()
+    assert.same(3, queue.count())
+  end)
+
+  local before = #sent
+  view.submit()
+
+  it("sends them as a single message", function()
+    assert.same(before + 1, #sent)
+    assert.same(0, queue.count())
+  end)
+
+  it("carries all three in that message, each addressed as best it can be", function()
+    local text = sent[#sent].text
+    assert.is_truthy(text:find("3 annotations", 1, true), text)
+    assert.is_truthy(text:find("@src/main.lua", 1, true), text)
+    assert.is_truthy(text:find("loose.lua", 1, true), text)
+    assert.is_truthy(text:find("(no file)", 1, true), text)
+  end)
+
+  it("clears the repository store", function()
+    assert.same(0, #state.load(root).queue)
+  end)
+
+  it("clears the store with no repository too", function()
+    assert.same(0, #state.load_global())
+  end)
+end)


### PR DESCRIPTION
Closes #6.

Two shapes had nowhere to go, and both for the same reason: neither has a repository root
to key a store against. A thought with no file behind it, and a file living outside any
checkout. Both were refused; both now queue, submit and survive a restart like anything
else.

- **A bare thought** becomes a `note` — the first kind that does not presuppose a diff, so
  the payload renderer and the queue float both learn it.
- **A file outside a checkout** keeps its absolute path and drops the repository-relative
  one. It travels by absolute path, since no target tree contains it.

### The routing falls out of the data

Having a repository-relative `path` is what marks an entry as belonging to a repository's
store. Both new shapes lack one, and both are exactly the entries with nowhere
repository-shaped to live — so one test partitions the queue, with no field to set and keep
true. `persist` and `persist_queue` split on it; `restore_queue` merges both stores back
into one queue, because which store an entry came from is a persistence detail.

Submitting therefore clears both without special-casing: the emptied queue partitions to
two empty halves.

### Why the sweep exists

The global store prunes entries older than seven days when it is read. Nothing else would
ever remove one — the per-repository store is reconciled against a diff, which is the
moment an entry can be judged obsolete, and this store never is. The window matches the
host config's draft store, which the issue names as prior art and which had the same
problem first.

Bounding growth is not bounding staleness: an old note about a scratch file can still claim
a line span that has moved. That was accepted in the PRD; it is now written down in the
README rather than left to be rediscovered.

### One behaviour from #3 is deliberately reversed

`capture_spec` asserted that a buffer with nothing on disk queues nothing. That was the
right answer when bare notes had no home, and this slice gives them one — so that case now
asserts the opposite, in `norepo_spec`. What still refuses is a buffer whose *name* is not
a file on disk: the review view's own buffer is one of those, and turning `aa` inside a
review into a bare note would be a worse answer than saying so.

### Notes

- 370 cases, from 342. `norepo_spec` asserts up front that its temp directory really is
  outside a checkout — otherwise every "loose file" case silently becomes a test of the
  ordinary in-repository path.
- The age sweep and the store routing were each mutation-tested by disabling them: three
  assertions go red in both cases.
- Both new shapes went in with a stray `nil` in the confirmation and the payload the first
  time; the specs assert the absence of `nil` in rendered output for exactly that reason.
- Touches README, which `chore/opensource-scaffolding` also edits — likely a small conflict
  whichever lands second.
