### PR TITLE
feat(annotate): let a reviewer decline an annotation type

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ file you are looking at; with no type it offers the same picker `aa` does.
 
 ```lua
 require("codereview").annotate("bug")  -- the selection, or the whole file
-require("codereview").annotate()       -- pick the type from a menu
+require("codereview").annotate()       -- pick the type from a menu, or decline one
 ```
 
 That is the entry point to bind a key to — nothing needs to reach into the plugin's
@@ -110,7 +110,7 @@ path, and inlines its code when it cannot. The buffer itself is never touched.
 | Key | Action |
 | --- | --- |
 | `ab` `af` `as` `an` `ai` | Annotate as bug / fix / suggestion / nitpick / issue |
-| `aa` | Annotate, picking the type from a menu |
+| `aa` | Annotate, picking the type from a menu or declining one |
 | `x` | Drop the annotation under the cursor |
 | `R` | Toggle reviewed on this file (collapses it) |
 | `za` | Toggle expansion without marking reviewed |
@@ -214,9 +214,20 @@ missing `name` or `key`, a duplicate of either, a `key` of `a` (which would shad
 `aa` type picker), or a field of the wrong type. Start from the shipped set with
 `require("codereview.types").defaults`.
 
+### No type
+
+The picker's last entry, after every configured type, is `no type`. It queues an untyped
+annotation: a remark worth reading with no instruction attached. It is an entry like any
+other — it shows on the diff, it is listed in the queue and it goes out with the batch —
+and its group renders last, under a bare `## Untyped (n)` heading, because a group with
+nothing to instruct has no directive to state.
+
+Declining is not dismissing. Pressing escape still abandons the annotation entirely.
+
 ## The payload
 
-Grouped by type, in the configured order, most actionable first:
+Grouped by type, in the configured order, most actionable first, with anything untyped
+last:
 
 ````markdown
 Code review — 4 annotations on branch vs origin/master (8 files, 6 reviewed)
@@ -236,6 +247,12 @@ was this dropped on purpose?
 
 ## Nitpicks (1) — low priority — batch these together
 ...
+
+## Untyped (1)
+
+### 4. @apps/api/src/db.ts#L8
+
+worth a look before we ship this
 ````
 
 ## Adapters

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -329,15 +329,36 @@ function M.annotate(type_name)
   M.annotate_target(V, target, type_def.name)
 end
 
----Pick the type from a menu, then annotate.
-function M.annotate_pick()
-  local cfg = config.get()
+---Offer the configured types, plus an explicit way to decline one.
+---
+---Declining is an entry in the menu rather than a second meaning for dismissing it. The
+---picker's only non-selection outcome is cancel, and cancel abandons the annotation
+---outright, so reusing it would make "no type" indistinguishable from "never mind".
+---
+---Shared by the review path and by buffer capture, which offered the same menu twice.
+---@param list CRType[]
+---@param cb fun(type_def: CRType|nil) Untyped when nil; not called at all if dismissed
+function M.pick_type(list, cb)
   local labels = vim.tbl_map(function(t)
     return ("%s  %s"):format(t.icon, t.name)
-  end, cfg.types)
+  end, list)
+  -- Appended, so every configured type keeps the position a reviewer already reaches for.
+  labels[#labels + 1] = ("%s  no type"):format(types.UNTYPED.icon)
 
+  vim.ui.select(labels, { prompt = "Annotation type:" }, function(_, index)
+    if not index then
+      return
+    end
+    -- One past the type list is the decline entry, where `list[index]` is nil: an untyped
+    -- annotation, which is not the dismissal above and must not be answered like one.
+    cb(list[index])
+  end)
+end
+
+---Pick the type from a menu, then annotate.
+function M.annotate_pick()
   -- The selection has to be read before vim.ui.select steals the mode, so resolve the
-  -- target first and hand the already-resolved type name to the normal path.
+  -- target first and hand the already-resolved type to the normal path.
   local V = require("codereview.view").current()
   if not V then
     return
@@ -348,11 +369,8 @@ function M.annotate_pick()
     return
   end
 
-  vim.ui.select(labels, { prompt = "Annotation type:" }, function(_, index)
-    if not index then
-      return
-    end
-    M.annotate_target(V, target, cfg.types[index].name)
+  M.pick_type(config.get().types, function(type_def)
+    M.annotate_target(V, target, type_def and type_def.name)
   end)
 end
 
@@ -363,11 +381,16 @@ end
 ---captured, and that is only true if one piece of code decides the composer context, the
 ---persistence call, the wording of the confirmation and where focus lands afterwards.
 ---@param entry CRAnnotation
----@param type_def CRType
+---@param type_def CRType|nil nil for an untyped annotation
 ---@param opts? { note_suffix?: string } Appended below the collected note. Buffer capture
 ---       uses it to carry diagnostics; the review path has nothing to add.
 function M.queue_entry(entry, type_def, opts)
-  entry.type = type_def.name
+  -- Left unset rather than stamped with a sentinel, so anything asking an entry which type
+  -- it carries gets the honest answer -- and so no configurable name can ever collide with
+  -- one the plugin reserved.
+  entry.type = type_def and type_def.name
+  -- The untyped group stands in wherever the annotation still has to be named.
+  local type_label = (type_def or types.UNTYPED).label
   -- Before anything is added, not after: persisting writes the in-memory queue over the
   -- document, so queueing into a queue this session has never read back would drop
   -- whatever the last session left. A review view has already restored by the time it
@@ -376,7 +399,7 @@ function M.queue_entry(entry, type_def, opts)
   collect(
     {
       scope = "none",
-      label = ("%s · %s"):format(type_def.label:gsub("s$", ""), M.describe(entry)),
+      label = ("%s · %s"):format(type_label:gsub("s$", ""), M.describe(entry)),
       rel_path = entry.path,
       file_path = entry.abs_path,
     },
@@ -388,7 +411,7 @@ function M.queue_entry(entry, type_def, opts)
       local view = require("codereview.view")
       view.paint()
       view.persist()
-      info(("Queued %s %s (%d in queue)"):format(type_def.name, M.describe(entry), queue.count()))
+      info(("Queued %s %s (%d in queue)"):format(entry.type or "untyped", M.describe(entry), queue.count()))
     end
   )
 end
@@ -396,11 +419,10 @@ end
 ---Annotate a target that was resolved earlier.
 ---@param V CRView
 ---@param target CRTarget
----@param type_name string
+---@param type_name string|nil nil annotates without a type
 function M.annotate_target(V, target, type_name)
-  local cfg = config.get()
-  local type_def = types.get(cfg.types, type_name)
-  if not type_def then
+  local type_def = type_name and types.get(config.get().types, type_name)
+  if type_name and not type_def then
     return
   end
   if target.clamped then
@@ -439,7 +461,7 @@ function M.drop()
   view.paint()
   view.persist()
   if removed then
-    info(("Dropped %s note (%d left)"):format(removed.type, queue.count()))
+    info(("Dropped %s note (%d left)"):format(removed.type or "untyped", queue.count()))
   end
 end
 

--- a/lua/codereview/capture.lua
+++ b/lua/codereview/capture.lua
@@ -219,14 +219,10 @@ function M.annotate(type_name, range)
     return
   end
 
-  local labels = vim.tbl_map(function(t)
-    return ("%s  %s"):format(t.icon, t.name)
-  end, cfg.types)
-  vim.ui.select(labels, { prompt = "Annotation type:" }, function(_, index)
-    if not index then
-      return
-    end
-    annotate.queue_entry(entry, cfg.types[index], opts)
+  -- The same menu the review view offers, including its way of declining a type outright:
+  -- which types exist, and how you say "none of them", cannot depend on where you asked.
+  annotate.pick_type(cfg.types, function(chosen)
+    annotate.queue_entry(entry, chosen, opts)
   end)
 end
 

--- a/lua/codereview/payload.lua
+++ b/lua/codereview/payload.lua
@@ -3,6 +3,8 @@
 ---References are resolved at submit time, not at capture time, because the same queue can
 ---be sent to an agent whose working directory differs from this Neovim's -- an `@ref` only
 ---resolves relative to whoever reads it.
+local types = require("codereview.types")
+
 local M = {}
 
 ---Canonical form of a directory refs will be resolved against.
@@ -137,21 +139,10 @@ function M.render(items, base, opts)
   -- canonical, and `base` is the only side that never went through git or a realpath.
   base = M.resolve_base(base)
 
-  -- Grouped here rather than through queue.lua so this stays a pure function of its
-  -- arguments: the same list always renders the same message, which is what makes the
-  -- payload testable without a view or a live queue.
-  local groups = {}
-  for _, t in ipairs(opts.types) do
-    local bucket = {}
-    for _, entry in ipairs(items) do
-      if entry.type == t.name then
-        bucket[#bucket + 1] = entry
-      end
-    end
-    if #bucket > 0 then
-      groups[#groups + 1] = { type = t, items = bucket }
-    end
-  end
+  -- Grouped from the arguments rather than through queue.lua, so this stays a pure
+  -- function of them: the same list always renders the same message, which is what makes
+  -- the payload testable without a view or a live queue.
+  local groups = types.group(items, opts.types)
 
   local total = #items
   local header = ("Code review — %d annotation%s"):format(total, total == 1 and "" or "s")

--- a/lua/codereview/queue.lua
+++ b/lua/codereview/queue.lua
@@ -91,28 +91,6 @@ function M.at(key)
   return M.by_key()[key] or {}
 end
 
----Annotations bucketed by type, in the configured type order.
----
----Order comes from the type list rather than insertion order so the payload always leads
----with the most actionable group, whatever sequence you happened to write them in.
----@param types CRType[]
----@return { type: CRType, items: CRAnnotation[] }[]
-function M.grouped(types)
-  local out = {}
-  for _, t in ipairs(types) do
-    local bucket = {}
-    for _, item in ipairs(items) do
-      if item.type == t.name then
-        bucket[#bucket + 1] = item
-      end
-    end
-    if #bucket > 0 then
-      out[#out + 1] = { type = t, items = bucket }
-    end
-  end
-  return out
-end
-
 ---@return integer
 function M.stale_count()
   local n = 0

--- a/lua/codereview/types.lua
+++ b/lua/codereview/types.lua
@@ -146,6 +146,38 @@ function M.normalise(list, opts)
   return out
 end
 
+---@class CRGroup
+---@field type CRType Configured type
+---@field items CRAnnotation[]
+
+---Bucket annotations by annotation type, in the configured type order.
+---
+---One helper rather than one loop per consumer: the queue float and the payload renderer
+---both group, and while they each owned a copy the two could -- and did -- drift into
+---disagreeing about what the queue contains.
+---
+---Pure, and deliberately takes the list rather than reading the queue: the payload
+---renderer is a pure function of its arguments, which is what lets a payload be asserted
+---without a live queue or a review view. Grouping through the queue would end that.
+---@param items CRAnnotation[]
+---@param list CRType[]
+---@return CRGroup[]
+function M.group(items, list)
+  local out = {}
+  for _, t in ipairs(list) do
+    local bucket = {}
+    for _, item in ipairs(items) do
+      if item.type == t.name then
+        bucket[#bucket + 1] = item
+      end
+    end
+    if #bucket > 0 then
+      out[#out + 1] = { type = t, items = bucket }
+    end
+  end
+  return out
+end
+
 ---@param list CRType[]
 ---@param name string
 ---@return CRType|nil

--- a/lua/codereview/types.lua
+++ b/lua/codereview/types.lua
@@ -146,8 +146,20 @@ function M.normalise(list, opts)
   return out
 end
 
+---The group an annotation with no annotation type falls into.
+---
+---Not a configured type and never one: it has no `name`, so nothing can be annotated *as*
+---untyped and no entry ever stores it. It exists so that both renderers have a heading and
+---a mark to print for a remark that carries no instruction. No `directive` for the same
+---reason -- a group with nothing to instruct should not pretend otherwise.
+---
+---The mark matches the one `render.lua` already prints for an annotation whose type it
+---cannot resolve, so an untyped note looks the same on the diff as it does in the queue.
+---@type CRType
+M.UNTYPED = { label = "Untyped", icon = "•" }
+
 ---@class CRGroup
----@field type CRType Configured type
+---@field type CRType Configured type, or `M.UNTYPED`
 ---@field items CRAnnotation[]
 
 ---Bucket annotations by annotation type, in the configured type order.
@@ -163,8 +175,9 @@ end
 ---@param list CRType[]
 ---@return CRGroup[]
 function M.group(items, list)
-  local out = {}
+  local out, configured = {}, {}
   for _, t in ipairs(list) do
+    configured[t.name] = true
     local bucket = {}
     for _, item in ipairs(items) do
       if item.type == t.name then
@@ -175,6 +188,23 @@ function M.group(items, list)
       out[#out + 1] = { type = t, items = bucket }
     end
   end
+
+  -- Last, after every typed group: an untyped annotation is worth reading, but a group
+  -- with no directive has nothing to ask for, so it does not belong above the ones that do.
+  --
+  -- Everything the loop above could not place, rather than only the entries carrying no
+  -- type at all: a queue persisted before a host dropped a type from its list restores
+  -- entries naming one that is gone, and those were being discarded just as silently.
+  local untyped = {}
+  for _, item in ipairs(items) do
+    if not configured[item.type] then
+      untyped[#untyped + 1] = item
+    end
+  end
+  if #untyped > 0 then
+    out[#out + 1] = { type = M.UNTYPED, items = untyped }
+  end
+
   return out
 end
 

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -956,7 +956,9 @@ function M.review_queue()
     local lines = {}
     anchors = {}
     local index = 0
-    for _, group in ipairs(queue.grouped(cfg.types)) do
+    -- The same helper the payload renders through, handed the same list: what the float
+    -- shows and what the batch says have to be the one grouping, not two that agree today.
+    for _, group in ipairs(require("codereview.types").group(queue.all(), cfg.types)) do
       local heading = ("## %s"):format(group.type.label)
       if group.type.directive and group.type.directive ~= "" then
         heading = heading .. (" — %s"):format(group.type.directive)

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit |
-| `capture_spec` | Annotating from an ordinary buffer: scope, types, blob, composer, diagnostics, restart, one queue |
+| `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,7 +33,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 
 | Spec | Covers |
 | --- | --- |
-| `types_spec` | Configuring annotation types: defaulting, validation, a custom type end to end |
+| `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
 | `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling |
 | `syntax_spec` | Treesitter harvest/replay, caching, guardrails |

--- a/tests/README.md
+++ b/tests/README.md
@@ -103,6 +103,10 @@ so the out-of-core language path is still checked locally without ever failing C
 - **`nvim -l` sends `print` to stderr, not stdout.** A child spawned with `-l` that reports
   its result through `print` has to be read from `stderr`, or from both streams. Asserting
   against `stdout` alone silently never matches.
+- **An empty environment variable does not reach a child.** `vim.system` drops an env entry
+  whose value is `""`, so a child cannot tell "set to empty" from "never set". A flag a
+  child branches on has to be absent or carry a real value — `capture_child.lua` declines a
+  type when `CAPTURE_TYPE` is absent, not when it is blank.
 - **git config is neutralised.** Both the fixture scripts and `minimal_init.lua` set
   `GIT_CONFIG_GLOBAL=/dev/null`. Inherited settings quietly change what a fixture means:
   `diff.renames = false` turns the rename case into an unrelated add plus delete, and

--- a/tests/codereview/annotate_spec.lua
+++ b/tests/codereview/annotate_spec.lua
@@ -326,7 +326,7 @@ describe("grouping the queue", function()
   -- Groups follow the configured type order, not the order notes were captured, so a
   -- reviewer reads bugs before nitpicks however they were written.
   it("orders groups by type, not by capture order", function()
-    local groups = queue.grouped(config.get().types)
+    local groups = require("codereview.types").group(queue.all(), config.get().types)
     assert.same(
       { "bug:2", "nitpick:1", "issue:1" },
       vim.tbl_map(function(g)

--- a/tests/codereview/annotate_spec.lua
+++ b/tests/codereview/annotate_spec.lua
@@ -316,6 +316,62 @@ describe("dropping annotations", function()
   end)
 end)
 
+-- The review path offers the same menu and the same way out of it: an annotation made over
+-- the diff has no more need to invent a type than one captured from a buffer.
+describe("declining a type over the diff", function()
+  queue.clear()
+  at(add_row)
+
+  local orig = vim.ui.select
+  vim.ui.select = function(items, _, cb)
+    cb(items[#items], #items)
+  end
+  annotate.annotate_pick()
+  vim.ui.select = orig
+
+  it("queues the annotation carrying no type", function()
+    assert.same(1, queue.count())
+    assert.is_nil(queue.all()[1].type)
+  end)
+
+  it("anchors it exactly as a typed annotation would be", function()
+    assert.same({ "src/fresh.lua:n:1", "line" }, { queue.all()[1].key, queue.all()[1].kind })
+  end)
+
+  it("titles the composer without inventing a type", function()
+    assert.same("Untyped · src/fresh.lua:1", last_ctx.label)
+  end)
+
+  -- The inline renderer already had a fallback for an annotation whose type it cannot
+  -- resolve. Until now nothing could produce one, so this is the first thing to reach it.
+  it("still projects onto the diff", function()
+    view.paint()
+    assert.same(1, #h.virt_marks(V))
+  end)
+
+  it("says what it dropped without naming a type it never had", function()
+    local msgs, restore = h.capture_notify()
+    at(add_row)
+    annotate.drop()
+    restore()
+    assert.same(0, queue.count())
+    assert.is_true(h.notified(msgs, "Dropped untyped note"), vim.inspect(msgs))
+  end)
+
+  -- Escape still means never mind, on this path as on the other.
+  it("abandons the annotation when the picker is dismissed instead", function()
+    queue.clear()
+    at(add_row)
+    local dismiss = vim.ui.select
+    vim.ui.select = function(_, _, cb)
+      cb(nil, nil)
+    end
+    annotate.annotate_pick()
+    vim.ui.select = dismiss
+    assert.same(0, queue.count())
+  end)
+end)
+
 describe("grouping the queue", function()
   queue.clear()
   for _, t in ipairs({ "nitpick", "bug", "issue", "bug" }) do

--- a/tests/codereview/capture_child.lua
+++ b/tests/codereview/capture_child.lua
@@ -16,7 +16,10 @@ vim.o.lines = 40
 local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
 local file = assert(vim.env.CAPTURE_FILE, "CAPTURE_FILE is not set")
 local note = assert(vim.env.CAPTURE_NOTE, "CAPTURE_NOTE is not set")
-local type_name = assert(vim.env.CAPTURE_TYPE, "CAPTURE_TYPE is not set")
+-- The one optional variable: with no type named, the child declines one below. An empty
+-- string would not do as the signal -- `vim.system` drops an empty value, so the child
+-- cannot tell it from a variable nobody set.
+local type_name = vim.env.CAPTURE_TYPE
 
 vim.cmd("cd " .. vim.fn.fnameescape(fixture))
 
@@ -31,7 +34,17 @@ codereview.setup({
 local queue = require("codereview.queue")
 
 vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, file)))
-codereview.annotate(type_name)
+
+if type_name then
+  codereview.annotate(type_name)
+else
+  -- Declining is the only way to reach an untyped annotation through the public entry
+  -- point, and the decline entry is the last one the picker offers.
+  vim.ui.select = function(items, _, cb)
+    cb(items[#items], #items)
+  end
+  codereview.annotate()
+end
 
 -- The count is the whole point of the second run: it can only include the first session's
 -- annotation if capture restored the persisted queue before adding to it.

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -228,33 +228,41 @@ describe("the user command", function()
   end)
 end)
 
+---One capture, in a process of its own.
+---@param file string
+---@param type_name string|nil nil declines a type, for an untyped annotation
+---@param note string
+local function session(file, type_name, note)
+  return vim
+    .system({
+      vim.v.progpath,
+      "--clean",
+      "-l",
+      vim.fs.joinpath(h.root, "tests", "codereview", "capture_child.lua"),
+    }, {
+      cwd = fixture,
+      text = true,
+      env = {
+        XDG_STATE_HOME = vim.env.XDG_STATE_HOME,
+        FIXTURE = fixture,
+        CAPTURE_FILE = file,
+        CAPTURE_TYPE = type_name,
+        CAPTURE_NOTE = note,
+      },
+    })
+    :wait(60000)
+end
+
+-- `nvim -l` sends `print` to stderr, so the child's report is read from both streams
+-- rather than from stdout alone.
+---@param child table
+---@return string
+local function output(child)
+  return (child.stdout or "") .. (child.stderr or "")
+end
+
 describe("capturing across a restart", function()
   local state = require("codereview.state")
-
-  ---One capture, in a process of its own.
-  ---@param file string
-  ---@param type_name string
-  ---@param note string
-  local function session(file, type_name, note)
-    return vim
-      .system({
-        vim.v.progpath,
-        "--clean",
-        "-l",
-        vim.fs.joinpath(h.root, "tests", "codereview", "capture_child.lua"),
-      }, {
-        cwd = fixture,
-        text = true,
-        env = {
-          XDG_STATE_HOME = vim.env.XDG_STATE_HOME,
-          FIXTURE = fixture,
-          CAPTURE_FILE = file,
-          CAPTURE_TYPE = type_name,
-          CAPTURE_NOTE = note,
-        },
-      })
-      :wait(60000)
-  end
 
   -- A clean slate on both sides, so what the two sessions write is all that is on disk.
   queue.clear()
@@ -267,14 +275,6 @@ describe("capturing across a restart", function()
     assert.same(0, first.code, (first.stderr or "") .. (first.stdout or ""))
     assert.same(0, second.code, (second.stderr or "") .. (second.stdout or ""))
   end)
-
-  -- `nvim -l` sends `print` to stderr, so the child's report is read from both streams
-  -- rather than from stdout alone.
-  ---@param child table
-  ---@return string
-  local function output(child)
-    return (child.stdout or "") .. (child.stderr or "")
-  end
 
   it("the first session persisted its annotation", function()
     assert.is_true(output(first):find("queued: 1", 1, true) ~= nil, output(first))
@@ -306,6 +306,57 @@ describe("capturing across a restart", function()
     assert.same({ "bug", "nitpick" }, { saved[1].type, saved[2].type })
     assert.same(h.git_lines(root, { "hash-object", "src/main.lua" })[1], saved[1].blob)
     assert.same(h.git_lines(root, { "hash-object", "src/routes.lua" })[1], saved[2].blob)
+  end)
+end)
+
+-- An entry with no type has to survive a restart like any other. Two processes for the
+-- reason the case above needs two: the queue is restored once per session, so a session
+-- that already restored cannot observe what restoring does to what the last one left.
+describe("an untyped annotation across a restart", function()
+  local state = require("codereview.state")
+
+  queue.clear()
+  state.clear(root)
+
+  local declined = session("src/main.lua", nil, "no instruction attached")
+  local later = session("src/routes.lua", "bug", "from a later session")
+
+  it("both sessions exit cleanly", function()
+    assert.same(0, declined.code, output(declined))
+    assert.same(0, later.code, output(later))
+  end)
+
+  it("queued the declined annotation rather than abandoning it", function()
+    assert.is_true(output(declined):find("queued: 1", 1, true) ~= nil, output(declined))
+  end)
+
+  -- Written with the field absent, not with a placeholder standing in for one: an entry
+  -- restored into a session whose host renamed its types must still read as untyped.
+  it("wrote it to disk carrying no type at all", function()
+    local saved = state.load(root).queue
+    assert.same("no instruction attached", saved[1].note)
+    assert.is_nil(saved[1].type)
+  end)
+
+  it("kept everything else an annotation carries", function()
+    local saved = state.load(root).queue
+    assert.same("src/main.lua", saved[1].path)
+    assert.same(h.git_lines(root, { "hash-object", "src/main.lua" })[1], saved[1].blob)
+  end)
+
+  -- The restore half: the later session captured one and ended up holding two, which is
+  -- only possible if the untyped entry came back off disk instead of being dropped.
+  it("is restored by the next session, not discarded on the way back", function()
+    assert.is_true(output(later):find("queued: 2", 1, true) ~= nil, output(later))
+  end)
+
+  it("still groups as untyped once restored", function()
+    local saved = state.load(root).queue
+    local groups = require("codereview.types").group(saved, require("codereview.config").get().types)
+    local labels = vim.tbl_map(function(g)
+      return g.type.label
+    end, groups)
+    assert.same({ "Bugs", "Untyped" }, labels)
   end)
 end)
 

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -104,12 +104,68 @@ describe("with no type given", function()
 
   it("offers the type picker", function()
     assert.is_truthy(prompt, "no picker was offered")
-    assert.same(#require("codereview.config").get().types, #offered)
+    assert.same(#require("codereview.config").get().types + 1, #offered)
   end)
 
   it("queues with the type that was picked", function()
     assert.same(1, queue.count())
     assert.same("fix", queue.all()[1].type)
+  end)
+end)
+
+-- A reviewer with no instruction to attach should not have to invent one. Declining is an
+-- answer, so it is an entry in the picker rather than a way of dismissing it.
+describe("declining a type", function()
+  local offered
+  local orig = vim.ui.select
+  vim.ui.select = function(items, _, cb)
+    offered = items
+    cb(items[#items], #items)
+  end
+
+  queue.clear()
+  edit("src/main.lua")
+  codereview.annotate()
+  vim.ui.select = orig
+
+  it("offers declining after every type, never before one", function()
+    assert.is_truthy(offered[#offered]:find("no type", 1, true), vim.inspect(offered))
+    for i = 1, #offered - 1 do
+      assert.is_nil(offered[i]:find("no type", 1, true), vim.inspect(offered))
+    end
+  end)
+
+  it("queues the annotation carrying no type", function()
+    assert.same(1, queue.count())
+    assert.is_nil(queue.all()[1].type)
+  end)
+
+  it("costs the type and nothing else", function()
+    assert.same("the note", queue.all()[1].note)
+    assert.same("src/main.lua", queue.all()[1].path)
+  end)
+end)
+
+-- Dismissing the picker still abandons the annotation entirely. The two were the same
+-- outcome while cancelling was the only way out of the picker without choosing.
+describe("cancelling the picker", function()
+  local orig = vim.ui.select
+  vim.ui.select = function(_, _, cb)
+    cb(nil, nil)
+  end
+
+  queue.clear()
+  local before = #composed
+  edit("src/main.lua")
+  codereview.annotate()
+  vim.ui.select = orig
+
+  it("queues nothing", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("never opens the composer", function()
+    assert.same(before, #composed)
   end)
 end)
 
@@ -569,6 +625,61 @@ describe("a range and a whole file together", function()
   end)
 end)
 
+-- An untyped annotation is a first-class entry: it appears wherever an entry appears. Both
+-- surfaces used to drop it, each through its own copy of the same grouping loop.
+describe("an untyped annotation in the queue and in the batch", function()
+  local view = require("codereview.view")
+  queue.clear()
+  local before_sent = #sent
+
+  local orig = vim.ui.select
+  vim.ui.select = function(items, _, cb)
+    cb(items[#items], #items)
+  end
+  edit("src/main.lua")
+  codereview.annotate()
+  vim.ui.select = orig
+
+  edit("src/routes.lua")
+  codereview.annotate("bug")
+
+  local float
+  view.review_queue()
+  do
+    local win = vim.api.nvim_get_current_win()
+    float = table.concat(vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, -1, false), "\n")
+    vim.api.nvim_win_close(win, true)
+  end
+
+  it("is listed in the queue float", function()
+    assert.is_truthy(float:find("## Untyped", 1, true), float)
+    assert.is_truthy(float:find("src/main.lua", 1, true), float)
+  end)
+
+  it("is listed after every typed group there", function()
+    assert.is_true(float:find("## Bugs", 1, true) < float:find("## Untyped", 1, true), float)
+  end)
+
+  it("carries no directive on its heading", function()
+    assert.is_truthy(float:find("## Untyped\n", 1, true), float)
+  end)
+
+  view.submit()
+
+  it("reaches the delivered payload, grouped and last", function()
+    assert.same(before_sent + 1, #sent)
+    local text = sent[#sent].text
+    assert.is_truthy(text:find("## Untyped (1)\n", 1, true), text)
+    assert.is_true(text:find("## Bugs", 1, true) < text:find("## Untyped", 1, true), text)
+  end)
+
+  it("travels with everything a typed annotation would have carried", function()
+    local text = sent[#sent].text
+    assert.is_truthy(text:find("@src/main.lua", 1, true), text)
+    assert.is_truthy(text:find("2 annotations", 1, true), text)
+  end)
+end)
+
 -- The two cases below reconfigure the plugin, so they come last.
 
 -- What a host that wires nothing gets is the plugin's own composer -- from capture exactly
@@ -675,7 +786,10 @@ describe("with a custom type vocabulary", function()
     codereview.annotate()
     vim.ui.select = orig
 
-    assert.same(2, #offered)
+    -- The host's two, then declining. Nothing the host did not configure is offered as a
+    -- type, and the way out of the menu without one does not depend on the vocabulary.
+    assert.same(3, #offered)
     assert.is_truthy(offered[1]:find("blocker", 1, true), vim.inspect(offered))
+    assert.is_truthy(offered[3]:find("no type", 1, true), vim.inspect(offered))
   end)
 end)

--- a/tests/codereview/payload_spec.lua
+++ b/tests/codereview/payload_spec.lua
@@ -155,6 +155,39 @@ describe("rendering a mixed queue in-tree", function()
   end)
 end)
 
+-- A remark worth reading with no instruction attached. It used to be dropped here: the
+-- renderer collected the entries matching each configured type, so one matching none never
+-- reached the agent at all.
+describe("rendering an untyped annotation", function()
+  -- Straight into the renderer, with a list built by hand: a payload is a pure function of
+  -- its arguments, so pinning this group needs neither a queue nor a review view.
+  local text = payload.render({
+    { kind = "note", type = "bug", note = "typed" },
+    { kind = "note", note = "no instruction attached" },
+  }, V.root, { types = config.get().types })
+
+  it("gives it a group of its own", function()
+    assert.is_truthy(text:find("## Untyped (1)", 1, true), text)
+  end)
+
+  it("renders it after every typed group", function()
+    assert.is_true(text:find("## Bugs", 1, true) < text:find("## Untyped", 1, true))
+  end)
+
+  -- A group with nothing to instruct should not pretend otherwise.
+  it("attaches no directive to the heading", function()
+    assert.is_truthy(text:find("## Untyped (1)\n", 1, true), text)
+  end)
+
+  it("numbers it in sequence with the typed entries", function()
+    assert.is_truthy(text:match("### 2%. %(no file%)"), text)
+  end)
+
+  it("carries its note", function()
+    assert.is_truthy(text:find("no instruction attached", 1, true), text)
+  end)
+end)
+
 describe("rendering for an out-of-tree target", function()
   -- The reader's cwd is somewhere else entirely, so `@src/...` would resolve against
   -- their tree, not ours. Every ref has to degrade to an absolute path plus the code.

--- a/tests/codereview/types_spec.lua
+++ b/tests/codereview/types_spec.lua
@@ -119,6 +119,42 @@ describe("rejecting a type list", function()
   end)
 end)
 
+-- One helper, shared by the queue float and the payload renderer, which used to carry a
+-- copy of this loop each. Pure: a plain list in, groups out, no queue and no view.
+describe("grouping annotations", function()
+  local list = {
+    { name = "bug", key = "b", label = "Bugs" },
+    { name = "nitpick", key = "n", label = "Nitpicks" },
+  }
+
+  ---@param groups table[]
+  local function shape(groups)
+    return vim.tbl_map(function(g)
+      return ("%s:%d"):format(g.type.label, #g.items)
+    end, groups)
+  end
+
+  -- Groups follow the configured type order, not the order notes were captured, so a
+  -- reviewer reads bugs before nitpicks however they were written.
+  it("buckets by type, in the configured order", function()
+    local groups = types.group({ { type = "nitpick" }, { type = "bug" }, { type = "bug" } }, list)
+    assert.same({ "Bugs:2", "Nitpicks:1" }, shape(groups))
+  end)
+
+  it("keeps capture order inside a group", function()
+    local first, second = { type = "bug", note = "one" }, { type = "bug", note = "two" }
+    assert.same({ first, second }, types.group({ first, second }, list)[1].items)
+  end)
+
+  it("omits a type nothing was annotated with", function()
+    assert.same({ "Bugs:1" }, shape(types.group({ { type = "bug" } }, list)))
+  end)
+
+  it("groups nothing when there is nothing to group", function()
+    assert.same({}, types.group({}, list))
+  end)
+end)
+
 describe("a custom type end to end", function()
   h.ui(110, 40)
   h.cd_fixture("mkfixture")

--- a/tests/codereview/types_spec.lua
+++ b/tests/codereview/types_spec.lua
@@ -153,6 +153,24 @@ describe("grouping annotations", function()
   it("groups nothing when there is nothing to group", function()
     assert.same({}, types.group({}, list))
   end)
+
+  it("collects annotations with no type into a group of their own, last", function()
+    local groups = types.group({ {}, { type = "bug" }, {} }, list)
+    assert.same({ "Bugs:1", "Untyped:2" }, shape(groups))
+  end)
+
+  -- A queue persisted before a host dropped a type from its list restores entries naming
+  -- one that no longer exists. They are still annotations someone wrote; the group with no
+  -- directive is where an entry the type list cannot account for belongs.
+  it("treats a type the list no longer configures as untyped", function()
+    assert.same({ "Untyped:1" }, shape(types.group({ { type = "retired" } }, list)))
+  end)
+
+  it("leaves the untyped group without a directive", function()
+    local group = types.group({ {} }, list)[1]
+    assert.is_nil(group.type.directive)
+    assert.is_nil(group.type.name)
+  end)
 end)
 
 describe("a custom type end to end", function()


### PR DESCRIPTION
An annotation with no **annotation type**: a remark worth reading with no instruction
attached. The type picker grows an explicit `no type` entry, and an **untyped annotation**
becomes a first-class **entry** everywhere an entry appears.

Closes #34

## The prefactor, first

The **queue** float and the **payload** renderer each carried the same grouping loop over
the configured types, character for character apart from the variable names — which is
exactly why the same defect lived in both: an entry matching no configured type was
silently dropped, so an untyped one would have vanished from the float *and* from the
delivered batch.

`types.group` is now the one helper both go through. It takes the entries as an argument
rather than reading the queue, so the payload renderer stays a pure function of what it is
handed — the property that lets a payload be asserted without a live queue or a **review
view**, and the reason it grouped inline in the first place. `queue.grouped` is gone rather
than left as a second name for the same thing.

That commit is behaviour-preserving and green on its own.

## Declining is not cancelling

Dismissing the picker was its only non-selection outcome, so answering "no type" through it
would have made abandoning the annotation and keeping it the same gesture. Declining is an
entry in the menu, appended after every configured type so each one keeps the position a
reviewer already reaches for. Escape still abandons the annotation entirely.

One picker, shared by the **review path** and the **capture path**, which offered the same
menu twice.

## What an untyped annotation gets

- Projected onto the diff — the inline renderer already tolerated a missing type; this is
  the first thing able to reach that fallback, so there is now a test on it.
- Listed in the queue float, and delivered in the batch, under `## Untyped (n)`.
- Rendered after every typed group, with a heading and **no directive**: a group with
  nothing to instruct should not pretend otherwise.
- Persisted with the `type` field absent rather than a placeholder standing in for one, and
  restored as an entry like any other.
- Stored with no type at all, so nothing a **host** can configure could ever collide with a
  name the plugin reserved.

The untyped bucket also catches an entry naming a type the host has since removed — a queue
persisted before a type was dropped from `opts.types` restores exactly those, and they were
being discarded just as silently.

Typed grouping is unchanged: same order, same headings, same directives.

## Tests

528 cases, up from 494. Payload grouping is asserted directly against the renderer over a
hand-built list, as `payload_spec` already does elsewhere. Persistence is two child
processes, for the reason the existing restart case needs two: the queue restores once per
session, so a session that already restored cannot observe what restoring does to what the
last one left.

Every new assertion was confirmed to fail against the behaviour it replaces before the fix
landed — the grouping ones by removing the untyped bucket, the diff-render one by removing
the renderer's nil-type fallback, and the persistence ones by dropping type-less entries on
the way out of the store.