### PR TITLE
fix(composer): leave the cursor where you can keep typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,18 @@ input loop, so `mode()` always reports `n` under `--headless` and a headless tes
 bug above passes whether or not the fix exists. That one is verified by driving a real
 Neovim over a pty and querying it with `--remote-expr`.
 
+**`startinsert` does nothing on the tick a picker answers on.** A picker that closes with
+`stopinsert` leaves the editor still reporting insert mode with the exit merely pending, so
+the composer's request to start inserting is dropped as redundant and the exit lands
+anyway. Reading `mode()` there is no help either — it reports the mode being left. The
+composer feeds `<C-\><C-n>` and then `i` or `A` instead, which the input loop applies once
+everything has settled, whichever mode the picker really left behind.
+
+**Normal mode cannot hold a cursor past the last character of a line.** Both places the
+composer positions a reviewer to keep typing — the end of a restored draft, the space after
+a spliced reference — are exactly that column, so setting it arrives one short. Entering
+insert with the bang (`startinsert!`, or `A` as a fed key) is what recovers it.
+
 **A picker must return focus to whoever opened it.** `pick_target` used to hardcode focus
 back to the diff window, so choosing an agent from the queue float dumped the cursor into
 the diff — where `<C-s>` hits the *main* buffer's mapping, which submits the batch but

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -220,12 +220,20 @@ into the note before the picker opens, so cancelling leaves the character you
 typed -- and it only opens a picker where a word begins, so an email address in
 a note is an email address.
 
+Either way you are left writing where the picker left off: past the reference
+and the space after it, or past the `@` if you cancelled, and back in insert
+mode. A picker takes focus and insert mode with it, and asking for a reference
+mid-sentence is not asking to stop writing.
+
 Drafts                                                  *codereview-drafts*
 
 Abandon the composer with something in it and the text is kept. Annotate that
 file again and it is offered back, with `^D` to discard it and start clean. A
 note you actually submit clears its draft, so what you have already said never
 comes back.
+
+A restored draft leaves the cursor at its end, so your next word continues the
+sentence rather than preceding it.
 
 Drafts are keyed by the file the note is about, not by the window it was
 started in: annotating a file in the review and capturing it from an ordinary

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -129,27 +129,55 @@ function M.open(ctx, on_accept, label)
       return
     end
     pick_file(function(chosen)
-      if not (chosen and chosen.path) then
+      -- Empty when the picker was dismissed, which is the whole point of writing the
+      -- sentinel up front: cancelling costs the reviewer the `@` they typed and nothing
+      -- else, and everything below still applies to where that leaves them.
+      local spliced = ""
+      if chosen and chosen.path then
+        local payload = require("codereview.payload")
+        -- A picker is entitled to answer with an absolute path, but a reference in a note
+        -- should read the way every other reference in the batch reads. Resolved through
+        -- the same helpers the payload uses, so a symlinked working directory does not turn
+        -- a perfectly relative path into an absolute one. Outside the tree there is nothing
+        -- to be relative to, and the absolute path is the only name the file has.
+        local path = chosen.path
+        if path:sub(1, 1) == "/" then
+          local root = payload.resolve_base(vim.uv.cwd())
+          path = payload.relative_to(vim.uv.fs_realpath(path) or path, root) or path
+        end
+        -- Rendered by the module that reads references, not spelled out again here. Lines
+        -- are optional: a picker that cannot select them omits both, and the reference is
+        -- then to the file rather than to a range in it.
+        local ref = payload.ref(path, chosen.first, chosen.last)
+        -- Past the `@`: the sentinel is already in the buffer, and re-writing it would
+        -- either double it or mean re-deriving where it went.
+        spliced = ref:sub(2) .. " "
+        vim.api.nvim_buf_set_text(buf, row - 1, col, row - 1, col, { spliced })
+      end
+
+      if not vim.api.nvim_win_is_valid(win) then
         return
       end
-      local payload = require("codereview.payload")
-      -- A picker is entitled to answer with an absolute path, but a reference in a note
-      -- should read the way every other reference in the batch reads. Resolved through the
-      -- same helpers the payload uses, so a symlinked working directory does not turn a
-      -- perfectly relative path into an absolute one. Outside the tree there is nothing to
-      -- be relative to, and the absolute path is the only name the file has.
-      local path = chosen.path
-      if path:sub(1, 1) == "/" then
-        local root = payload.resolve_base(vim.uv.cwd())
-        path = payload.relative_to(vim.uv.fs_realpath(path) or path, root) or path
-      end
-      -- Rendered by the module that reads references, not spelled out again here. Lines are
-      -- optional: a picker that cannot select them omits both, and the reference is then to
-      -- the file rather than to a range in it.
-      local ref = payload.ref(path, chosen.first, chosen.last)
-      -- Past the `@`: the sentinel is already in the buffer, and re-writing it would either
-      -- double it or mean re-deriving where it went.
-      vim.api.nvim_buf_set_text(buf, row - 1, col, row - 1, col, { ref:sub(2) .. " " })
+      -- The picker took focus, and the cursor and insert mode with it, so handing writing
+      -- back is this composer's job. Past what was just written: a reference carries a
+      -- trailing space that is an invitation to keep typing, and it is only that if the
+      -- cursor is behind it.
+      local target = col + #spliced
+      vim.api.nvim_win_set_cursor(win, { row, target })
+      -- Keys rather than `startinsert`, which is a no-op on the tick a picker answers on: a
+      -- picker that closes with `stopinsert` leaves the editor still reporting insert mode
+      -- with the exit merely pending, so a request to start inserting is dropped and the
+      -- exit lands afterwards regardless. Reading the mode here is no better -- it reports
+      -- the one being left. `<C-\><C-n>` settles that first, from whichever mode the picker
+      -- really left behind, and the key after it is then read against a known state.
+      --
+      -- `A` when nothing follows, because normal mode cannot hold a cursor past the last
+      -- character of a line: the target arrives one column short there, and appending is
+      -- what recovers it. Mid-sentence the two are different places, and the end of the
+      -- line is not the one being written at.
+      local line = vim.api.nvim_buf_get_lines(buf, row - 1, row, false)[1]
+      local settle = vim.api.nvim_replace_termcodes("<C-\\><C-n>", true, false, true)
+      vim.api.nvim_feedkeys(settle .. (target >= #line and "A" or "i"), "n", false)
     end)
   end, { buffer = buf, desc = "Reference a file" })
 

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -175,7 +175,11 @@ function M.open(ctx, on_accept, label)
 
   if restored then
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(restored, "\n"))
-    vim.api.nvim_win_set_cursor(win, { vim.api.nvim_buf_line_count(buf), 0 })
+    -- The end of the draft, not the start of its last line. A draft comes back to be
+    -- carried on with, and column zero puts the next word before the reviewer's own words
+    -- rather than after them.
+    local last = vim.api.nvim_buf_line_count(buf)
+    vim.api.nvim_win_set_cursor(win, { last, #vim.api.nvim_buf_get_lines(buf, last - 1, last, false)[1] })
     -- Said out loud, because text you did not just type appearing in a buffer you are about
     -- to write in is otherwise a small mystery.
     vim.notify("Draft restored — ^D to discard", vim.log.levels.INFO, { title = "Code review" })
@@ -185,7 +189,12 @@ function M.open(ctx, on_accept, label)
   -- You opened this to write something, so start writing. Leaving insert mode again is
   -- `collect`'s job, not this one's: closing a window does not end insert by itself, and
   -- the review buffer is `nomodifiable`, where every motion would land as a failed edit.
-  vim.cmd("startinsert")
+  --
+  -- With the bang, because normal mode cannot hold a cursor past the last character of a
+  -- line: the end-of-draft position set above arrives one column short, and only the bang
+  -- makes entering insert mean the end of the line rather than that clamped column. On an
+  -- empty composer the two are the same thing.
+  vim.cmd("startinsert!")
   return win
 end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
-| `codereview/interactive_init.lua` | The composer stub `interactive_spec` drives — deliberately not a spec. |
+| `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `perf.lua` | Open-time report on a 60-file diff. Not part of `make test`. |
 
 | Spec | Covers |
@@ -46,7 +46,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
-| `interactive_spec` | The insert-mode leak, in a real pty-backed Neovim |
+| `interactive_spec` | The insert-mode leak, and where a completed or cancelled `@` leaves you, in a real pty-backed Neovim |
 
 ## Fixtures
 
@@ -122,6 +122,13 @@ so the out-of-core language path is still checked locally without ever failing C
   interaction into one tick and no test can observe the order. `composer_spec` holds the
   picker's callback and fires it by hand, which is also the only way to assert that the
   composer had not opened yet.
+- **A picker stub that answers inline cannot test insert mode.** The composer's `@` is an
+  insert-mode mapping, so a stub that calls back before returning never left insert — and
+  an assertion that insert mode *comes back* then passes with nothing restoring it.
+  `interactive_init.lua`'s file picker opens a window, takes focus, `stopinsert`s and
+  answers a tick later, which is the shape a real picker has and the only one that
+  reproduces the defect. `composer_spec`'s file picker still answers inline on purpose: it
+  is asserting text and cursor, not mode.
 - **`interactive_spec` must keep its teeth.** To confirm it still reproduces the bug,
   remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -594,6 +594,36 @@ describe("a restored draft", function()
   end
 end)
 
+-- Restoring a draft is an invitation to carry on writing it, so the cursor belongs at the
+-- end of what came back. Column zero of the last line puts the next word *before* the
+-- reviewer's own draft. Insert mode is unreachable headless, but where the cursor sits is
+-- not, which is why this half lives here and the reference half lives in interactive_spec.
+describe("where a restored draft leaves the cursor", function()
+  local tail = "and the rest of it"
+
+  reset()
+  annotate_line()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "half a thought", tail })
+  h.feed("q")
+
+  annotate_line()
+  local win = floating()
+  local cursor = vim.api.nvim_win_get_cursor(win)
+  h.feed("q")
+
+  it("lands on the last line of the draft", function()
+    assert.same(2, cursor[1])
+  end)
+
+  -- Past the last character, which normal mode cannot hold a cursor at and which is
+  -- therefore the position insert mode will be entered at rather than the one normal mode
+  -- clamped it to. Observable headless despite insert mode not being: it is the pending
+  -- insert that carries the column, not the mode. Column zero is where this used to land.
+  it("lands past the end of the draft, where the next word continues it", function()
+    assert.same(#tail, cursor[2])
+  end)
+end)
+
 describe("a draft picked up and put down again", function()
   reset()
   annotate_line()

--- a/tests/codereview/interactive_init.lua
+++ b/tests/codereview/interactive_init.lua
@@ -9,13 +9,45 @@
 -- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it.
 vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
 
+---What the picker answers with. `nil` is a cancel; `interactive_spec` flips this over the
+---socket to drive that case.
+_G.cr_pick_answer = { path = "src/routes.lua", first = 2, last = 4 }
+
+---How many times the picker has answered *and* the composer has finished reacting. What
+---the spec polls on: neither the keystroke nor the answer is a state it can wait for.
+_G.cr_picks = 0
+
 require("codereview").setup({
   syntax = false,
   send = function() end,
-  -- Answers immediately with a fixed file. A real picker is a window that takes focus, and
-  -- what that costs the splice position is covered headless; what cannot be covered there
-  -- is that `@` is an insert-mode key at all.
+  -- Behaves like a real picker rather than answering inline: a window that opens on a
+  -- later tick, takes focus, leaves insert mode behind it, and hands focus back when it is
+  -- done. Answering inline would leave the composer in insert mode by accident -- never
+  -- having left it -- and an assertion that insert mode comes back would pass with nothing
+  -- restoring it, which is the trap this whole file exists to avoid.
   pick_file = function(cb)
-    cb({ path = "src/routes.lua", first = 2, last = 4 })
+    local composer = vim.api.nvim_get_current_win()
+    vim.schedule(function()
+      local picker = vim.api.nvim_open_win(vim.api.nvim_create_buf(false, true), true, {
+        relative = "editor",
+        width = 30,
+        height = 5,
+        row = 1,
+        col = 1,
+        style = "minimal",
+      })
+      -- Scheduled apart from the answer: returning from an insert-mode mapping can put Vim
+      -- straight back into insert, so a `stopinsert` has to survive a trip through the
+      -- main loop before the composer is handed anything.
+      vim.cmd("stopinsert")
+      vim.schedule(function()
+        vim.api.nvim_win_close(picker, true)
+        vim.api.nvim_set_current_win(composer)
+        cb(_G.cr_pick_answer)
+        -- Counted after the fact, so a spec polling on it knows the composer has finished
+        -- reacting rather than merely that the picker answered.
+        _G.cr_picks = _G.cr_picks + 1
+      end)
+    end)
   end,
 })

--- a/tests/codereview/interactive_spec.lua
+++ b/tests/codereview/interactive_spec.lua
@@ -151,10 +151,30 @@ describe("annotating from insert mode", function()
   end)
 end)
 
+---Wait for the picker to have answered `n` times and the composer to have taken writing
+---back. Neither the keystroke that opens the picker nor the answer it gives is a state
+---reachable from out here, and the line the splice lands on reads as finished from the
+---moment the `@` sentinel is written -- long before the picker has been anywhere.
+---
+---Waits on insert mode as well because the composer restores it with a fed key, which the
+---editor consumes on its own schedule; the count alone can be read before it has.
+---@param n integer
+---@return fun(): boolean
+local function resumed(n)
+  return function()
+    return expr("luaeval('cr_picks')") == tostring(n) and expr("mode()"):sub(1, 1) == "i"
+  end
+end
+
 -- `@` is bound in insert mode, so this is the only place it can be pressed the way a user
 -- presses it. Headless the mapping is reachable only by feeding an `i` first, which is not
 -- what a composer opened in insert mode does.
 describe("referencing a file while typing", function()
+  -- What the splice leaves on the line, trailing space and all. `expr` trims what comes
+  -- back over the socket, so the space is only reachable from here as arithmetic on the
+  -- cursor -- which is the point: it is a place to type, not a character to look at.
+  local spliced = "compare with @src/routes.lua#L2-4 "
+
   it("opens the composer again", function()
     send("ab", function()
       return expr("mode()"):sub(1, 1) == "i"
@@ -163,13 +183,21 @@ describe("referencing a file while typing", function()
   end)
 
   it("splices the reference as the @ is typed", function()
-    send("compare with @", function()
-      return expr("getline('.')"):find("routes", 1, true) ~= nil
-    end)
-    -- Without its trailing space: `expr` trims what comes back over the socket, so the
-    -- space the splice leaves for you to keep typing is not observable from here. That it
-    -- is there at all is a headless assertion.
-    assert.same("compare with @src/routes.lua#L2-4", expr("getline('.')"))
+    send("compare with @", resumed(1))
+    assert.same(vim.trim(spliced), expr("getline('.')"))
+  end)
+
+  -- The trailing space is an invitation to keep typing, and it is only that if the cursor
+  -- is behind it. The splice goes in *after* the cursor, so without moving it the reviewer
+  -- resumes between the `@` and the path they just chose.
+  it("leaves the cursor past the reference and its trailing space", function()
+    assert.same(tostring(#spliced + 1), expr("col('.')"))
+  end)
+
+  -- The picker took focus and insert mode with it. Restoring insert mode is the composer's
+  -- job: a reviewer who asked for a reference mid-sentence did not ask to stop writing.
+  it("leaves the composer in insert mode", function()
+    assert.same("i", expr("mode()"):sub(1, 1))
   end)
 
   it("queues the note with its reference", function()
@@ -177,6 +205,46 @@ describe("referencing a file while typing", function()
       return expr("&filetype") == "codereview"
     end)
     assert.same("compare with @src/routes.lua#L2-4", expr("luaeval(\"require('codereview.queue').all()[2].note\")"))
+  end)
+end)
+
+-- Cancelling is the case the sentinel is written up front for. What it costs the reviewer
+-- should be the `@` they typed and nothing else -- not the sentence they were in the
+-- middle of.
+describe("cancelling the file picker while typing", function()
+  local typed = "look at @"
+
+  -- A picker that answers with nothing is a picker the reviewer dismissed.
+  server("--remote-send", ":lua cr_pick_answer = nil<CR>")
+
+  it("opens the composer again", function()
+    send("ab", function()
+      return expr("mode()"):sub(1, 1) == "i"
+    end)
+    assert.same("i", expr("mode()"):sub(1, 1))
+  end)
+
+  it("leaves the literal @ that was typed", function()
+    send(typed, resumed(2))
+    assert.same(typed, expr("getline('.')"))
+  end)
+
+  it("leaves the cursor after it", function()
+    assert.same(tostring(#typed + 1), expr("col('.')"))
+  end)
+
+  it("leaves the composer in insert mode", function()
+    assert.same("i", expr("mode()"):sub(1, 1))
+  end)
+
+  -- Out through the submit key rather than by abandoning: `q` reaches the review buffer
+  -- and closes the whole review if the composer has already gone, and whether it has
+  -- depends on the very mode these assertions are about.
+  it("submits what was written anyway", function()
+    send("<C-s>", function()
+      return expr("&filetype") == "codereview"
+    end)
+    assert.same(typed, expr("luaeval(\"require('codereview.queue').all()[3].note\")"))
   end)
 end)
 


### PR DESCRIPTION
Two places the composer acts on the reviewer's behalf and then leaves them somewhere they
cannot write from.

**A restored draft** put the cursor at column zero of its last line, so the next word
preceded the sentence it was meant to continue. It now lands past the end of the draft.

**A completed reference** left the cursor between the `@` and the path just chosen, in
normal mode. The reference is written with a trailing space that only makes sense as an
invitation to keep typing, and the space was inert. Both a completed and a cancelled pick
now leave the cursor past what was written and the composer in insert mode.

## What the fix turned on

Two Neovim behaviours, both verified by driving a real editor rather than reasoned about:

- **`startinsert` does nothing on the tick a picker answers on.** A picker closing with
  `stopinsert` leaves the editor reporting insert mode with the exit merely pending, so
  starting insert is dropped as redundant and the exit lands anyway. Reading `mode()` there
  reports the mode being left, so a guard on it is no better. The composer feeds
  `<C-\><C-n>` and then `i` or `A`, which the input loop applies once things have settled.
- **Normal mode cannot hold a cursor past the last character of a line.** Both target
  positions are exactly that column, so setting it arrives one short; entering insert with
  the bang (`startinsert!`, or `A` as a fed key) recovers it.

Both are recorded in the README's design notes.

## Where the tests live

Split the way the issue asks. Cursor position after a draft restore is observable headless
and is asserted in `composer_spec`. Anything about insert mode runs in the pty harness, as
further assertions on `interactive_spec`'s existing `@` case plus a new cancel case.

`interactive_init.lua`'s picker stub had to grow into a real picker's shape — a window that
opens a tick later, takes focus, drops insert mode and answers a tick after that. Answering
inline never left insert mode, so an assertion that insert mode *comes back* would have
passed with nothing restoring it. `composer_spec`'s stub still answers inline on purpose:
it asserts text and cursor, not mode. Noted in `tests/README.md`.

Every new assertion was confirmed to fail against current behaviour first:

| Assertion | Before | After |
| --- | --- | --- |
| draft restore, cursor column | `0` | `18` |
| reference, cursor column | `14` | `35` |
| reference, mode | `n` | `i` |
| cancel, cursor column | `9` | `10` |
| cancel, mode | `n` | `i` |

An intermediate state where only the cursor was set, without the bang, read `17` — so the
headless draft assertion pins both halves of that fix.

`make all` green; the pty spec run three times over for flakiness.

Closes #35