### PR TITLE
fix(payload): resolve the delivery target's cwd before matching refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,15 @@ number now belongs to unrelated code. A hunk is always inlined for the same reas
 to an agent whose working directory is not this one; anything outside its tree falls back
 to an absolute path with the code inlined.
 
+**That cwd is realpath'd first, and only that side.** Every `abs_path` in the queue is
+already canonical — `git rev-parse --show-toplevel` answers with symlinks resolved, and
+buffer capture realpaths for the same reason — but a target's `cwd` is whatever the adapter
+reported. On macOS a directory reached through `/var` is a symlink into `/private/var`, so
+comparing the two unresolved makes every file look like it lives outside the target's own
+tree, and the whole batch silently degrades to absolute paths with pasted snippets. It
+resolves once per submit rather than per entry, and falls back to the string it was given:
+a routed agent can name a directory that does not exist on this machine at all.
+
 **Collapsing is done at render time, not with folds.** A collapsed file's body is never
 emitted, so the buffer and the anchor map stay small on a large review, and there is one
 mechanism instead of two.

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -251,7 +251,10 @@ pick_target({cb})                                 *codereview-opt-pick_target*
         Choose a delivery target and call {cb} with it. The target may carry
         `short` (shown in the winbar) and `cwd`. `cwd` matters: references are
         re-resolved against it at submit time, because an `@ref` only resolves
-        relative to whoever reads it.
+        relative to whoever reads it. Report it in either form -- it is
+        realpath'd before the comparison, so a directory named through a
+        symlink still matches, and one that does not exist on this machine is
+        compared as given.
 
         A chosen target is held for the session, not for the view: it survives
         closing the review, and picking one with nothing open works. It is

--- a/docs/agents/HANDOFF.md
+++ b/docs/agents/HANDOFF.md
@@ -109,14 +109,13 @@ post-image). Do not start this alongside anything else.
 - **`git diff` long tail**: submodules, mode-only changes, and combined (merge) diffs are
   not handled. They should degrade to a visible "unsupported entry" row rather than a stack
   trace — currently untested either way, and called out as such in `tests/README.md`.
-- **Symlinked roots.** `git rev-parse --show-toplevel` returns the *canonical* path, so on
-  macOS a repo reached through `/var/...` yields a root of `/private/var/...`. Internally
-  consistent (every `abs_path` is built from that root), but `payload.relative_to()`
-  compares against a delivery target's reported `cwd` — if an agent reports the symlinked
-  form, the prefix match fails and refs silently degrade to absolute paths with inlined
-  code. Not a crash, and arguably the safe direction, but it means `@refs` can quietly stop
-  being emitted. Worth a `vim.uv.fs_realpath()` on both sides. The suite runs from
-  `$TMPDIR` and so hits this constantly; `diff_spec` resolves both paths.
+- ~~**Symlinked roots.**~~ Fixed in #17. `payload.resolve_base()` realpaths the delivery
+  target's `cwd` once per submit, so an adapter may report either form. Only that side
+  needed it — every `abs_path` is already canonical, from `git rev-parse --show-toplevel`
+  or from capture's own `fs_realpath`. `relative_to` stays a pure string predicate on
+  purpose; do not move the resolution into it. The suite runs from `$TMPDIR`, so on macOS
+  `payload_spec` exercises a genuinely symlinked root for free — and on Linux, where the
+  two forms coincide, that case marks itself `pending` rather than passing vacuously.
 - **The gitsigns diff base is gone.** The host's `claude_review.start()` also called
   `gitsigns.change_base(merge_base, true)`, which made `]h`/`[h` walk branch-relative hunks
   in ordinary buffers. The plugin never touched gitsigns, so the cutover removed that with

--- a/lua/codereview/payload.lua
+++ b/lua/codereview/payload.lua
@@ -5,6 +5,31 @@
 ---resolves relative to whoever reads it.
 local M = {}
 
+---Canonical form of a directory refs will be resolved against.
+---
+---Every `abs_path` in the queue is already canonical: the review path joins `V.root`,
+---which is `git rev-parse --show-toplevel` and answers with symlinks resolved, and capture
+---realpaths the buffer name for the same reason. A delivery target's `cwd` is whatever the
+---adapter reported and went through neither. On macOS a directory reached through /var is
+---a symlink into /private/var, so comparing the two unresolved makes every file look like
+---it lives outside the target's own tree -- and every `@ref` in the batch degrades to an
+---absolute path with the code pasted after it. Silently, and in the direction that looks
+---fine: nothing errors, the reader just stops getting refs they can open.
+---
+---Resolved here rather than inside `relative_to`, which stays a pure string predicate: one
+---syscall per submit instead of one per entry, and the comparison stays testable.
+---@param base string
+---@return string
+function M.resolve_base(base)
+  if not base or base == "" then
+    return base
+  end
+  -- Falls back to the input. A routed agent can report a working directory that does not
+  -- exist on this machine at all, and a path that cannot be resolved is still worth
+  -- prefix-matching -- dropping it would break remote targets to fix local symlinks.
+  return vim.uv.fs_realpath(base) or base
+end
+
 ---Path relative to `base`, or nil when it is not underneath it.
 ---@param path string
 ---@param base string
@@ -90,6 +115,10 @@ end
 ---@return string
 function M.render(items, base, opts)
   local out = {}
+
+  -- Once, before the entries: the comparison below is against paths that are already
+  -- canonical, and `base` is the only side that never went through git or a realpath.
+  base = M.resolve_base(base)
 
   -- Grouped here rather than through queue.lua so this stays a pure function of its
   -- arguments: the same list always renders the same message, which is what makes the

--- a/tests/codereview/payload_spec.lua
+++ b/tests/codereview/payload_spec.lua
@@ -6,7 +6,10 @@
 local h = require("tests.helpers")
 
 h.ui(110, 40)
-h.cd_fixture("mkfixture")
+-- Kept: this is the path the fixture was *created* under, before anything resolved it.
+-- On macOS $TMPDIR is /var/folders/..., a symlink into /private/var/folders/..., so this
+-- differs from the root git reports and is what a target reporting its own cwd looks like.
+local fixture_dir = h.cd_fixture("mkfixture")
 
 local sent = {}
 require("codereview").setup({
@@ -52,6 +55,32 @@ describe("relative_to", function()
   -- refs the target cannot resolve.
   it("refuses a sibling that merely shares a prefix", function()
     assert.is_nil(payload.relative_to("/about/c.lua", "/a"))
+  end)
+end)
+
+describe("resolve_base", function()
+  -- `fixture_dir`, not `vim.fn.getcwd()`: getcwd already answers in resolved form, so
+  -- feeding it here would assert the same thing as the canonical case below and the
+  -- symlink would never be exercised. The path the fixture was created under is the only
+  -- unresolved one to hand.
+  local canonical = vim.uv.fs_realpath(fixture_dir)
+
+  it("canonicalises a directory reached through a symlink", function()
+    assert.same(canonical, payload.resolve_base(fixture_dir))
+  end)
+
+  it("leaves an already-canonical path alone", function()
+    assert.same(canonical, payload.resolve_base(canonical))
+  end)
+
+  -- A routed agent can report a working directory that does not exist here at all.
+  -- Dropping it would be worse than prefix-matching the string it gave us.
+  it("returns a path that does not exist unchanged", function()
+    assert.same("/no/such/place", payload.resolve_base("/no/such/place"))
+  end)
+
+  it("returns an empty base unchanged", function()
+    assert.same("", payload.resolve_base(""))
   end)
 end)
 
@@ -258,5 +287,48 @@ describe("the queue float", function()
 
   it("closes itself once nothing is left", function()
     assert.is_false(vim.api.nvim_win_is_valid(qwin))
+  end)
+end)
+
+describe("rendering for a target that names the root through a symlink", function()
+  -- Same directory, different string. Every abs_path in the queue is canonical, because
+  -- the review path joins `V.root` and git reports that resolved -- so a target that
+  -- reports the unresolved form of its own cwd fails the prefix match, and the batch
+  -- silently loses every @ref to an absolute path with the code pasted after it.
+  queue.clear()
+  at(assert(h.line_row(V, "src/fresh.lua")))
+  annotate.annotate("bug")
+
+  local text = payload.render(queue.all(), fixture_dir, { types = config.get().types })
+
+  if fixture_dir == V.root then
+    -- Linux CI: $TMPDIR is not a symlink, so there is no unresolved form to report and
+    -- this asserts nothing. Say so rather than pass green and look like coverage.
+    pending("$TMPDIR is not a symlink here, so the two forms are the same string")
+  else
+    it("resolves a cwd git would have reported differently", function()
+      assert.same(V.root, vim.uv.fs_realpath(fixture_dir))
+      assert.are_not.same(V.root, fixture_dir)
+    end)
+
+    it("still emits an @ref", function()
+      assert.is_truthy(text:find("@src/fresh.lua#L1", 1, true))
+    end)
+
+    it("does not fall back to an absolute path", function()
+      assert.is_nil(text:find(V.root .. "/src/fresh.lua", 1, true))
+    end)
+
+    it("does not inline the code an @ref carries for free", function()
+      assert.is_nil(text:find("+local function fresh() end", 1, true))
+    end)
+  end
+
+  -- A target genuinely elsewhere must still degrade. Resolving the base cannot become a
+  -- way to emit refs the reader has no hope of opening.
+  it("still refuses an @ref for a target actually outside the tree", function()
+    local elsewhere = payload.render(queue.all(), "/somewhere/else", { types = config.get().types })
+    assert.is_nil(elsewhere:find("@src/", 1, true))
+    assert.is_truthy(elsewhere:find("+local function fresh() end", 1, true))
   end)
 end)


### PR DESCRIPTION
## Why

A delivery target that names the repository root *through a symlink* lost every `@ref` in
the batch. Same directory, different string.

Every `abs_path` in the queue is canonical: the review path joins `V.root`, which is
`git rev-parse --show-toplevel` and answers with symlinks resolved, and capture realpaths
the buffer name for the same reason. A target's `cwd` is whatever the adapter reported and
went through neither, so `payload.relative_to` compared a resolved path against an
unresolved one, the prefix match failed, and every entry fell back to an absolute path with
its code pasted after it.

On macOS that is any repo under `$TMPDIR`, since `/var` is a symlink into `/private/var`.

Before, against the `mkfixture` repo with a target reporting the fixture's own directory:

````markdown
### 1. /private/var/folders/77/0w2fn61s33ggszzx8s0cht2m0000gn/T/nvim.felipeva/j2McWT/1-mkfixture/src/fresh.lua:1
```diff
+local function fresh() end
```
````

After:

```markdown
### 1. @src/fresh.lua#L1
```

It never errored and never warned — it degraded in the direction that looks fine. The
reader just stopped getting refs their agent could open, and the payload grew by every
snippet it did not need to carry.

## What is in it

`payload.resolve_base()`, called once in `render` before the entry loop.

**Only `base` needed it**, not "both sides" as `docs/agents/HANDOFF.md` assumed —
`abs_path` is already canonical at both construction sites, which I checked rather than
took on faith. Resolving per submit instead of per entry keeps `relative_to` a pure string
predicate, which is what makes its four existing cases testable without a filesystem; the
resolution deliberately does not move into it.

**The fallback is load-bearing.** `fs_realpath` returning nil means the target named a
directory that does not exist on this machine — a routed agent elsewhere — and that string
is still worth prefix-matching. Returning nil there would break remote targets to fix local
symlinks.

## Notes for the reviewer

- The suite runs from `$TMPDIR`, so on macOS `payload_spec` exercises a genuinely symlinked
  root for free. On Linux the two forms coincide, and the case marks itself `pending`
  rather than passing vacuously.
- **The first draft of the unit case was wrong and worth flagging.** It fed
  `vim.fn.getcwd()` as the "unresolved" path — but getcwd already answers resolved, so the
  assertion was identical to the canonical case beside it and passed against a no-op
  `resolve_base`. It now uses the path the fixture was created under, which is the only
  provably unresolved one to hand.
- Three mutations checked, each failing exactly the assertions that guard it: removing the
  call at the render site (3 fail), making `resolve_base` a passthrough (4 fail), dropping
  the `or base` fallback (1 fails).
- `make all` green: 386 cases across 14 spec files, +9.
- `README.md` § *Design notes* and the `pick_target` entry in `doc/codereview.txt` both
  gain the rule, so an adapter author knows either form is fine. The HANDOFF's sharp-edge
  bullet is struck through rather than deleted, with the reason `relative_to` stays pure.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
