### PR TITLE
feat(drafts): keep a note you walked away from

### DIFF
--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -196,7 +196,8 @@ and what is being annotated:
     ^S              queue the note and close
     ^T              choose where the batch goes
     @               reference another file (|codereview-opt-pick_file|)
-    q  <Esc>        abandon without queueing
+    ^D              discard a restored draft
+    q  <Esc>        abandon, keeping what you wrote as a draft
 
 It opens in insert mode, because you opened it to write something. `^S` and
 `^T` work in insert and normal alike -- you may well have pressed <Esc> to
@@ -214,6 +215,26 @@ same choice: a target belongs to the batch, not to the window that asked.
 into the note before the picker opens, so cancelling leaves the character you
 typed -- and it only opens a picker where a word begins, so an email address in
 a note is an email address.
+
+Drafts                                                  *codereview-drafts*
+
+Abandon the composer with something in it and the text is kept. Annotate that
+file again and it is offered back, with `^D` to discard it and start clean. A
+note you actually submit clears its draft, so what you have already said never
+comes back.
+
+Drafts are keyed by the file the note is about, not by the window it was
+started in: annotating a file in the review and capturing it from an ordinary
+buffer are the same thought about the same code, and meet the same draft. A
+draft for one file never surfaces while you annotate another.
+
+They live in `stdpath("state")/codereview/drafts.json`, separate from review
+progress because a draft is not review progress -- that document is rewritten
+whenever the queue changes, and a draft has nothing to do with the queue.
+Anything untouched for a week is dropped when the store is next read. A store
+that cannot be read is treated as no drafts at all: failing there would cost
+you the note you were about to write in order to report one you had already
+abandoned.
 
 Wire |codereview-opt-compose| to replace this composer with your own.
 
@@ -386,6 +407,8 @@ defines, so overriding any of them works without the plugin fighting back: >
 
 Reviewed marks and the queue are written to
 `stdpath("state")/codereview/{repo}.json`, keyed by scope and diff base.
+Half-written notes are kept separately, in `drafts.json` -- see
+|codereview-drafts|.
 
 Each entry records the git blob it was captured against, which is what makes
 persisting safe. On reload:

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -4,6 +4,7 @@
 ---default implementation of that contract, not a lesser path beside it. Anything a host
 ---composer is handed, this one is handed; anything it must do, this one does.
 local config = require("codereview.config")
+local drafts = require("codereview.drafts")
 
 local M = {}
 
@@ -16,6 +17,9 @@ function M.open(ctx, on_accept, label)
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].bufhidden = "wipe"
   vim.bo[buf].filetype = "markdown"
+
+  local draft_key = drafts.key(ctx)
+  local restored = drafts.get(draft_key)
 
   local width = math.min(84, math.max(40, math.floor(vim.o.columns * 0.7)))
   local height = 6
@@ -50,11 +54,19 @@ function M.open(ctx, on_accept, label)
     if #name > 16 then
       name = name:sub(1, 15) .. "…"
     end
-    cfg_win.footer = (" ^T %s · ^S %s · q abandon "):format(name, label)
+    -- `^D` only while there is something to discard. A key named in the footer that does
+    -- nothing is worse than one that is not named at all.
+    local drop = restored and " · ^D drop" or ""
+    cfg_win.footer = (" ^T %s%s · ^S %s · q abandon "):format(name, drop, label)
     vim.api.nvim_win_set_config(win, cfg_win)
   end
 
-  local function close()
+  ---@param keep_draft boolean Stash what is written for next time
+  local function close(keep_draft)
+    -- Read before the window goes: `bufhidden = "wipe"` takes the buffer with it.
+    if keep_draft and vim.api.nvim_buf_is_valid(buf) then
+      drafts.set(draft_key, table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n"))
+    end
     if vim.api.nvim_win_is_valid(win) then
       vim.api.nvim_win_close(win, true)
     end
@@ -71,7 +83,9 @@ function M.open(ctx, on_accept, label)
   ---Read before closing: `bufhidden = "wipe"` takes the buffer with the window.
   local function submit()
     local text = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
-    close()
+    close(false)
+    -- Committed: there is nothing left worth restoring for this file.
+    drafts.set(draft_key, nil)
     -- The target argument is the adapter contract's, not this composer's: routing is a
     -- property of the batch and the plugin already holds it.
     on_accept(nil, text)
@@ -135,8 +149,31 @@ function M.open(ctx, on_accept, label)
 
   -- Normal mode only. In insert both are the keys you actually want -- `q` is a letter and
   -- <Esc> is how you leave insert to reread what you wrote.
-  vim.keymap.set("n", "q", close, { buffer = buf, desc = "Abandon" })
-  vim.keymap.set("n", "<Esc>", close, { buffer = buf, desc = "Abandon" })
+  -- Discarding is not the same as writing an empty note: it says "forget what I left here",
+  -- and without it the only way to be rid of a draft is to submit it.
+  vim.keymap.set({ "i", "n" }, "<C-d>", function()
+    if not restored then
+      return
+    end
+    restored = nil
+    drafts.set(draft_key, nil)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "" })
+    refresh()
+  end, { buffer = buf, desc = "Discard the restored draft" })
+
+  local function abandon()
+    close(true)
+  end
+  vim.keymap.set("n", "q", abandon, { buffer = buf, desc = "Abandon (keeps a draft)" })
+  vim.keymap.set("n", "<Esc>", abandon, { buffer = buf, desc = "Abandon (keeps a draft)" })
+
+  if restored then
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(restored, "\n"))
+    vim.api.nvim_win_set_cursor(win, { vim.api.nvim_buf_line_count(buf), 0 })
+    -- Said out loud, because text you did not just type appearing in a buffer you are about
+    -- to write in is otherwise a small mystery.
+    vim.notify("Draft restored — ^D to discard", vim.log.levels.INFO, { title = "Code review" })
+  end
 
   refresh()
   -- You opened this to write something, so start writing. Leaving insert mode again is

--- a/lua/codereview/drafts.lua
+++ b/lua/codereview/drafts.lua
@@ -1,0 +1,104 @@
+---Notes abandoned half-written, kept until you come back for them.
+---
+---Its own store rather than a corner of the review document, because a draft is not review
+---progress: that document is rewritten every time the queue changes, and a draft has
+---nothing to do with the queue. It is also the one thing here that has to survive a file
+---leaving the repository entirely, so it is keyed by absolute path and lives in one place
+---regardless of which checkout the note was written in.
+local M = {}
+
+local VERSION = 1
+
+---Matches the sweep on the no-repository queue, and for the same reason: this is a store
+---nothing else prunes, so it has to age out on its own or it grows forever.
+local TTL_SECONDS = 7 * 24 * 60 * 60
+
+---@return string
+function M.path()
+  return vim.fs.joinpath(vim.fn.stdpath("state"), "codereview", "drafts.json")
+end
+
+---Every draft, minus the ones that have aged out.
+---
+---Swept on load rather than on a timer: this is the only moment the store is read, so it is
+---the only moment anything is in a position to drop from it.
+---@return table<string, { text: string, at: integer }>
+local function load()
+  local file = M.path()
+  if vim.fn.filereadable(file) == 0 then
+    return {}
+  end
+  local ok, decoded = pcall(function()
+    return vim.json.decode(table.concat(vim.fn.readfile(file), "\n"), {
+      luanil = { object = true, array = true },
+    })
+  end)
+  -- A corrupt or older store is no drafts at all. Erroring here would happen on the way
+  -- *into* the composer, which would cost you the note you were about to write to save one
+  -- you had already abandoned.
+  if not ok or type(decoded) ~= "table" or decoded.version ~= VERSION then
+    return {}
+  end
+
+  local now, fresh = os.time(), {}
+  for key, entry in pairs(decoded.drafts or {}) do
+    if type(entry) == "table" and type(entry.text) == "string" and (now - (entry.at or 0)) < TTL_SECONDS then
+      fresh[key] = entry
+    end
+  end
+  return fresh
+end
+
+---@param drafts table
+local function save(drafts)
+  local file = M.path()
+  vim.fn.mkdir(vim.fs.dirname(file), "p")
+  local ok, encoded = pcall(vim.json.encode, { version = VERSION, drafts = drafts })
+  if not ok then
+    return
+  end
+  pcall(vim.fn.writefile, { encoded }, file)
+end
+
+---The key a note about `ctx` is filed under.
+---
+---The absolute path, so a review annotation and a capture of the same file meet the same
+---draft -- they are the same thought about the same code, and both paths already carry a
+---canonical absolute path. A bare note has no file at all, and every bare note shares the
+---one slot there is.
+---@param ctx table
+---@return string
+function M.key(ctx)
+  return ctx.file_path or "(no file)"
+end
+
+---@param key string
+---@return string|nil
+function M.get(key)
+  local entry = load()[key]
+  return entry and entry.text or nil
+end
+
+---@param key string
+---@param text string|nil nil forgets the draft
+function M.set(key, text)
+  local drafts = load()
+  if text and vim.trim(text) ~= "" then
+    -- Stamped fresh on every write, unlike the queue's sweep: a draft you came back to and
+    -- put down again is a draft you are still thinking about.
+    drafts[key] = { text = text, at = os.time() }
+  else
+    drafts[key] = nil
+  end
+  save(drafts)
+end
+
+---Forget every draft.
+function M.clear()
+  local file = M.path()
+  if vim.fn.filereadable(file) == 1 then
+    vim.fn.delete(file)
+  end
+end
+
+return M

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -33,11 +33,22 @@ require("codereview").setup({
 
 local view = require("codereview.view")
 local queue = require("codereview.queue")
+local drafts = require("codereview.drafts")
 local annotate = require("codereview.annotate")
 
 view.open("branch")
 local V = view.current()
 queue.clear()
+
+---Start a block from nothing.
+---
+---Drafts outlive a composer on purpose, so a block that abandons a note leaves one behind
+---for the next block to open into. Anything that assumes an empty composer has to say so,
+---exactly as it already says it wants an empty queue.
+local function reset()
+  queue.clear()
+  drafts.clear()
+end
 
 ---@param kind "line"|"hunk"|"file"
 ---@return integer row
@@ -83,6 +94,22 @@ local function annotate_line(type_name)
   annotate.annotate(type_name or "bug")
 end
 
+---Annotate a line in a different file from the one `annotate_line` lands on.
+---@return string path The file annotated
+local function annotate_other_file()
+  local first = V.render.anchors[row_of("line")].file
+  for row = 1, vim.api.nvim_buf_line_count(V.buf) do
+    local a = V.render.anchors[row]
+    if a and a.kind == "line" and a.file ~= first then
+      vim.api.nvim_set_current_win(V.win)
+      vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+      annotate.annotate("bug")
+      return V.files[a.file].path
+    end
+  end
+  error("the render has only one file")
+end
+
 describe("annotating with no composer wired", function()
   -- Stubbed rather than left alone: the built-in prompt blocks headless Neovim, so a
   -- regression here would hang the suite instead of failing it.
@@ -114,7 +141,7 @@ describe("annotating with no composer wired", function()
 end)
 
 describe("submitting a note", function()
-  queue.clear()
+  reset()
   annotate_line()
   local win = floating()
 
@@ -138,7 +165,7 @@ end)
 
 describe("abandoning a note", function()
   for _, key in ipairs({ "q", "<Esc>" }) do
-    queue.clear()
+    reset()
     annotate_line()
     local win = floating()
     vim.api.nvim_buf_set_lines(0, 0, -1, false, { "half a thought" })
@@ -157,7 +184,7 @@ end)
 -- Opening the composer by accident should cost nothing, and submitting an empty one is
 -- how that gets undone by someone who has already forgotten which key aborts.
 describe("submitting an empty note", function()
-  queue.clear()
+  reset()
   local msgs, restore = h.capture_notify()
   annotate_line()
   local win = floating()
@@ -201,7 +228,7 @@ describe("where focus lands afterwards", function()
     vim.api.nvim_set_current_win(composer_win)
   end
 
-  queue.clear()
+  reset()
   annotate_line()
   vim.api.nvim_buf_set_lines(0, 0, -1, false, { "a note" })
   picker_flicker()
@@ -224,7 +251,7 @@ describe("where focus lands afterwards", function()
 end)
 
 describe("the composer's chrome", function()
-  queue.clear()
+  reset()
   local row = row_of("line")
   local path = V.files[V.render.anchors[row].file].path
   annotate_line()
@@ -251,7 +278,7 @@ describe("the composer's chrome", function()
 end)
 
 describe("routing from the composer", function()
-  queue.clear()
+  reset()
   annotate_line()
   local win = floating()
   h.feed("<C-t>")
@@ -294,7 +321,7 @@ describe("routing from the composer", function()
 end)
 
 describe("referencing a file", function()
-  queue.clear()
+  reset()
   file_answer = { path = "apps/web/src/index.lua" }
   annotate_line()
   local composer_win = floating()
@@ -322,7 +349,7 @@ end)
 -- A real picker takes focus and the cursor with it, and can leave the composer's cursor
 -- anywhere at all by the time it answers. The splice belongs where the `@` was typed.
 describe("referencing a file mid-sentence", function()
-  queue.clear()
+  reset()
   file_answer = { path = "docs/guide.md" }
   annotate_line()
   local composer_win = floating()
@@ -365,7 +392,7 @@ describe("referencing lines in a file", function()
     { answer = { path = "docs/guide.md", first = 12, last = 12 }, expect = "@docs/guide.md#L12 " },
     { answer = { path = "docs/guide.md" }, expect = "@docs/guide.md " },
   }) do
-    queue.clear()
+    reset()
     file_answer = case.answer
     annotate_line()
     local composer_win = floating()
@@ -385,7 +412,7 @@ end)
 -- Notes contain email addresses. An `@` that continues a word is a character, not a
 -- request for a picker.
 describe("an @ that does not begin a word", function()
-  queue.clear()
+  reset()
   file_answer = { path = "docs/guide.md" }
   local before = file_picks
   annotate_line()
@@ -409,7 +436,7 @@ end)
 -- A picker is entitled to answer with an absolute path. What lands in the note should read
 -- the way every other reference in the batch reads.
 describe("a picker that answers with an absolute path", function()
-  queue.clear()
+  reset()
   file_answer = { path = vim.fs.joinpath(vim.uv.cwd(), "docs/guide.md"), first = 3 }
   annotate_line()
   local composer_win = floating()
@@ -428,7 +455,7 @@ end)
 -- Outside the tree there is nothing to be relative to, and an absolute path is the only
 -- name the file has.
 describe("a picker that answers with a path outside the tree", function()
-  queue.clear()
+  reset()
   file_answer = { path = "/etc/hosts" }
   annotate_line()
   local composer_win = floating()
@@ -447,7 +474,7 @@ end)
 -- The sentinel is written before the picker opens precisely so that this is what cancelling
 -- costs you: nothing.
 describe("cancelling the file picker", function()
-  queue.clear()
+  reset()
   file_answer = nil
   annotate_line()
   local composer_win = floating()
@@ -464,7 +491,7 @@ describe("cancelling the file picker", function()
 end)
 
 describe("a note carrying a reference", function()
-  queue.clear()
+  reset()
   file_answer = { path = "docs/guide.md", first = 3 }
   annotate_line()
   h.feed("icompare with @<Esc>")
@@ -476,12 +503,261 @@ describe("a note carrying a reference", function()
   end)
 end)
 
+-- A note you walked away from is worth more than the keystrokes it took, which is the whole
+-- argument for keeping one.
+describe("abandoning a note with text in it", function()
+  reset()
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "half a thought" })
+  h.feed("q")
+
+  annotate_line()
+  local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local composer_win = floating()
+  h.feed("q")
+
+  it("offers the text back the next time that file is annotated", function()
+    assert.same({ "half a thought" }, reopened)
+  end)
+
+  it("queued nothing on the way", function()
+    assert.same(0, queue.count())
+  end)
+
+  if composer_win and vim.api.nvim_win_is_valid(composer_win) then
+    vim.api.nvim_win_close(composer_win, true)
+  end
+end)
+
+describe("a restored draft", function()
+  local function footer_of(win)
+    local cfg_win = vim.api.nvim_win_get_config(win)
+    return cfg_win.footer and tostring(cfg_win.footer[1][1]) or ""
+  end
+
+  reset()
+  annotate_line()
+  local fresh_footer = footer_of(floating())
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "half a thought" })
+  h.feed("q")
+
+  local msgs, restore = h.capture_notify()
+  annotate_line()
+  restore()
+  local win = floating()
+  local restored_footer = footer_of(win)
+
+  it("is not advertised when there is nothing to discard", function()
+    assert.is_falsy(fresh_footer:find("^D", 1, true), fresh_footer)
+  end)
+
+  it("says that it restored one", function()
+    assert.is_true(h.notified(msgs, "Draft restored"), vim.inspect(msgs))
+  end)
+
+  it("offers the discard key while there is one", function()
+    assert.is_truthy(restored_footer:find("^D", 1, true), restored_footer)
+  end)
+
+  h.feed("<C-d>")
+  local emptied = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local discarded_footer = footer_of(win)
+
+  it("empties the composer when discarded", function()
+    assert.same({ "" }, emptied)
+  end)
+
+  it("stops offering the discard key once there is nothing to discard", function()
+    assert.is_falsy(discarded_footer:find("^D", 1, true), discarded_footer)
+  end)
+
+  -- The point of discarding: it is gone, not merely off screen.
+  h.feed("q")
+  annotate_line()
+  local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local last = floating()
+  h.feed("q")
+
+  it("does not come back after being discarded", function()
+    assert.same({ "" }, reopened)
+  end)
+
+  if last and vim.api.nvim_win_is_valid(last) then
+    vim.api.nvim_win_close(last, true)
+  end
+end)
+
+describe("a draft picked up and put down again", function()
+  reset()
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "first thought" })
+  h.feed("q")
+
+  annotate_line() -- restores it
+  h.feed("q") -- and abandons it again, untouched
+
+  annotate_line()
+  local twice = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local win = floating()
+  h.feed("q")
+
+  it("is still there the third time", function()
+    assert.same({ "first thought" }, twice)
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end)
+
+describe("a draft whose note gets submitted", function()
+  reset()
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "not finished yet" })
+  h.feed("q")
+
+  annotate_line() -- restores it
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "finished now" })
+  h.feed("<C-s>")
+
+  annotate_line()
+  local after = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local win = floating()
+  h.feed("q")
+
+  it("queued the note that was actually sent", function()
+    assert.same(1, queue.count())
+    assert.same("finished now", queue.all()[1].note)
+  end)
+
+  -- A note you have already made must never come back as a draft.
+  it("leaves nothing behind to restore", function()
+    assert.same({ "" }, after)
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end)
+
+-- A note about one file surfacing while you annotate another would be worse than losing it.
+describe("a draft belonging to another file", function()
+  reset()
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "about the first file" })
+  h.feed("q")
+
+  annotate_other_file()
+  local other = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  h.feed("q")
+
+  annotate_line()
+  local original = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local win = floating()
+  h.feed("q")
+
+  it("does not surface on a different file", function()
+    assert.same({ "" }, other)
+  end)
+
+  it("is still waiting on the file it belongs to", function()
+    assert.same({ "about the first file" }, original)
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end)
+
+-- Annotating a file in the review and capturing it from an ordinary buffer are the same
+-- thought about the same code. They meet the same draft, which is only true because the key
+-- is the absolute path -- the one name both paths already agree on.
+describe("a draft started in the review and reopened from the buffer", function()
+  reset()
+  local path = V.files[V.render.anchors[row_of("line")].file].path
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "same thought, either way" })
+  h.feed("q")
+
+  vim.cmd("tabedit " .. vim.fn.fnameescape(path))
+  require("codereview").annotate("bug")
+  local captured = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local win = floating()
+  h.feed("q")
+  vim.cmd("tabclose")
+
+  it("is offered back to capture, not just to the review", function()
+    assert.same({ "same thought, either way" }, captured)
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end)
+
+-- The two below write the store directly. Neither state can be reached through the
+-- composer: you cannot corrupt a file by annotating, and you cannot wait a week.
+describe("a draft store that cannot be read", function()
+  reset()
+  vim.fn.mkdir(vim.fs.dirname(drafts.path()), "p")
+  vim.fn.writefile({ "{ this is not json" }, drafts.path())
+
+  local msgs, restore = h.capture_notify()
+  annotate_line()
+  local opened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  restore()
+  local win = floating()
+  h.feed("q")
+
+  -- Failing here would cost the note you were about to write in order to report one you
+  -- had already abandoned, which is the wrong way round.
+  it("opens an empty composer instead of erroring", function()
+    assert.is_truthy(win, "the composer never opened")
+    assert.same({ "" }, opened)
+  end)
+
+  it("says nothing about a draft", function()
+    assert.is_false(h.notified(msgs, "Draft restored"), vim.inspect(msgs))
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end)
+
+describe("a draft old enough to have aged out", function()
+  reset()
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "long forgotten" })
+  h.feed("q")
+
+  -- Backdate what was just written, rather than wait a week for it.
+  local raw = vim.json.decode(table.concat(vim.fn.readfile(drafts.path()), "\n"))
+  for _, entry in pairs(raw.drafts) do
+    entry.at = os.time() - 30 * 24 * 60 * 60
+  end
+  vim.fn.writefile({ vim.json.encode(raw) }, drafts.path())
+
+  annotate_line()
+  local opened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local win = floating()
+  h.feed("q")
+
+  it("is pruned rather than restored", function()
+    assert.same({ "" }, opened)
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end)
+
 -- Reconfigures, so it comes after everything that wants a picker. The plugin ships none:
 -- every config already has one, and `@` staying a literal `@` is what "the composer is
 -- still fully usable without it" means.
 describe("with no file picker wired", function()
   require("codereview").setup({ syntax = false })
-  queue.clear()
+  reset()
   annotate_line()
   local composer_win = floating()
   h.feed("ilook at @")
@@ -507,7 +783,7 @@ describe("with a composer wired", function()
       on_accept(nil, "from the host's composer")
     end,
   })
-  queue.clear()
+  reset()
   annotate_line()
 
   it("does not open the built-in composer", function()

--- a/tests/codereview/drafts_child.lua
+++ b/tests/codereview/drafts_child.lua
@@ -1,0 +1,49 @@
+-- The first half of drafts_spec: a Neovim that abandons a half-written note and exits.
+--
+-- Deliberately a separate process. A draft is only meaningfully restored across a genuine
+-- restart -- reopening the composer twice in one process proves nothing about what reached
+-- the disk, because the value never left memory.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- drafts_spec with XDG_STATE_HOME and FIXTURE in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+-- No `compose`: the composer that keeps drafts is the plugin's own.
+require("codereview").setup({ syntax = false })
+
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+local annotate = require("codereview.annotate")
+
+view.open("branch")
+local V = assert(view.current(), "the review view did not open")
+queue.clear()
+
+local row, path
+for r = 1, vim.api.nvim_buf_line_count(V.buf) do
+  local a = V.render.anchors[r]
+  if a and a.kind == "line" then
+    row, path = r, V.files[a.file].path
+    break
+  end
+end
+assert(row, "no annotatable line in the render")
+
+vim.api.nvim_set_current_win(V.win)
+vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+annotate.annotate("bug")
+
+-- Written, then walked away from -- which is the only way a draft is ever made.
+vim.api.nvim_buf_set_lines(0, 0, -1, false, { "written in an earlier session" })
+vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("q", true, false, true), "x", false)
+
+-- Nothing is reported back. The spec opens the same fixture at the same scope and finds
+-- the same first annotatable line, so both processes are talking about the same file
+-- without having to pass its name between them -- and `qa!` would not reliably flush it.
+local _ = path
+vim.cmd("qa!")

--- a/tests/codereview/drafts_spec.lua
+++ b/tests/codereview/drafts_spec.lua
@@ -1,0 +1,70 @@
+-- A draft outliving the session it was written in.
+--
+-- Two processes, because one cannot answer the question. Reopening the composer twice in a
+-- single Neovim restores from a table that never left memory, and would pass whether or not
+-- anything reached the disk.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mktree")
+
+local drafts = require("codereview.drafts")
+
+describe("the writing session", function()
+  -- The child shares this process's throwaway XDG_STATE_HOME and nothing else. `--clean`
+  -- so no user config, and no minimal_init, can hand it a different one.
+  local proc = vim.system({
+    vim.v.progpath,
+    "--clean",
+    "-l",
+    vim.fs.joinpath(h.root, "tests", "codereview", "drafts_child.lua"),
+  }, {
+    cwd = fixture,
+    text = true,
+    env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = fixture },
+  })
+  local child = proc:wait(60000)
+
+  it("exits cleanly", function()
+    assert.same(0, child.code, (child.stderr or "") .. (child.stdout or ""))
+  end)
+
+  it("leaves a draft store behind", function()
+    assert.same(1, vim.fn.filereadable(drafts.path()), "no drafts at " .. drafts.path())
+  end)
+
+  describe("the session that follows", function()
+    require("codereview").setup({ syntax = false })
+    local view = require("codereview.view")
+    local queue = require("codereview.queue")
+    local annotate = require("codereview.annotate")
+
+    view.open("branch")
+    local V = assert(view.current(), "the review view did not open")
+    queue.clear()
+
+    -- The same first annotatable line the child took. Same fixture, same scope, same
+    -- dimensions, so the render is the same and both sessions mean the same file.
+    local row
+    for r = 1, vim.api.nvim_buf_line_count(V.buf) do
+      local a = V.render.anchors[r]
+      if a and a.kind == "line" then
+        row = r
+        break
+      end
+    end
+
+    it("finds the file the earlier session annotated", function()
+      assert.is_truthy(row, "no annotatable line in the render")
+    end)
+
+    vim.api.nvim_set_current_win(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { assert(row), 0 })
+    annotate.annotate("bug")
+    local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+    it("opens the composer holding what the earlier one abandoned", function()
+      assert.same({ "written in an earlier session" }, reopened)
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #28.

Abandon the composer with something in it and the text is kept. Annotate that file again and
it is offered back, with `^D` to discard and start clean. Submitting clears it, so what you
have already said never comes back.

### Its own store

A draft is not review progress. The review document is rewritten every time the queue
changes and a draft has nothing to do with the queue, so drafts live in `drafts.json` beside
it rather than inside it.

The sweep matches the no-repository queue's — untouched for a week and it is dropped on the
next read, swept on load because that is the only moment the store is read. One deliberate
difference: the timestamp *refreshes* on every write, where the queue's is stamped once. A
draft you came back to and put down again is a draft you are still thinking about.

### Keyed by absolute path

This is the whole reason the review view and buffer capture meet the same draft — they are
the same thought about the same code. Both paths already carry a canonical absolute path:
the review joins the realpath'd git root, capture realpaths the buffer name. It is also the
only name that survives a file having no repository at all, which a repo-relative key would
not.

There is a test for exactly this: start a note in the review, abandon it, then capture the
same file from an ordinary buffer in another tab and find the draft waiting. That was the
design's main risk and it holds.

### A store that cannot be read is no drafts

Erroring there would happen on the way *into* the composer — costing you the note you were
about to write in order to report one you had already abandoned. Wrong way round.

### What the tests found

**Adding drafts broke three existing tests, correctly.** Blocks that assumed an empty
composer were inheriting a draft left by an earlier `q`. They now say what they assume, the
same way they already say they want an empty queue. Two of those teardowns turned out to be
*abandoning* rather than merely leaving insert mode: feeding `<Esc>` between `nvim_feedkeys`
calls arrives in normal mode, so it reached the mapping — the same inter-feed quirk that bit
in #30.

**Cross-restart needs a second process.** In one Neovim the value never leaves memory, so
reopening the composer twice would pass whether or not anything reached the disk. A child
writes and abandons; the parent opens the same fixture at the same scope and finds the draft.
The child reports nothing back — `qa!` does not reliably flush stdout, and both sessions can
find the same file independently.

**The sweep was mutation-checked.** Drop the age comparison and the pruning case goes red, so
it is guarding rather than passing along with everything else.

478 passing.
