### PR TITLE
feat(annotate): tell the composer which window it was opened from

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,10 @@ opts = {
   pick_target = function(cb) cb({ short = "agent", cwd = "/path" }) end,
 
   -- Collect note text. Without it, falls back to vim.ui.input.
+  -- `ctx` describes what is being annotated: `scope`, `label`, `rel_path`, `file_path`,
+  -- and `origin_win` — the window the annotation was started from. Focus goes back there
+  -- once `on_accept` runs; a composer the user can *cancel* never calls it, so that path
+  -- is the composer's to restore.
   compose = function(ctx, on_accept, label) on_accept(nil, "text") end,
 }
 ```

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -266,6 +266,25 @@ compose({ctx}, {on_accept}, {label})                  *codereview-opt-compose*
         Collect note text and call {on_accept}(target, text). Falls back to
         |vim.ui.input()|.
 
+        {ctx} describes what is being annotated: >
+            scope       always "none" -- a note carries its own code, so
+                        there is no separate context to attach
+            label       title for the composer, from the type and the target
+            rel_path    repository-relative path; nil outside a checkout
+            file_path   absolute path; nil for a note with no file
+            origin_win  window the annotation was started from
+<
+        `origin_win` is there for composers that can be dismissed. Once
+        {on_accept} is called the plugin puts focus back there itself, so a
+        composer that always submits can ignore it. One the user can cancel
+        never calls {on_accept} at all, and on that path nothing but the
+        composer can put focus back.
+
+        It has to be told rather than restoring "wherever it came from",
+        because closing a floating window focuses whichever window Neovim
+        recorded last -- and that stops being the annotation's window the
+        moment the composer opens a picker of its own.
+
 ==============================================================================
 8. CONFIGURATION                                  *codereview-configuration*
 

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -82,8 +82,10 @@ both sides fixes it.
 Collect note text and call `on_accept(target, text)`. Without it the plugin falls back to
 `vim.ui.input`.
 
-`ctx` carries `scope = "none"`, a `label` for the prompt (`"Bug · src/main.lua:12"`),
-`rel_path` and `file_path`.
+`ctx` describes what is being annotated; `:help codereview-opt-compose` lists the fields.
+The one a herdr composer should not ignore is `origin_win`, the window the annotation was
+started from. The plugin restores focus there itself once `on_accept` runs — but a float
+the user dismisses never calls it, and on that path only the composer can put focus back.
 
 **The plugin ignores the `target` argument you pass to `on_accept`.** If your composer
 offers its own routing picker, that choice does not survive — routing is a property of the

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -271,6 +271,12 @@ local function collect(ctx, label, cb)
   -- Read before anything opens: this is the window that asked for the composer -- the diff
   -- on the review path, an ordinary buffer's window on the capture one.
   local origin = vim.api.nvim_get_current_win()
+  -- Handed on rather than kept private. A composer the user dismisses never calls back, so
+  -- there is no path on which the plugin could restore focus itself, and only the composer
+  -- can -- which it cannot do without being told where the annotation came from. Stamped
+  -- here and not by the caller, so the window the composer is told about and the window
+  -- focus returns to cannot drift into being two different windows.
+  ctx.origin_win = origin
 
   ---Runs whether or not a note came back. A composer submitted from an insert-mode mapping
   ---leaks insert mode either way, and a note abandoned halfway should still leave the

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -43,6 +43,10 @@ M.defaults = {
   ---@type fun(cb: fun(target: table|nil))|nil
   pick_target = nil,
   ---Collect note text. Falls back to `vim.ui.input` when not wired.
+  ---
+  ---`ctx` carries `scope`, `label`, `rel_path`, `file_path` and `origin_win` -- the window
+  ---the annotation was started from. The plugin restores focus there once `on_accept`
+  ---runs; a composer that can be dismissed without calling it owns that path itself.
   ---@type fun(ctx: table, on_accept: fun(target: table|nil, text: string), label: string)|nil
   compose = nil,
 }

--- a/tests/codereview/annotate_spec.lua
+++ b/tests/codereview/annotate_spec.lua
@@ -62,6 +62,12 @@ describe("annotating an added line", function()
   it("hands the composer a titled context", function()
     assert.same("Bug · src/fresh.lua:1", last_ctx.label)
   end)
+
+  -- What a composer needs to put focus back when the user dismisses it, which is the one
+  -- path that never reaches the plugin.
+  it("tells the composer which window the annotation came from", function()
+    assert.same(V.win, last_ctx.origin_win)
+  end)
 end)
 
 describe("annotating a deleted line", function()

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -330,6 +330,7 @@ end)
 describe("what the composer is handed", function()
   queue.clear()
   edit("src/routes.lua")
+  local win = vim.api.nvim_get_current_win()
   local before = #composed
   local msgs, restore = h.capture_notify()
   codereview.annotate("suggestion")
@@ -354,6 +355,12 @@ describe("what the composer is handed", function()
 
   it("passes the same `queue` label the review path passes", function()
     assert.same("queue", call.label)
+  end)
+
+  -- Here that is the buffer's own window, not the review view's -- which is the whole
+  -- reason the composer is told rather than left to assume.
+  it("names the window the annotation was started from", function()
+    assert.same(win, call.ctx.origin_win)
   end)
 
   it("reports what was queued and how many are now in the batch", function()


### PR DESCRIPTION
Closes #20.

Stacked on #19 and targets its branch, so the diff here is only the field and its
documentation. Merge that one first.

### The one path the plugin cannot reach

#19 makes the plugin put focus back once a note comes back. A composer the user *dismisses*
never calls back at all — there is no moment at which the plugin could act, and only the
composer can put focus where the annotation started.

It cannot do that unaided. Closing a float focuses whichever window Neovim recorded last,
and that stops being the annotation's window the moment the composer opens a picker of its
own — the same mechanism #19 is about. So it has to be told.

`ctx` now carries `origin_win`. Additive: a composer that always submits can ignore it and
behaves exactly as before, and the `vim.ui.input` fallback is untouched.

It is stamped where the window is read rather than by the caller, so the window the
composer is told about and the window focus returns to cannot become two different windows.

### The ctx shape was documented nowhere

Four fields the adapter has always been handed, written down for the first time because a
fifth needed explaining. The help file lists all five under `codereview-opt-compose`; the
README names them inline.

What an adapter does with `origin_win` is its own business — a host composer's cancel path
is not this repository's to fix.

### Verifying

Both new assertions — one on the review path, one on capture — go red when the single
assignment is commented out, so neither is passing on the shape the composer already had.
