### PR TITLE
fix(state): keep reviewed marks for scopes the view never opened

### DIFF
--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -148,18 +148,31 @@ end
 --- Writing and reading ----------------------------------------------------------
 
 ---Write the view's progress and the current queue.
+---
+---Merged over the stored document rather than rebuilt from the view. A view only knows the
+---scopes it has itself opened -- `open` seeds `per_scope` with one key and `set_scope`
+---adds one per scope cycled to -- so building the whole table from it wrote every other
+---scope out of existence. Review a branch on Monday, open only `staged` on Tuesday, and
+---Monday's reviewed marks were gone the first time anything touched the file.
 ---@param view CRView
 function M.persist(view)
   local owned, loose = partition(queue.all())
   M.save_global(loose)
-  local data = { version = VERSION, scopes = {}, queue = owned }
+
+  local data = M.load(view.root)
+  data.queue = owned
+  data.scopes = data.scopes or {}
   for key, entry in pairs(view.per_scope) do
     -- `expanded` is deliberately not persisted: it is a transient way of peeking at a
     -- file, and restoring it would contradict the reviewed marks that drive collapse.
-    if not vim.tbl_isempty(entry.reviewed) then
-      data.scopes[key] = { reviewed = entry.reviewed }
-    end
+    --
+    -- An emptied scope is written as absence rather than skipped. Skipping was harmless
+    -- when the table was rebuilt every time; against a merge it would hand back the marks
+    -- that were just un-marked. Only keys this view actually knows about are touched --
+    -- one it has never opened is not evidence of anything.
+    data.scopes[key] = not vim.tbl_isempty(entry.reviewed) and { reviewed = entry.reviewed } or nil
   end
+
   M.save(view.root, data)
 end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `syntax_spec` | Treesitter harvest/replay, caching, guardrails |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
-| `state_spec` | Persistence across a real restart, blob invalidation, corrupt files |
+| `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, blob, composer, diagnostics, restart, one queue |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |

--- a/tests/codereview/state_spec.lua
+++ b/tests/codereview/state_spec.lua
@@ -205,3 +205,70 @@ describe("an unreadable state file", function()
     assert.same(1, state.load(root).version)
   end)
 end)
+
+-- Reviewed marks are the expensive state here -- they stand for hours of reading -- and a
+-- write rebuilt the whole scopes table from the open view's `per_scope`. A view only knows
+-- the scopes it has itself opened, so every scope it had not seen was overwritten by its
+-- own absence, silently, on the next `R`.
+--
+-- One process is enough, unlike the queue: a view has no session-wide latch. Every
+-- `view.open` builds a fresh `per_scope`, so reopening in another scope reproduces exactly
+-- what a new session does.
+describe("marks belonging to a scope this view never opened", function()
+  local root = assert(vim.uv.fs_realpath(fixture))
+
+  ---Mark the file at `path` reviewed in the open view.
+  ---@param path string
+  local function toggle_reviewed_on(path)
+    local V = assert(view.current(), "no view open")
+    local index = assert(h.file_index(V, path), path .. " is not in this scope")
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index], 0 })
+    view.toggle_reviewed()
+  end
+
+  ---@return string
+  local function scope_key_of()
+    local V = assert(view.current())
+    return V.scope.name .. ":" .. V.scope.before
+  end
+
+  view.close()
+  queue.clear()
+  state.clear(root)
+
+  -- One review, in one scope.
+  view.open("branch")
+  local branch_key = scope_key_of()
+  toggle_reviewed_on("src/routes.lua")
+  view.close()
+
+  it("saved the first scope's mark", function()
+    assert.is_truthy(state.load(root).scopes[branch_key], "nothing was saved to begin with")
+  end)
+
+  -- A different scope, in a view that has never seen the first one.
+  view.open("staged")
+  local staged_key = scope_key_of()
+  toggle_reviewed_on("src/routes.lua")
+
+  it("saved the second scope's mark", function()
+    assert.is_truthy(state.load(root).scopes[staged_key])
+  end)
+
+  it("kept the first scope's mark, which this view could not see", function()
+    local scopes = state.load(root).scopes
+    assert.is_truthy(scopes[branch_key], "the earlier scope's reviewed marks were lost")
+    assert.same(2, vim.tbl_count(scopes))
+  end)
+
+  -- The half a naive merge gets wrong. Un-marking has to remove the scope outright, or
+  -- merging over what is stored hands back the marks that were just cleared.
+  it("removes a scope once its last mark is cleared, rather than resurrecting it", function()
+    toggle_reviewed_on("src/routes.lua")
+    local scopes = state.load(root).scopes
+    assert.is_nil(scopes[staged_key], "an emptied scope came back from the stored document")
+    assert.is_truthy(scopes[branch_key], "the other scope was lost while removing this one")
+  end)
+
+  view.close()
+end)


### PR DESCRIPTION
Closes #8.

Every write rebuilt the `scopes` table from the open view's `per_scope`, and a view only
knows the scopes it has itself opened — `open` seeds it with one key, `set_scope` adds one
per scope cycled to. Every other scope was overwritten by its own absence.

Review a branch on Monday, open only `staged` on Tuesday, and Monday's reviewed marks were
gone the first time anything touched the file: an `R`, a refresh, an annotation, a submit.
Nothing warned, and the loss only surfaced the next time that scope was opened.

The document is merged over rather than rebuilt — the shape `persist_queue` already used,
for the same reason. Only keys the view actually knows about are touched; one it has never
opened is not evidence of anything.

### The half that is easy to get wrong

An emptied scope is written as **absence**, not skipped. Skipping was harmless while the
table was rebuilt every time, but against a merge it hands back the marks that were just
un-marked — un-marking a whole scope would silently fail, and the stale entry would
resurrect on the next load.

Both halves are mutation-tested independently: rebuilding instead of merging fails two
assertions, and skipping instead of deleting fails exactly the resurrection case.

### On the test

One process, unlike the queue's persistence tests. A view has no session-wide latch — every
`view.open` builds a fresh `per_scope` — so reopening in another scope reproduces exactly
what a new session does. The spec says so, since the neighbouring cases deliberately spawn
a child and the difference is not obvious.

374 cases, from 370.
