### PR TITLE
feat(composer): reference another file with @

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ was this dropped on purpose?
 
 ## Adapters
 
-The plugin has no opinion about where a review goes. Three optional functions inject that:
+The plugin has no opinion about where a review goes, or about which pickers you use. Four
+optional functions inject that:
 
 ```lua
 opts = {
@@ -250,6 +251,11 @@ opts = {
   -- Choose a delivery target; call back with anything carrying `short` and `cwd`.
   -- `cwd` matters: refs are re-resolved against it at submit time.
   pick_target = function(cb) cb({ short = "agent", cwd = "/path" }) end,
+
+  -- Choose a file to reference from `@` inside the composer. The plugin ships no picker,
+  -- so without this `@` stays a literal `@`. `first`/`last` are optional — omit them and
+  -- the reference is to the file rather than to a range in it.
+  pick_file = function(cb) cb({ path = "src/main.lua", first = 12, last = 20 }) end,
 
   -- Collect note text. Without it you get the composer the plugin ships, which implements
   -- this same contract — wiring one replaces that composer rather than upgrading a prompt.

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -195,6 +195,7 @@ and what is being annotated:
 
     ^S              queue the note and close
     ^T              choose where the batch goes
+    @               reference another file (|codereview-opt-pick_file|)
     q  <Esc>        abandon without queueing
 
 It opens in insert mode, because you opened it to write something. `^S` and
@@ -208,6 +209,11 @@ returns to the window the annotation was started from.
 
 Routing from here is the same choice the queue float offers, because it is the
 same choice: a target belongs to the batch, not to the window that asked.
+
+`@` references another file, through |codereview-opt-pick_file|. It is written
+into the note before the picker opens, so cancelling leaves the character you
+typed -- and it only opens a picker where a word begins, so an email address in
+a note is an email address.
 
 Wire |codereview-opt-compose| to replace this composer with your own.
 
@@ -262,9 +268,10 @@ path, and inlines its code when it cannot. The buffer itself is never touched.
 ==============================================================================
 7. ADAPTERS                                            *codereview-adapters*
 
-The plugin has no opinion about where a review goes. Three optional functions
-inject that. With none of them wired everything still works except delivery,
-which falls back to the `+` register.
+The plugin has no opinion about where a review goes, or about which pickers
+you use. Four optional functions inject that. With none of them wired
+everything still works except delivery, which falls back to the `+` register,
+and `@` in the composer, which stays a literal `@`.
 
 send({payload}, {target})                                *codereview-opt-send*
         Deliver the rendered batch. {target} is whatever `pick_target`
@@ -284,6 +291,22 @@ pick_target({cb})                                 *codereview-opt-pick_target*
         deliberately **not persisted**. The queue is worth keeping across a
         restart; a target names a live destination -- a pane id, say -- and
         restoring a dead one would route a batch into nothing.
+
+pick_file({cb})                                     *codereview-opt-pick_file*
+        Choose a file to reference from inside the composer and call {cb} with
+        it. The plugin ships no picker -- every config already has one -- so
+        without this `@` stays a literal `@` and opens nothing: >
+            cb({ path = "src/main.lua", first = 12, last = 20 })
+<
+        `first` and `last` are optional. A picker that cannot select lines
+        omits both, and the reference is then to the file rather than to a
+        range in it. Answering with nothing is a cancel, which leaves the `@`
+        that was typed and nothing else.
+
+        An absolute path under the working directory is spliced relative to
+        it, so that a reference written into a note reads the way every
+        reference the payload renders does. Outside that tree it stays
+        absolute -- there is nothing for it to be relative to.
 
 compose({ctx}, {on_accept}, {label})                  *codereview-opt-compose*
         Collect note text and call {on_accept}(target, text). Replaces the

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -3,6 +3,8 @@
 ---Deliberately the same shape as the `compose` adapter a host injects -- it *is* the
 ---default implementation of that contract, not a lesser path beside it. Anything a host
 ---composer is handed, this one is handed; anything it must do, this one does.
+local config = require("codereview.config")
+
 local M = {}
 
 ---Open the composer.
@@ -83,6 +85,54 @@ function M.open(ctx, on_accept, label)
   vim.keymap.set({ "i", "n" }, "<C-t>", function()
     require("codereview.view").pick_target(refresh)
   end, { buffer = buf, desc = "Choose target" })
+  -- The sentinel is written *before* the picker opens, so cancelling leaves the literal
+  -- character that was just pressed. The position is remembered rather than re-derived for
+  -- the same reason a host composer has to remember it: the picker takes focus, and the
+  -- cursor with it, so by the time it answers the composer's cursor means nothing.
+  vim.keymap.set("i", "@", function()
+    local row, col = unpack(vim.api.nvim_win_get_cursor(win))
+    vim.api.nvim_buf_set_text(buf, row - 1, col, row - 1, col, { "@" })
+    col = col + 1
+    vim.api.nvim_win_set_cursor(win, { row, col })
+
+    -- Only where a word begins. Notes contain email addresses, and an `@` that continues a
+    -- word is a character the user typed, not a request for a picker. Whitespace-or-start
+    -- rather than anything cleverer, because the rule has to be predictable while typing:
+    -- you should never be surprised by a picker.
+    local before = col > 1 and vim.api.nvim_buf_get_text(buf, row - 1, col - 2, row - 1, col - 1, {})[1]
+    if before and not before:match("%s") then
+      return
+    end
+
+    local pick_file = config.get().pick_file
+    if not pick_file then
+      return
+    end
+    pick_file(function(chosen)
+      if not (chosen and chosen.path) then
+        return
+      end
+      local payload = require("codereview.payload")
+      -- A picker is entitled to answer with an absolute path, but a reference in a note
+      -- should read the way every other reference in the batch reads. Resolved through the
+      -- same helpers the payload uses, so a symlinked working directory does not turn a
+      -- perfectly relative path into an absolute one. Outside the tree there is nothing to
+      -- be relative to, and the absolute path is the only name the file has.
+      local path = chosen.path
+      if path:sub(1, 1) == "/" then
+        local root = payload.resolve_base(vim.uv.cwd())
+        path = payload.relative_to(vim.uv.fs_realpath(path) or path, root) or path
+      end
+      -- Rendered by the module that reads references, not spelled out again here. Lines are
+      -- optional: a picker that cannot select them omits both, and the reference is then to
+      -- the file rather than to a range in it.
+      local ref = payload.ref(path, chosen.first, chosen.last)
+      -- Past the `@`: the sentinel is already in the buffer, and re-writing it would either
+      -- double it or mean re-deriving where it went.
+      vim.api.nvim_buf_set_text(buf, row - 1, col, row - 1, col, { ref:sub(2) .. " " })
+    end)
+  end, { buffer = buf, desc = "Reference a file" })
+
   -- Normal mode only. In insert both are the keys you actually want -- `q` is a letter and
   -- <Esc> is how you leave insert to reread what you wrote.
   vim.keymap.set("n", "q", close, { buffer = buf, desc = "Abandon" })

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -42,6 +42,12 @@ M.defaults = {
   ---Choose a delivery target, calling back with it (or nil for the default).
   ---@type fun(cb: fun(target: table|nil))|nil
   pick_target = nil,
+  ---Choose a file to reference from inside the composer, calling back with it. The plugin
+  ---ships no picker -- every config already has one -- so without this `@` stays a literal
+  ---`@`. `first`/`last` are optional: a picker that cannot select lines omits them, and the
+  ---reference is then to the file rather than to a range in it.
+  ---@type fun(cb: fun(chosen: { path: string, first: integer?, last: integer? }|nil))|nil
+  pick_file = nil,
   ---Collect note text. Replaces the composer the plugin ships, which is the default
   ---implementation of this same contract rather than a fallback beside it -- both are
   ---handed exactly the same arguments.

--- a/lua/codereview/payload.lua
+++ b/lua/codereview/payload.lua
@@ -49,6 +49,25 @@ function M.relative_to(path, base)
   return nil
 end
 
+---An `@ref`: the one syntax this plugin speaks for "look at this code".
+---
+---Here rather than at either call site because there are two of them now -- the payload
+---renders an annotation's own location, and the composer splices a reference to somewhere
+---else -- and a note that says `@path#L12-12` where the payload says `@path#L12` is a
+---composer authoring a dialect of its reader's language.
+---@param rel string Path, relative to whoever will resolve it
+---@param first integer|nil Omit both for a reference to the whole file
+---@param last integer|nil
+---@return string
+function M.ref(rel, first, last)
+  if not first then
+    return ("@%s"):format(rel)
+  end
+  last = last or first
+  local suffix = first == last and ("#L%d"):format(first) or ("#L%d-%d"):format(first, last)
+  return ("@%s%s"):format(rel, suffix)
+end
+
 ---@param entry CRAnnotation
 ---@return string
 local function range_text(entry)
@@ -86,15 +105,13 @@ local function describe(entry, base)
 
   if entry.kind == "file" then
     if rel and not entry.stale then
-      return ("@%s"):format(rel), nil
+      return M.ref(rel), nil
     end
     return ("%s (%s)"):format(where, entry.tag or "whole file"), nil
   end
 
   if not must_inline then
-    local suffix = entry.first == entry.last and ("#L%d"):format(entry.first)
-      or ("#L%d-%d"):format(entry.first, entry.last)
-    return ("@%s%s"):format(rel, suffix), nil
+    return M.ref(rel, entry.first, entry.last), nil
   end
 
   local tags = {}

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -10,12 +10,24 @@ h.cd_fixture("mktree")
 
 -- Deliberately no `compose`: the built-in composer is the subject of this file.
 local pending_pick -- the picker's callback, held so it answers on a later tick like a real one
+local file_answer -- what the file picker answers with; nil is a cancel
+local file_picks = 0 -- how many times it was opened at all
+local file_pick_hook -- runs inside the picker, before it answers
 require("codereview").setup({
   syntax = false,
   pick_target = function(cb)
     pending_pick = function()
       cb({ short = "janus · api", pane_id = "wV:p3", cwd = "/elsewhere" })
     end
+  end,
+  -- Answers inline. A real picker takes focus and gives it back; `file_pick_hook` is how a
+  -- test makes it behave like one -- moving the cursor, say -- before it answers.
+  pick_file = function(cb)
+    file_picks = file_picks + 1
+    if file_pick_hook then
+      file_pick_hook()
+    end
+    cb(file_answer)
   end,
 })
 
@@ -278,6 +290,209 @@ describe("routing from the composer", function()
   it("still queues the note it was holding", function()
     assert.same(1, queue.count())
     assert.same("a routed note", queue.all()[1].note)
+  end)
+end)
+
+describe("referencing a file", function()
+  queue.clear()
+  file_answer = { path = "apps/web/src/index.lua" }
+  annotate_line()
+  local composer_win = floating()
+  h.feed("i@")
+  local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  -- Closed through the API, not by feeding `q`: abandoning has its own test, and a stray
+  -- `q` that arrives after the composer has gone reaches the review buffer, where it
+  -- closes the whole review and takes every assertion below with it.
+  h.feed("<Esc>")
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+
+  it("opens the file picker", function()
+    assert.is_true(file_picks > 0, "pick_file was never called")
+  end)
+
+  -- Trailing space because you are mid-sentence: a reference is something you write *into*
+  -- a note, not the end of one.
+  it("splices a reference to the chosen file", function()
+    assert.same("@apps/web/src/index.lua ", line)
+  end)
+end)
+
+-- A real picker takes focus and the cursor with it, and can leave the composer's cursor
+-- anywhere at all by the time it answers. The splice belongs where the `@` was typed.
+describe("referencing a file mid-sentence", function()
+  queue.clear()
+  file_answer = { path = "docs/guide.md" }
+  annotate_line()
+  local composer_win = floating()
+
+  -- A picker that moves the cursor before it answers, which any real one does by taking
+  -- focus. What gets spliced must not depend on where it left things.
+  local moved = false
+  file_pick_hook = function()
+    vim.api.nvim_win_set_cursor(composer_win, { 1, 0 })
+    moved = true
+  end
+
+  -- One feed, not two: `nvim_feedkeys` does not reliably leave the editor in insert mode
+  -- between calls, so a second feed would arrive in normal mode and never reach the
+  -- insert-mode `@`.
+  h.feed("icompare with @")
+  local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  file_pick_hook = nil
+  h.feed("<Esc>")
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+
+  it("ran a picker that moved the cursor", function()
+    assert.is_true(moved)
+  end)
+
+  it("splices where the @ was typed, not where the cursor ended up", function()
+    assert.same("compare with @docs/guide.md ", line)
+  end)
+end)
+
+-- The form has to be the one the payload renders for an annotation's own lines, or the
+-- coupling this work exists to remove has simply moved: the composer would be authoring a
+-- syntax the module that reads it never produces. Note the single line collapses to `#L12`
+-- rather than `#L12-12`.
+describe("referencing lines in a file", function()
+  for _, case in ipairs({
+    { answer = { path = "docs/guide.md", first = 12, last = 20 }, expect = "@docs/guide.md#L12-20 " },
+    { answer = { path = "docs/guide.md", first = 12, last = 12 }, expect = "@docs/guide.md#L12 " },
+    { answer = { path = "docs/guide.md" }, expect = "@docs/guide.md " },
+  }) do
+    queue.clear()
+    file_answer = case.answer
+    annotate_line()
+    local composer_win = floating()
+    h.feed("i@")
+    local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+    h.feed("<Esc>")
+    if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+      vim.api.nvim_win_close(composer_win, true)
+    end
+
+    it(("splices %s"):format(case.expect), function()
+      assert.same(case.expect, line)
+    end)
+  end
+end)
+
+-- Notes contain email addresses. An `@` that continues a word is a character, not a
+-- request for a picker.
+describe("an @ that does not begin a word", function()
+  queue.clear()
+  file_answer = { path = "docs/guide.md" }
+  local before = file_picks
+  annotate_line()
+  local composer_win = floating()
+  h.feed("iask someone@example.com about this")
+  local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  h.feed("<Esc>")
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+
+  it("does not open the picker", function()
+    assert.same(before, file_picks)
+  end)
+
+  it("leaves the address as typed", function()
+    assert.same("ask someone@example.com about this", line)
+  end)
+end)
+
+-- A picker is entitled to answer with an absolute path. What lands in the note should read
+-- the way every other reference in the batch reads.
+describe("a picker that answers with an absolute path", function()
+  queue.clear()
+  file_answer = { path = vim.fs.joinpath(vim.uv.cwd(), "docs/guide.md"), first = 3 }
+  annotate_line()
+  local composer_win = floating()
+  h.feed("i@")
+  local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  h.feed("<Esc>")
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+
+  it("splices it relative to the working directory", function()
+    assert.same("@docs/guide.md#L3 ", line)
+  end)
+end)
+
+-- Outside the tree there is nothing to be relative to, and an absolute path is the only
+-- name the file has.
+describe("a picker that answers with a path outside the tree", function()
+  queue.clear()
+  file_answer = { path = "/etc/hosts" }
+  annotate_line()
+  local composer_win = floating()
+  h.feed("i@")
+  local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  h.feed("<Esc>")
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+
+  it("leaves it absolute", function()
+    assert.same("@/etc/hosts ", line)
+  end)
+end)
+
+-- The sentinel is written before the picker opens precisely so that this is what cancelling
+-- costs you: nothing.
+describe("cancelling the file picker", function()
+  queue.clear()
+  file_answer = nil
+  annotate_line()
+  local composer_win = floating()
+  h.feed("ilook at @")
+  local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  h.feed("<Esc>")
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+
+  it("leaves the literal @ the user typed, and nothing else", function()
+    assert.same("look at @", line)
+  end)
+end)
+
+describe("a note carrying a reference", function()
+  queue.clear()
+  file_answer = { path = "docs/guide.md", first = 3 }
+  annotate_line()
+  h.feed("icompare with @<Esc>")
+  h.feed("<C-s>")
+
+  it("queues the note with the reference intact", function()
+    assert.same(1, queue.count())
+    assert.same("compare with @docs/guide.md#L3", queue.all()[1].note)
+  end)
+end)
+
+-- Reconfigures, so it comes after everything that wants a picker. The plugin ships none:
+-- every config already has one, and `@` staying a literal `@` is what "the composer is
+-- still fully usable without it" means.
+describe("with no file picker wired", function()
+  require("codereview").setup({ syntax = false })
+  queue.clear()
+  annotate_line()
+  local composer_win = floating()
+  h.feed("ilook at @")
+  local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  h.feed("<Esc>")
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+
+  it("inserts a literal @ and opens nothing", function()
+    assert.same("look at @", line)
   end)
 end)
 

--- a/tests/codereview/interactive_init.lua
+++ b/tests/codereview/interactive_init.lua
@@ -12,4 +12,10 @@ vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(
 require("codereview").setup({
   syntax = false,
   send = function() end,
+  -- Answers immediately with a fixed file. A real picker is a window that takes focus, and
+  -- what that costs the splice position is covered headless; what cannot be covered there
+  -- is that `@` is an insert-mode key at all.
+  pick_file = function(cb)
+    cb({ path = "src/routes.lua", first = 2, last = 4 })
+  end,
 })

--- a/tests/codereview/interactive_spec.lua
+++ b/tests/codereview/interactive_spec.lua
@@ -151,6 +151,35 @@ describe("annotating from insert mode", function()
   end)
 end)
 
+-- `@` is bound in insert mode, so this is the only place it can be pressed the way a user
+-- presses it. Headless the mapping is reachable only by feeding an `i` first, which is not
+-- what a composer opened in insert mode does.
+describe("referencing a file while typing", function()
+  it("opens the composer again", function()
+    send("ab", function()
+      return expr("mode()"):sub(1, 1) == "i"
+    end)
+    assert.same("i", expr("mode()"):sub(1, 1))
+  end)
+
+  it("splices the reference as the @ is typed", function()
+    send("compare with @", function()
+      return expr("getline('.')"):find("routes", 1, true) ~= nil
+    end)
+    -- Without its trailing space: `expr` trims what comes back over the socket, so the
+    -- space the splice leaves for you to keep typing is not observable from here. That it
+    -- is there at all is a headless assertion.
+    assert.same("compare with @src/routes.lua#L2-4", expr("getline('.')"))
+  end)
+
+  it("queues the note with its reference", function()
+    send("<C-s>", function()
+      return expr("&filetype") == "codereview"
+    end)
+    assert.same("compare with @src/routes.lua#L2-4", expr("luaeval(\"require('codereview.queue').all()[2].note\")"))
+  end)
+end)
+
 describe("the review buffer after submitting", function()
   -- The reported symptom: navigation keys typed text instead of moving.
   it("treats ]h as a motion, not as input", function()


### PR DESCRIPTION
Closes #27.

A note that says "this contradicts the loader" should be able to point at the loader. `@`
opens whatever picker the config wires and splices a reference where it was typed.

`pick_file` is the fourth adapter. The plugin ships no picker — every config already has one
— so without it `@` is a literal `@` and the composer is otherwise untouched. It answers
with a path and, optionally, lines; a picker that cannot select a range omits them and the
reference is to the file.

### The check the issue asked for found something

#27 says `@path#Lfirst-last` throughout. `payload.lua` renders a **single line as `#L20`,
not `#L20-20`** — so implementing the issue literally would have had the composer writing a
form the module that reads references never produces.

Rather than fix that by copying the rule, the form now lives in one function both callers go
through:

```lua
function M.ref(rel, first, last)   -- payload.lua
  if not first then return ("@%s"):format(rel) end
  last = last or first
  local suffix = first == last and ("#L%d"):format(first) or ("#L%d-%d"):format(first, last)
  return ("@%s%s"):format(rel, suffix)
end
```

The payload's own rendering now calls it too, so the two cannot drift. `payload_spec` is
unchanged and still green, which is the evidence that extracting it changed nothing.

An absolute path under the working directory resolves through the same `resolve_base` /
`relative_to` the payload uses, so a reference in a note reads like every reference in the
batch — and a symlinked working directory does not turn a relative path absolute. Outside
the tree it stays absolute; there is nothing to be relative to.

### Two behaviours that look like details

**The `@` is written before the picker opens**, so cancelling leaves the character you
pressed. The splice position is remembered rather than re-derived, because the picker takes
focus and the cursor with it. The mid-sentence test is only worth having because of this: I
mutated the implementation to re-derive the position and confirmed it goes red, since it had
passed on the first cycle's code without being driven by it.

**An `@` that continues a word is a character, not a request for a picker** —
`someone@example.com` stays typeable. Whitespace-or-start rather than anything cleverer,
because the rule has to be predictable while typing: nobody should be surprised by a picker.

### Testing

The pty case is new, because `@` is an insert-mode key. Headless the mapping is reachable
only by feeding an `i` first, which is not what a composer opened in insert mode does — so
the socket-driven spec presses it the way a user does and asserts both the spliced line and
the queued note.

One thing the pty *cannot* see: `expr` trims what comes back over the socket, so the trailing
space the splice leaves for you to keep typing is invisible there. That assertion is headless.

472 passing.
