### PR TITLE
fix(view): keep the delivery target when no review view is open

### DIFF
--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -32,6 +32,18 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@type CRView|nil
 local V = nil
 
+---Where the next batch goes, or nil for the adapter's default.
+---
+---Module-level for the reason the queue is: it describes what you are submitting to, not
+---what you are looking at. Held on the view, choosing a target with nothing open ran the
+---picker and discarded the answer, and the batch went to the default having just asked.
+---
+---Deliberately not persisted. The queue is worth keeping across a restart; a target
+---identifies a live destination -- a herdr pane id, say -- and restoring a dead one would
+---route a batch into nothing, which is worse than asking again.
+---@type table|nil
+local target = nil
+
 ---@param msg string
 local function warn(msg)
   vim.notify(msg, vim.log.levels.WARN, { title = "Code review" })
@@ -140,8 +152,8 @@ local function update_winbar()
   if notes > 0 then
     bar = bar .. (" · %d note%s"):format(notes, notes == 1 and "" or "s")
   end
-  if V.target and V.target.short then
-    bar = bar .. (" · → %s"):format(V.target.short)
+  if target and target.short then
+    bar = bar .. (" · → %s"):format(target.short)
   end
   vim.wo[V.win].winbar = bar:gsub("%%", "%%%%")
 end
@@ -798,14 +810,15 @@ function M.pick_target(on_done)
   local return_win = vim.api.nvim_get_current_win()
 
   cfg.pick_target(function(picked)
-    if not V then
-      return
+    -- Recorded before anything view-shaped is touched. This used to return early with no
+    -- view, which meant the picker ran, the user answered, and the answer was dropped.
+    target = picked
+    if V then
+      update_winbar()
     end
-    V.target = picked
-    update_winbar()
     if vim.api.nvim_win_is_valid(return_win) then
       vim.api.nvim_set_current_win(return_win)
-    elseif vim.api.nvim_win_is_valid(V.win) then
+    elseif V and vim.api.nvim_win_is_valid(V.win) then
       vim.api.nvim_set_current_win(V.win)
     end
     -- The picker is asynchronous, so anything that has to reflect the new target has to
@@ -835,7 +848,7 @@ function M.submit()
 
   local V_ = M.current()
   local root = V_ and V_.root or (git.root(vim.fn.getcwd()) or vim.fn.getcwd())
-  local target = V_ and V_.target or nil
+  -- Read unconditionally: the target outlives any view, and there may not be one.
   -- Resolve refs against the directory the batch is actually going to: a routed agent
   -- reads `@path` relative to its own cwd, not this Neovim's.
   local base = (target and target.cwd and target.cwd ~= "") and target.cwd or root
@@ -960,7 +973,7 @@ function M.review_queue()
     vim.bo[buf].modifiable = false
 
     local n, stale = queue.count(), queue.stale_count()
-    local name = (V and V.target and V.target.short) or "local"
+    local name = (target and target.short) or "local"
     cfg_win.title = (" Review queue · %d annotation%s%s "):format(
       n,
       n == 1 and "" or "s",

--- a/tests/codereview/focus_spec.lua
+++ b/tests/codereview/focus_spec.lua
@@ -88,8 +88,10 @@ describe("opening the queue float", function()
 
     pending_pick()
 
+    -- Asserted through the winbar rather than the field behind it: where the target is
+    -- stored is the plugin's business, and it has already moved once.
     it("records the target", function()
-      assert.same("janus · api", V.target.short)
+      assert.is_truthy(vim.wo[V.win].winbar:find("→ janus · api", 1, true), vim.wo[V.win].winbar)
     end)
 
     it("returns focus to the float, not the diff underneath", function()

--- a/tests/codereview/payload_spec.lua
+++ b/tests/codereview/payload_spec.lua
@@ -167,10 +167,6 @@ end)
 describe("submitting to a routed target", function()
   view.pick_target()
 
-  it("records the target", function()
-    assert.same("janus · api", V.target.short)
-  end)
-
   it("shows it in the winbar", function()
     assert.is_truthy(vim.wo[V.win].winbar:find("→ janus · api", 1, true))
   end)
@@ -197,7 +193,14 @@ describe("submitting to a routed target", function()
 end)
 
 describe("submitting locally", function()
-  V.target = nil
+  -- Cleared the way a user clears it: the picker's own "local" entry answers with nil.
+  -- Reaching in to blank a field stopped working when the target moved off the view, and
+  -- the field was never the interface anyway.
+  require("codereview.config").get().pick_target = function(cb)
+    cb(nil)
+  end
+  view.pick_target()
+
   at(assert(h.line_row(V, "src/fresh.lua")))
   annotate.annotate("fix")
   view.submit()

--- a/tests/codereview/viewless_spec.lua
+++ b/tests/codereview/viewless_spec.lua
@@ -16,10 +16,15 @@ local queue = require("codereview.queue")
 local state = require("codereview.state")
 
 local sent = {}
+local offered = 0
 require("codereview").setup({
   syntax = false,
   send = function(text, target)
     sent[#sent + 1] = { text = text, target = target }
+  end,
+  pick_target = function(cb)
+    offered = offered + 1
+    cb({ short = "agent", pane_id = "wV:p9", cwd = fixture })
   end,
 })
 
@@ -129,5 +134,81 @@ describe("submitting with no review view", function()
 
   it("still leaves the reviewed marks alone", function()
     assert.is_truthy(next(state.load(root).scopes))
+  end)
+end)
+
+-- The queue moved off the view because it is what you submit, not what you are looking at.
+-- The target is what you submit *to*, and it stayed behind: the picker ran, the answer was
+-- thrown away, and the batch went to the default destination having just asked.
+describe("choosing a delivery target with no review view", function()
+  local before_sent = #sent
+
+  queue.clear()
+  queue.add({
+    type = "bug",
+    kind = "file",
+    path = "src/routes.lua",
+    abs_path = vim.fs.joinpath(root, "src/routes.lua"),
+    key = "src/routes.lua:f:0",
+    note = "routed with nothing open",
+  })
+
+  assert(view.current() == nil, "this case is about having no view")
+  view.pick_target()
+
+  it("asked the configured picker", function()
+    assert.same(1, offered)
+  end)
+
+  it("names the chosen target in the queue float", function()
+    view.review_queue()
+    local win = vim.api.nvim_get_current_win()
+    local footer = vim.api.nvim_win_get_config(win).footer
+    local text = type(footer) == "table" and footer[1][1] or tostring(footer)
+    vim.api.nvim_win_close(win, true)
+    assert.is_truthy(text:find("agent", 1, true), text)
+  end)
+
+  it("submits to it rather than to the default", function()
+    view.submit()
+    assert.same(before_sent + 1, #sent)
+    assert.is_not_nil(sent[#sent].target, "the chosen target was discarded")
+    assert.same("wV:p9", sent[#sent].target.pane_id)
+  end)
+end)
+
+describe("a target chosen while a review was open", function()
+  local cfg = require("codereview.config").get()
+  local chooses_agent = cfg.pick_target
+  local before_sent = #sent
+
+  -- Cleared first, so nothing below can pass on what the previous case left behind.
+  cfg.pick_target = function(cb)
+    cb(nil)
+  end
+  view.pick_target()
+  cfg.pick_target = chooses_agent
+
+  queue.clear()
+  queue.add({
+    type = "bug",
+    kind = "file",
+    path = "src/fresh.lua",
+    abs_path = vim.fs.joinpath(root, "src/fresh.lua"),
+    key = "src/fresh.lua:f:0",
+    note = "routed from inside a review",
+  })
+
+  view.open("branch")
+  assert(view.current(), "the review did not open")
+  view.pick_target()
+  view.close()
+
+  it("outlives the review view, the way the queue does", function()
+    assert.is_nil(view.current())
+    view.submit()
+    assert.same(before_sent + 1, #sent)
+    assert.is_not_nil(sent[#sent].target, "closing the review dropped the target")
+    assert.same("wV:p9", sent[#sent].target.pane_id)
   end)
 end)


### PR DESCRIPTION
Closes #15.

The delivery target lived on the review view while the queue did not. Choosing one with
nothing open ran the picker, took the answer, and dropped it:

```lua
cfg.pick_target(function(picked)
  if not V then
    return          -- the answer, discarded
  end
  V.target = picked
```

The batch then went to the adapter's default, having just asked the user where it should
go. That made the entire viewless flow unroutable — capture from a buffer, open the float,
choose a destination, submit, and the destination was never applied.

It is the mistake the queue already fixed, and the fix is the same one: the queue is
module-level because *"the queue is what you submit, not what you are looking at"*. The
target is what you submit **to**.

### Deliberately not persisted

The queue survives a restart; a target should not. It names a live destination — a herdr
pane id — and restoring a dead one would route a batch into nothing, which is worse than
asking again. It does survive closing the review view, since the queue does.

### Three specs were testing the field, not the behaviour

`focus_spec` and `payload_spec` asserted `V.target.short`, and `payload_spec` cleared the
target by assigning `V.target = nil`. All three now go through the winbar, the float's
footer, and what the `send` adapter is handed — none of which care where the value is kept.
The clearing case picks the picker's own "local" entry, which is how a user clears it.

### A note on verifying this one

The mutation check initially looked like it killed only one assertion. It kills two — the
second `Fail` line was prefixed by notification output on the same line, so a `^Fail`
anchored grep missed it. Worth knowing if you script over plenary's output: the per-file
`Failed :` totals and the exit code are the reliable signals, not line-anchored markers.

373 cases.
