### PR TITLE
feat(composer): write annotations in a buffer, not a prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ opts = {
   -- `cwd` matters: refs are re-resolved against it at submit time.
   pick_target = function(cb) cb({ short = "agent", cwd = "/path" }) end,
 
-  -- Collect note text. Without it, falls back to vim.ui.input.
+  -- Collect note text. Without it you get the composer the plugin ships, which implements
+  -- this same contract — wiring one replaces that composer rather than upgrading a prompt.
   -- `ctx` describes what is being annotated: `scope`, `label`, `rel_path`, `file_path`,
   -- and `origin_win` — the window the annotation was started from. Focus goes back there
   -- once `on_accept` runs; a composer the user can *cancel* never calls it, so that path

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -188,6 +188,29 @@ that caused it: a missing or duplicated `name` or `key`, a `key` of "a" (which
 would shadow the `aa` type picker), or a field of the wrong type. Start from
 the shipped set with `require("codereview.types").defaults`.
 
+The composer                                          *codereview-composer*
+
+Annotating opens a floating buffer to write the note in, titled with the type
+and what is being annotated:
+
+    ^S              queue the note and close
+    ^T              choose where the batch goes
+    q  <Esc>        abandon without queueing
+
+It opens in insert mode, because you opened it to write something. `^S` and
+`^T` work in insert and normal alike -- you may well have pressed <Esc> to
+reread the note first, and a submit key that works in only one of those is a
+trap.
+
+The note is whatever the buffer holds, newlines and all. An empty one queues
+nothing, so opening the composer by accident costs nothing. Either way focus
+returns to the window the annotation was started from.
+
+Routing from here is the same choice the queue float offers, because it is the
+same choice: a target belongs to the batch, not to the window that asked.
+
+Wire |codereview-opt-compose| to replace this composer with your own.
+
 ==============================================================================
 6. CAPTURE                                              *codereview-capture*
 
@@ -263,8 +286,11 @@ pick_target({cb})                                 *codereview-opt-pick_target*
         restoring a dead one would route a batch into nothing.
 
 compose({ctx}, {on_accept}, {label})                  *codereview-opt-compose*
-        Collect note text and call {on_accept}(target, text). Falls back to
-        |vim.ui.input()|.
+        Collect note text and call {on_accept}(target, text). Replaces the
+        composer the plugin ships (|codereview-composer|), which is the default
+        implementation of this same contract rather than a lesser path beside
+        it: both are handed exactly the same arguments, and neither is a
+        fallback for the other.
 
         {ctx} describes what is being annotated: >
             scope       always "none" -- a note carries its own code, so

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -79,8 +79,9 @@ both sides fixes it.
 
 ## `compose(ctx, on_accept, label)`
 
-Collect note text and call `on_accept(target, text)`. Without it the plugin falls back to
-`vim.ui.input`.
+Collect note text and call `on_accept(target, text)`. Without it you get the composer the
+plugin ships, which implements this same contract — wiring one replaces it rather than
+upgrading from a prompt.
 
 `ctx` describes what is being annotated; `:help codereview-opt-compose` lists the fields.
 The one a herdr composer should not ignore is `origin_win`, the window the annotation was

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -290,14 +290,13 @@ local function collect(ctx, label, cb)
     end
   end
 
-  if cfg.compose then
-    cfg.compose(ctx, function(_, text)
-      done(text)
-    end, label)
-    return
-  end
-  -- Fallback so the plugin is useful with nothing wired at all.
-  vim.ui.input({ prompt = ("%s > "):format(ctx.label) }, done)
+  -- The plugin's own composer is the *default implementation of the adapter*, not a lesser
+  -- path beside it: a host that injects one replaces it, and both are handed exactly the
+  -- same thing. There is no third behaviour to keep in step.
+  local compose = cfg.compose or require("codereview.composer").open
+  compose(ctx, function(_, text)
+    done(text)
+  end, label)
 end
 
 ---Annotate whatever the cursor or selection points at.

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -1,0 +1,99 @@
+---The composer the plugin ships.
+---
+---Deliberately the same shape as the `compose` adapter a host injects -- it *is* the
+---default implementation of that contract, not a lesser path beside it. Anything a host
+---composer is handed, this one is handed; anything it must do, this one does.
+local M = {}
+
+---Open the composer.
+---@param ctx table What is being annotated. See `codereview-opt-compose`.
+---@param on_accept fun(target: table|nil, text: string)
+---@param label string Verb for the submit key
+---@return integer win
+function M.open(ctx, on_accept, label)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].bufhidden = "wipe"
+  vim.bo[buf].filetype = "markdown"
+
+  local width = math.min(84, math.max(40, math.floor(vim.o.columns * 0.7)))
+  local height = 6
+  local cfg_win = {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2 - 1),
+    col = math.floor((vim.o.columns - width) / 2),
+    style = "minimal",
+    border = "rounded",
+    -- `ctx.label` already reads "Bug · src/main.lua:12" -- the type and the target, which is
+    -- everything there is to say about what is being written here.
+    title = (" %s "):format(ctx.label),
+    title_pos = "center",
+    footer = "",
+    footer_pos = "center",
+  }
+  local win = vim.api.nvim_open_win(buf, true, cfg_win)
+  vim.wo[win].wrap = true
+  vim.wo[win].linebreak = true
+
+  ---Redraw the footer. The target is the only part that changes while the composer is
+  ---open, and it is worth showing: it is what decides where the batch ends up.
+  local function refresh()
+    if not vim.api.nvim_win_is_valid(win) then
+      return
+    end
+    -- Truncated because a target name can be long ("janus · Analyze RUM patterns") and a
+    -- footer wider than the float is silently clipped, taking the keys with it.
+    local name = require("codereview.view").target_label()
+    if #name > 16 then
+      name = name:sub(1, 15) .. "…"
+    end
+    cfg_win.footer = (" ^T %s · ^S %s · q abandon "):format(name, label)
+    vim.api.nvim_win_set_config(win, cfg_win)
+  end
+
+  local function close()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+    -- Closing a float does not put focus back where the annotation started. Neovim focuses
+    -- the window it recorded last -- a picker this composer opened, say -- and the first
+    -- window in the tab once that is gone, which during a review is the tree. The plugin
+    -- restores this itself once a note is accepted; on the abandoned path nothing else can,
+    -- which is what `origin_win` is on the context for.
+    if ctx.origin_win and vim.api.nvim_win_is_valid(ctx.origin_win) then
+      vim.api.nvim_set_current_win(ctx.origin_win)
+    end
+  end
+
+  ---Read before closing: `bufhidden = "wipe"` takes the buffer with the window.
+  local function submit()
+    local text = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
+    close()
+    -- The target argument is the adapter contract's, not this composer's: routing is a
+    -- property of the batch and the plugin already holds it.
+    on_accept(nil, text)
+  end
+
+  -- Both modes: you are typing when you finish, but you may well have pressed <Esc> to
+  -- reread the note first, and a submit key that only works in one of those is a trap.
+  vim.keymap.set({ "i", "n" }, "<C-s>", submit, { buffer = buf, desc = label })
+  -- Routing without abandoning the note. The picker answers on a later tick and puts focus
+  -- back here itself, so there is nothing to restore -- only a footer to redraw.
+  vim.keymap.set({ "i", "n" }, "<C-t>", function()
+    require("codereview.view").pick_target(refresh)
+  end, { buffer = buf, desc = "Choose target" })
+  -- Normal mode only. In insert both are the keys you actually want -- `q` is a letter and
+  -- <Esc> is how you leave insert to reread what you wrote.
+  vim.keymap.set("n", "q", close, { buffer = buf, desc = "Abandon" })
+  vim.keymap.set("n", "<Esc>", close, { buffer = buf, desc = "Abandon" })
+
+  refresh()
+  -- You opened this to write something, so start writing. Leaving insert mode again is
+  -- `collect`'s job, not this one's: closing a window does not end insert by itself, and
+  -- the review buffer is `nomodifiable`, where every motion would land as a failed edit.
+  vim.cmd("startinsert")
+  return win
+end
+
+return M

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -42,7 +42,9 @@ M.defaults = {
   ---Choose a delivery target, calling back with it (or nil for the default).
   ---@type fun(cb: fun(target: table|nil))|nil
   pick_target = nil,
-  ---Collect note text. Falls back to `vim.ui.input` when not wired.
+  ---Collect note text. Replaces the composer the plugin ships, which is the default
+  ---implementation of this same contract rather than a fallback beside it -- both are
+  ---handed exactly the same arguments.
   ---
   ---`ctx` carries `scope`, `label`, `rel_path`, `file_path` and `origin_win` -- the window
   ---the annotation was started from. The plugin restores focus there once `on_accept`

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -795,6 +795,15 @@ end
 
 --- Delivery -------------------------------------------------------------------
 
+---Short name of where the batch is going, or what to call the adapter's own default.
+---
+---Exposed because the queue float and the composer both name this choice, and it is the
+---same choice: routing is a property of the batch, not of whichever window asked.
+---@return string
+function M.target_label()
+  return (target and target.short) or "local"
+end
+
 ---Choose where the batch goes, through the injected picker.
 ---@param on_done fun()|nil Runs after a target is chosen, once the picker has closed
 function M.pick_target(on_done)
@@ -973,7 +982,7 @@ function M.review_queue()
     vim.bo[buf].modifiable = false
 
     local n, stale = queue.count(), queue.stale_count()
-    local name = (target and target.short) or "local"
+    local name = M.target_label()
     cfg_win.title = (" Review queue · %d annotation%s%s "):format(
       n,
       n == 1 and "" or "s",

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -571,28 +571,56 @@ end)
 
 -- The two cases below reconfigure the plugin, so they come last.
 
+-- What a host that wires nothing gets is the plugin's own composer -- from capture exactly
+-- as from the review view, since both arrive through the same tail. `vim.ui.input` is not
+-- the fallback any more.
 describe("with no composer wired", function()
   codereview.setup({ syntax = false })
   queue.clear()
   edit("src/main.lua")
+  local origin = vim.api.nvim_get_current_win()
 
-  local prompt
+  -- Stubbed rather than left alone: the prompt blocks headless Neovim, so a regression to
+  -- it would hang the suite rather than fail it.
+  local prompted = false
   local orig = vim.ui.input
-  vim.ui.input = function(opts, cb)
-    prompt = opts.prompt
-    cb("typed into the fallback")
+  vim.ui.input = function()
+    prompted = true
   end
   codereview.annotate("bug")
   vim.ui.input = orig
 
-  it("falls back to the built-in prompt", function()
-    assert.is_truthy(prompt, "vim.ui.input was never called")
-    assert.is_truthy(prompt:find("src/main.lua", 1, true), prompt)
+  local composer
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.api.nvim_win_get_config(win).relative ~= "" then
+      composer = win
+    end
+  end
+
+  it("opens the plugin's composer, not a prompt", function()
+    assert.is_false(prompted)
+    assert.is_truthy(composer, "no composer window was opened")
   end)
 
-  it("queues the note that prompt collected", function()
+  it("titles it with what is being annotated", function()
+    local cfg_win = vim.api.nvim_win_get_config(composer)
+    local title = cfg_win.title and tostring(cfg_win.title[1][1]) or ""
+    assert.is_truthy(title:find("src/main.lua", 1, true), title)
+  end)
+
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "captured through the composer" })
+  h.feed("<C-s>")
+
+  it("queues the note it collected", function()
     assert.same(1, queue.count())
-    assert.same("typed into the fallback", queue.all()[1].note)
+    assert.same("captured through the composer", queue.all()[1].note)
+  end)
+
+  it("leaves focus in the buffer it was captured from", function()
+    vim.wait(200, function()
+      return vim.api.nvim_get_current_win() == origin
+    end)
+    assert.same(origin, vim.api.nvim_get_current_win())
   end)
 end)
 

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -1,0 +1,317 @@
+-- The composer the plugin ships: what opens when a host wires no `compose` adapter.
+--
+-- Everything here drives the public entry points, because the composer is only reachable
+-- that way -- there is no "open the composer" API and there should not be one. What insert
+-- mode does is not observable headless at all; that is interactive_spec's job.
+local h = require("tests.helpers")
+
+h.ui(120, 45)
+h.cd_fixture("mktree")
+
+-- Deliberately no `compose`: the built-in composer is the subject of this file.
+local pending_pick -- the picker's callback, held so it answers on a later tick like a real one
+require("codereview").setup({
+  syntax = false,
+  pick_target = function(cb)
+    pending_pick = function()
+      cb({ short = "janus · api", pane_id = "wV:p3", cwd = "/elsewhere" })
+    end
+  end,
+})
+
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+local annotate = require("codereview.annotate")
+
+view.open("branch")
+local V = view.current()
+queue.clear()
+
+---@param kind "line"|"hunk"|"file"
+---@return integer row
+local function row_of(kind)
+  for row = 1, vim.api.nvim_buf_line_count(V.buf) do
+    local a = V.render.anchors[row]
+    if a and a.kind == kind then
+      return row
+    end
+  end
+  error("no " .. kind .. " row in the render")
+end
+
+---The floating window in this tab, if there is one. Identified by being floating rather
+---than by a handle the plugin hands out: a test that asks the composer where it is would
+---pass against a composer that never appeared.
+---@return integer|nil
+local function floating()
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    if vim.api.nvim_win_get_config(win).relative ~= "" then
+      return win
+    end
+  end
+end
+
+---Focus is restored on the tick after a note is accepted, so give it one. Bounded rather
+---than fixed: returns as soon as focus settles, and spends the whole wait only when the
+---assertion after it is going to fail anyway.
+---@param win integer Window focus is expected to settle on
+---@return integer focused
+local function settled(win)
+  vim.wait(200, function()
+    return vim.api.nvim_get_current_win() == win
+  end)
+  return vim.api.nvim_get_current_win()
+end
+
+---Annotate the first line-kind row, from the diff.
+---@param type_name? string
+local function annotate_line(type_name)
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { row_of("line"), 0 })
+  annotate.annotate(type_name or "bug")
+end
+
+describe("annotating with no composer wired", function()
+  -- Stubbed rather than left alone: the built-in prompt blocks headless Neovim, so a
+  -- regression here would hang the suite instead of failing it.
+  local prompted = false
+  local orig = vim.ui.input
+  vim.ui.input = function()
+    prompted = true
+  end
+
+  annotate_line()
+  local win = floating()
+  vim.ui.input = orig
+
+  it("does not fall back to a prompt", function()
+    assert.is_false(prompted)
+  end)
+
+  it("opens a composer window", function()
+    assert.is_truthy(win, "no floating window was opened")
+  end)
+
+  it("puts the cursor in it", function()
+    assert.same(win, vim.api.nvim_get_current_win())
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end)
+
+describe("submitting a note", function()
+  queue.clear()
+  annotate_line()
+  local win = floating()
+
+  -- Written into the buffer rather than typed: insert mode is unreachable headless, and
+  -- what this is about is that whatever ends up in the composer ends up in the queue.
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "why the rename?", "", "no callers were updated" })
+  h.feed("<C-s>")
+
+  it("queues one annotation", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("keeps the note as written, blank lines and all", function()
+    assert.same("why the rename?\n\nno callers were updated", queue.all()[1].note)
+  end)
+
+  it("closes the composer", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+end)
+
+describe("abandoning a note", function()
+  for _, key in ipairs({ "q", "<Esc>" }) do
+    queue.clear()
+    annotate_line()
+    local win = floating()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "half a thought" })
+    h.feed(key)
+
+    it(("closes the composer on %s"):format(key), function()
+      assert.is_false(vim.api.nvim_win_is_valid(win))
+    end)
+
+    it(("queues nothing on %s"):format(key), function()
+      assert.same(0, queue.count())
+    end)
+  end
+end)
+
+-- Opening the composer by accident should cost nothing, and submitting an empty one is
+-- how that gets undone by someone who has already forgotten which key aborts.
+describe("submitting an empty note", function()
+  queue.clear()
+  local msgs, restore = h.capture_notify()
+  annotate_line()
+  local win = floating()
+  h.feed("<C-s>")
+  restore()
+
+  it("queues nothing", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("closes the composer", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+
+  it("says nothing alarming about it", function()
+    assert.is_false(h.notified(msgs, "Queued"), vim.inspect(msgs))
+  end)
+end)
+
+-- Closing a float focuses whatever window Neovim recorded last, and the first window in
+-- the tab when that one is gone -- which with the tree on the left is the tree. Submitting
+-- is covered by the plugin's own restore; abandoning never reaches it, so the composer
+-- owns that half itself.
+describe("where focus lands afterwards", function()
+  ---Open a window from inside the composer and close it again, then take focus back.
+  ---
+  ---This is what `<C-t>` does, and what `@` will. Without it these assertions pass on luck:
+  ---the window Neovim recorded is still the diff, so its fallback happens to be right and a
+  ---composer that restored nothing would look identical.
+  local function picker_flicker()
+    local composer_win = vim.api.nvim_get_current_win()
+    local picker = vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), true, {
+      relative = "editor",
+      width = 20,
+      height = 4,
+      row = 2,
+      col = 2,
+      style = "minimal",
+    })
+    vim.api.nvim_win_close(picker, true)
+    vim.api.nvim_set_current_win(composer_win)
+  end
+
+  queue.clear()
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "a note" })
+  picker_flicker()
+  h.feed("<C-s>")
+  local after_submit = settled(V.win)
+
+  it("returns to the diff after submitting", function()
+    assert.same(V.win, after_submit)
+  end)
+
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "second thoughts" })
+  picker_flicker()
+  h.feed("q")
+  local after_abandon = settled(V.win)
+
+  it("returns to the diff after abandoning", function()
+    assert.same(V.win, after_abandon)
+  end)
+end)
+
+describe("the composer's chrome", function()
+  queue.clear()
+  local row = row_of("line")
+  local path = V.files[V.render.anchors[row].file].path
+  annotate_line()
+  local cfg_win = vim.api.nvim_win_get_config(floating())
+  local title = cfg_win.title and tostring(cfg_win.title[1][1]) or ""
+  local footer = cfg_win.footer and tostring(cfg_win.footer[1][1]) or ""
+  h.feed("q")
+
+  it("titles itself with the type and what is being annotated", function()
+    assert.is_truthy(title:find("Bug", 1, true), title)
+    assert.is_truthy(title:find(path, 1, true), title)
+  end)
+
+  it("names the submit, routing and abandon keys in the footer", function()
+    assert.is_truthy(footer:find("^S", 1, true), footer)
+    assert.is_truthy(footer:find("^T", 1, true), footer)
+    assert.is_truthy(footer:find("q", 1, true), footer)
+  end)
+
+  -- The verb the caller passed, not a hardcoded one: an annotation is queued, not sent.
+  it("names the submit key with the verb it was given", function()
+    assert.is_truthy(footer:find("queue", 1, true), footer)
+  end)
+end)
+
+describe("routing from the composer", function()
+  queue.clear()
+  annotate_line()
+  local win = floating()
+  h.feed("<C-t>")
+
+  it("reaches the pick_target adapter", function()
+    assert.is_truthy(pending_pick, "<C-t> never opened the picker")
+  end)
+
+  it("holds focus in the composer while the picker is open", function()
+    assert.same(win, vim.api.nvim_get_current_win())
+  end)
+
+  -- Guarded so an unbound key fails these assertions instead of erroring out of the file
+  -- and taking every test below it with it.
+  if pending_pick then
+    pending_pick()
+  end
+
+  local function footer_now()
+    local cfg_win = vim.api.nvim_win_get_config(win)
+    return cfg_win.footer and tostring(cfg_win.footer[1][1]) or ""
+  end
+
+  it("comes back to the composer, not the diff underneath", function()
+    assert.same(win, vim.api.nvim_get_current_win())
+    assert.is_true(vim.api.nvim_win_is_valid(win))
+  end)
+
+  it("shows the chosen target in the footer", function()
+    assert.is_truthy(footer_now():find("janus", 1, true), footer_now())
+  end)
+
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "a routed note" })
+  h.feed("<C-s>")
+
+  it("still queues the note it was holding", function()
+    assert.same(1, queue.count())
+    assert.same("a routed note", queue.all()[1].note)
+  end)
+end)
+
+-- Comes last: it reconfigures the plugin. The guarantee is that shipping a composer took
+-- nothing away from a host that already had one.
+describe("with a composer wired", function()
+  local seen
+  require("codereview").setup({
+    syntax = false,
+    compose = function(ctx, on_accept, composer_label)
+      seen = { ctx = ctx, label = composer_label }
+      on_accept(nil, "from the host's composer")
+    end,
+  })
+  queue.clear()
+  annotate_line()
+
+  it("does not open the built-in composer", function()
+    assert.is_nil(floating())
+  end)
+
+  it("queues what the host's composer collected", function()
+    assert.same(1, queue.count())
+    assert.same("from the host's composer", queue.all()[1].note)
+  end)
+
+  -- Field by field rather than by shape: an adapter written against the old context has to
+  -- keep working, and that is only true if nothing was added, renamed or dropped.
+  it("hands it the context it has always been handed", function()
+    assert.same("none", seen.ctx.scope)
+    assert.same("queue", seen.label)
+    assert.is_truthy(seen.ctx.label)
+    assert.is_truthy(seen.ctx.rel_path)
+    assert.is_truthy(seen.ctx.file_path)
+    assert.same(V.win, seen.ctx.origin_win)
+  end)
+end)

--- a/tests/codereview/interactive_init.lua
+++ b/tests/codereview/interactive_init.lua
@@ -1,31 +1,15 @@
--- The composer stub interactive_spec drives, in a real (pty-backed) Neovim.
+-- The config interactive_spec drives, in a real (pty-backed) Neovim.
 --
--- Minimal on purpose: a float entered with `startinsert`, submitted from an insert-mode
--- mapping, closing its own window WITHOUT `stopinsert`. That is exactly the shape of the
--- real composer, and it is what leaves focus back in the review buffer still in INSERT.
+-- No `compose` adapter on purpose: the plugin's own composer is the subject now. This used
+-- to hold a stub shaped like a host's composer -- a float entered with `startinsert`,
+-- submitted from an insert-mode mapping, closing its window without `stopinsert` -- because
+-- there was nothing else to drive. Now that the plugin ships the thing that stub was
+-- imitating, the imitation is worth less than the original.
 --
 -- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it.
 vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
 
 require("codereview").setup({
   syntax = false,
-  compose = function(_, on_accept, _)
-    local buf = vim.api.nvim_create_buf(false, true)
-    local win = vim.api.nvim_open_win(buf, true, {
-      relative = "editor",
-      width = 50,
-      height = 3,
-      row = 3,
-      col = 3,
-      style = "minimal",
-      border = "rounded",
-    })
-    vim.keymap.set("i", "<C-s>", function()
-      local text = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
-      vim.api.nvim_win_close(win, true) -- closes WITHOUT stopinsert, like the real one
-      on_accept(nil, text)
-    end, { buffer = buf })
-    vim.cmd("startinsert")
-  end,
   send = function() end,
 })

--- a/tests/codereview/interactive_spec.lua
+++ b/tests/codereview/interactive_spec.lua
@@ -142,6 +142,13 @@ describe("annotating from insert mode", function()
   it("queued the annotation", function()
     assert.same("1", expr("luaeval(\"require('codereview').count()\")"))
   end)
+
+  -- Only meaningful now that the composer is genuinely entered in insert mode. Typed in
+  -- normal mode those keystrokes would have been motions, and the note would have been
+  -- something else entirely -- which is what this asserted nothing about before.
+  it("queued what was actually typed", function()
+    assert.same("why the rename", expr("luaeval(\"require('codereview.queue').all()[1].note\")"))
+  end)
 end)
 
 describe("the review buffer after submitting", function()


### PR DESCRIPTION
Closes #26.

Wire nothing and annotating gave you `vim.ui.input` — one line, no newlines, nothing kept
if you changed your mind. A review annotation is a paragraph about why something is wrong,
so anyone serious wired their own composer and the weak default stayed most people's
experience.

### Not a fallback beside the adapter — the default implementation of it

```lua
local compose = cfg.compose or require("codereview.composer").open
compose(ctx, function(_, text) done(text) end, label)
```

Both are handed the same arguments; there is no third behaviour to keep in step. Wiring
`compose` replaces it outright, and the context an adapter receives is unchanged field for
field — asserted field by field rather than asserted *about*, because an adapter written
against the old shape has to keep working.

### What it does

`^S` queues, `^T` routes, `q`/`<Esc>` abandons. Opens in insert mode; `^S` and `^T` work in
insert and normal alike, since you may well have pressed `<Esc>` to reread the note first.
The note is whatever the buffer holds, newlines and all; an empty one queues nothing.

Routing goes through the picker the plugin already owns, and the footer names the target the
way the queue float does — `target_label` is now one function rather than the same
expression written twice. It is the same choice: routing belongs to the batch, not to the
window that asked.

Focus on the accept path was already `collect`'s. The composer owns the abandoned path,
which nothing else can reach, and that is what `origin_win` exists for.

### The tests that would otherwise have proved nothing

**Focus.** The abandon assertion passed before the composer restored anything. With no
window opened from inside the composer, the diff is still what Neovim recorded, its fallback
happens to be right, and a composer restoring nothing looks identical. The test now opens and
closes a window first — standing in for what `^T` does and `@` will — and fails without the
restore. Same trap #19 documented, hit again from the other side.

**Insert mode.** `interactive_init`'s stub composer is gone; it imitated a real composer back
when there wasn't one. The pty spec drives the original now, through `ab`, typing, `^S`. Its
note assertion is new and only means anything because the composer genuinely enters insert
mode — in normal mode those keystrokes would have been motions.

### Two tests changed on purpose

`capture_spec` asserted the `vim.ui.input` fallback. That is the behaviour this changes, so
they now assert the composer opens, is titled with the file, queues what it collected, and
returns focus to the buffer's own window rather than the review's. Nothing else in the suite
moved: 455 passing.

Drafts (#28) and `@` refs (#27) are deliberately absent.
