### PR TITLE
feat(capture): send one annotation without queueing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,36 @@ groups under its type in the same payload, and it goes out in the same batch to 
 target. A selection travels as `@path#L12-20` when the delivery target can resolve the
 path, and inlines its code when it cannot. The buffer itself is never touched.
 
+### Sending one annotation now
+
+A thought you want acted on should not have to wait for a batch you have not finished
+assembling. The same entry point sends one annotation on its own instead of queueing it:
+
+```lua
+require("codereview").annotate("bug", nil, { immediate = true })
+require("codereview").annotate(nil, nil, { immediate = true })  -- or pick the type, or decline one
+```
+
+Delivery is a property of the call, not a different door: everything above still applies —
+the same paths, the same blob, the same diagnostics, the same drafts and `@` references,
+and the same picker with its `no type` entry. It renders through the same renderer a batch
+does, so what arrives is an ordinary review payload that happens to hold one annotation
+([ADR-0004](docs/adr/0004-an-immediate-send-is-a-batch-of-one.md)) — untyped, if that is
+what you chose, in the group that carries no directive.
+
+That a type is optional at all is a consequence of this: a batch of one would otherwise
+force one onto the fastest interaction there is.
+
+The queue is untouched: an annotation sent this way never joins it, and whatever is already
+queued is neither delivered nor cleared.
+
+You are asked where it goes **before** the composer opens, through `pick_target` — so
+declining costs no typing. Decline and nothing is sent. With no `pick_target` wired there
+is nothing to choose between, so it goes with no target and `send` decides what that means.
+Because the note owns that choice rather than the batch, the composer's footer names the
+target *this note* will reach, and `^T` in the composer reroutes the note, leaving the
+batch pointing where it was.
+
 ### Inside the view
 
 | Key | Action |
@@ -280,6 +310,10 @@ opts = {
   -- and `origin_win` — the window the annotation was started from. Focus goes back there
   -- once `on_accept` runs; a composer the user can *cancel* never calls it, so that path
   -- is the composer's to restore.
+  --
+  -- On an immediate send `ctx.routing` is also there — `{ label(), pick(on_done) }` for
+  -- the target *this note* will reach. Name it, and change it with `pick`. It is absent
+  -- for a note joining the queue, which the batch routes.
   compose = function(ctx, on_accept, label) on_accept(nil, "text") end,
 }
 ```

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -193,8 +193,9 @@ The composer                                          *codereview-composer*
 Annotating opens a floating buffer to write the note in, titled with the type
 and what is being annotated:
 
-    ^S              queue the note and close
-    ^T              choose where the batch goes
+    ^S              queue the note and close (or send it, on an immediate
+                    send -- the footer names the verb it will use)
+    ^T              choose where it goes
     @               reference another file (|codereview-opt-pick_file|)
     ^D              discard a restored draft
     q  <Esc>        abandon, keeping what you wrote as a draft
@@ -208,8 +209,11 @@ The note is whatever the buffer holds, newlines and all. An empty one queues
 nothing, so opening the composer by accident costs nothing. Either way focus
 returns to the window the annotation was started from.
 
-Routing from here is the same choice the queue float offers, because it is the
-same choice: a target belongs to the batch, not to the window that asked.
+The footer names the target the note in front of you will actually reach, and
+`^T` changes that one. For a note joining the queue that is the batch's target,
+the same choice the queue float offers -- routing belongs to the batch, not to
+the window that asked. For an |codereview-immediate-send| it is that note's own
+target, and rerouting it leaves the batch pointing where it was.
 
 `@` references another file, through |codereview-opt-pick_file|. It is written
 into the note before the picker opens, so cancelling leaves the character you
@@ -286,6 +290,36 @@ stale the same way a review annotation does -- see |codereview-persistence|.
 A selection travels as `@path#L12-20` when the delivery target can resolve the
 path, and inlines its code when it cannot. The buffer itself is never touched.
 
+Sending one now                                 *codereview-immediate-send*
+
+A thought you want acted on should not wait for a batch you have not finished
+assembling. The same entry point sends one annotation on its own: >
+    require("codereview").annotate("bug", nil, { immediate = true })
+<
+Delivery is a property of the call rather than a different door, so everything
+above still applies -- the same path resolution, blob, diagnostics, drafts and
+`@` references, and the same type picker with its way of declining a type. It
+renders through the same renderer a batch does, so what arrives is an ordinary
+review payload holding one annotation, untyped if that is what you chose.
+
+That a type is optional at all follows from this: a batch of one would
+otherwise force one onto the fastest interaction there is.
+
+The queue is untouched: an annotation sent this way never joins it, and what is
+already queued is neither delivered nor cleared.
+
+You are asked where it goes *before* the composer opens, through
+|codereview-opt-pick_target|, so declining costs no typing -- decline and
+nothing is sent. With no picker wired there is nothing to choose between and no
+way to decline, so it goes with no target and |codereview-opt-send| decides
+what that means. With no `send` either, the payload lands in the `+` register
+like a batch does.
+
+Because the note owns that choice rather than the batch, the composer's footer
+names the target *this note* will reach and `^T` reroutes the note, leaving the
+batch pointing where it was. Abandon it and the text is kept as a draft, like
+any other note you walked away from.
+
 ==============================================================================
 7. ADAPTERS                                            *codereview-adapters*
 
@@ -343,7 +377,15 @@ compose({ctx}, {on_accept}, {label})                  *codereview-opt-compose*
             rel_path    repository-relative path; nil outside a checkout
             file_path   absolute path; nil for a note with no file
             origin_win  window the annotation was started from
+            routing     immediate sends only -- see below
 <
+        `routing` is `{ label(), pick(on_done) }` for the target *this note*
+        will reach: `label()` is what to name in the chrome, `pick()` changes
+        it and calls {on_done} once the picker has answered. It is absent for a
+        note joining the queue, which is routed by the batch it joins -- so a
+        composer that ignores it entirely still works, it just cannot name or
+        change where an |codereview-immediate-send| is going.
+
         `origin_win` is there for composers that can be dismissed. Once
         {on_accept} is called the plugin puts focus back there itself, so a
         composer that always submits can ignore it. One the user can cancel
@@ -461,11 +503,14 @@ accepted cost of not making those annotations second-class.
 require("codereview").setup({opts})                     *codereview.setup()*
 require("codereview").open({scope})                      *codereview.open()*
 require("codereview").close()                           *codereview.close()*
-require("codereview").annotate({type}, {range})      *codereview.annotate()*
+require("codereview").annotate({type}, {range}, {opts})
+                                                     *codereview.annotate()*
         Annotate the current buffer, with no review view involved. {type} is
         an annotation name; with nil, the type picker opens. {range} is
         `{ first = 12, last = 20 }`, overriding both a live visual selection
-        and the whole-file default. See |codereview-capture|.
+        and the whole-file default. {opts} takes `immediate = true` to send
+        this one annotation on its own instead of queueing it. See
+        |codereview-capture| and |codereview-immediate-send|.
 require("codereview").queue()                           *codereview.queue()*
         Open the queue float: drop, route, submit.
 require("codereview").submit()                         *codereview.submit()*

--- a/docs/adr/0004-an-immediate-send-is-a-batch-of-one.md
+++ b/docs/adr/0004-an-immediate-send-is-a-batch-of-one.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # An immediate send is a batch of one

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -374,6 +374,33 @@ function M.annotate_pick()
   end)
 end
 
+---The note as it reaches an entry: what was written, plus whatever rides along under it.
+---@param text string
+---@param opts { note_suffix?: string }|nil
+---@return string
+local function note_with(text, opts)
+  local suffix = opts and opts.note_suffix
+  return (suffix and suffix ~= "") and (text .. "\n\n" .. suffix) or text
+end
+
+---The composer context both tails hand over.
+---@param entry CRAnnotation
+---@param type_def CRType|nil nil for an untyped annotation
+---@param routing table|nil What the composer's footer names and its routing key changes.
+---       Absent for a note joining the queue, which is routed by the batch it joins.
+---@return table
+local function compose_ctx(entry, type_def, routing)
+  -- The untyped group stands in wherever the annotation still has to be named.
+  local type_label = (type_def or types.UNTYPED).label
+  return {
+    scope = "none",
+    label = ("%s · %s"):format(type_label:gsub("s$", ""), M.describe(entry)),
+    rel_path = entry.path,
+    file_path = entry.abs_path,
+    routing = routing,
+  }
+end
+
 ---Collect a note for an already-built entry, queue it, and report.
 ---
 ---Shared by the review path and by buffer capture, rather than each growing its own tail:
@@ -389,31 +416,105 @@ function M.queue_entry(entry, type_def, opts)
   -- it carries gets the honest answer -- and so no configurable name can ever collide with
   -- one the plugin reserved.
   entry.type = type_def and type_def.name
-  -- The untyped group stands in wherever the annotation still has to be named.
-  local type_label = (type_def or types.UNTYPED).label
   -- Before anything is added, not after: persisting writes the in-memory queue over the
   -- document, so queueing into a queue this session has never read back would drop
   -- whatever the last session left. A review view has already restored by the time it
   -- gets here; capture from a buffer can be the very first thing a session does.
   require("codereview.view").ensure_queue()
-  collect(
-    {
-      scope = "none",
-      label = ("%s · %s"):format(type_label:gsub("s$", ""), M.describe(entry)),
-      rel_path = entry.path,
-      file_path = entry.abs_path,
-    },
-    "queue",
-    function(text)
-      local suffix = opts and opts.note_suffix
-      entry.note = (suffix and suffix ~= "") and (text .. "\n\n" .. suffix) or text
-      queue.add(entry)
-      local view = require("codereview.view")
-      view.paint()
-      view.persist()
-      info(("Queued %s %s (%d in queue)"):format(entry.type or "untyped", M.describe(entry), queue.count()))
+  collect(compose_ctx(entry, type_def), "queue", function(text)
+    entry.note = note_with(text, opts)
+    queue.add(entry)
+    local view = require("codereview.view")
+    view.paint()
+    view.persist()
+    info(("Queued %s %s (%d in queue)"):format(entry.type or "untyped", M.describe(entry), queue.count()))
+  end)
+end
+
+---Collect a note for an already-built entry and deliver it on its own.
+---
+---The queued path's twin, and deliberately the same shape: the same composer context, the
+---same note suffix, the same focus restore. What differs is the tail -- this one renders a
+---batch of one through the payload renderer (ADR-0004) and hands it to the send adapter,
+---never touching the queue. An errand does not disturb a batch you are still assembling.
+---@param entry CRAnnotation
+---@param type_def CRType|nil nil for an untyped annotation. The reason a type became
+---       optional at all (ADR-0004): a batch of one must not be the one interaction that
+---       forces a type onto a remark that carries no instruction.
+---@param opts? { note_suffix?: string }
+function M.send_entry(entry, type_def, opts)
+  entry.type = type_def and type_def.name
+  local view = require("codereview.view")
+
+  -- Said the same way from both places the absence can be discovered: before the composer
+  -- opens, and from the routing key once it is.
+  local NO_PICKER = "No pick_target adapter configured — sending to the default target"
+
+  ---Where this one note goes. Held here rather than in the view because it belongs to the
+  ---note: an errand must not redirect the batch you are still assembling.
+  ---@type table|nil
+  local to = nil
+
+  ---What the composer names in its footer and changes with its routing key. The batch's
+  ---equivalent is `view.routing()`; this is the same shape for a note that owns its own
+  ---destination, which is what lets one composer tell the truth on both paths.
+  local routing = {
+    label = function()
+      return view.label_of(to)
+    end,
+    pick = function(on_done)
+      local asked = view.choose_target(function(picked)
+        -- Declining a reroute is "never mind", not "send it nowhere". The note is written
+        -- by now, and dropping the target it already had would redirect it in the one
+        -- direction nobody asked for.
+        if picked then
+          to = picked
+        end
+        if on_done then
+          on_done()
+        end
+      end)
+      if not asked then
+        info(NO_PICKER)
+      end
+    end,
+  }
+
+  local function compose_and_send()
+    collect(compose_ctx(entry, type_def, routing), "send", function(text)
+      entry.note = note_with(text, opts)
+      if view.deliver({ entry }, to) then
+        info(
+          ("Sent %s %s to %s"):format(
+            entry.type or "untyped",
+            M.describe(entry),
+            to and (to.short or "agent") or "local"
+          )
+        )
+      end
+    end)
+  end
+
+  -- Asked before the composer opens, not after it closes: declining then costs nothing,
+  -- where declining after the note is written costs the note.
+  local asked = view.choose_target(function(picked)
+    -- A picker that ran and came back empty is a reviewer who chose not to send. Said out
+    -- loud, because a note that goes nowhere in silence looks exactly like one that was
+    -- delivered.
+    if not picked then
+      warn("No target chosen — nothing sent")
+      return
     end
-  )
+    to = picked
+    compose_and_send()
+  end)
+  -- Nothing to choose between, and no way to decline. The plugin has no opinion about
+  -- where a payload goes (ADR-0001), so it hands this one over with no target and lets
+  -- the send adapter decide what that means, exactly as a batch does.
+  if not asked then
+    info(NO_PICKER)
+    compose_and_send()
+  end
 end
 
 ---Annotate a target that was resolved earlier.

--- a/lua/codereview/capture.lua
+++ b/lua/codereview/capture.lua
@@ -182,7 +182,10 @@ end
 ---Annotate the current buffer: the visual selection if there is one, else the whole file.
 ---@param type_name string|nil Falls back to the same picker the review view offers
 ---@param range { first: integer, last: integer }|nil Explicit lines, e.g. a command range
-function M.annotate(type_name, range)
+---@param opts { immediate?: boolean }|nil `immediate` sends this one annotation on its own
+---       rather than queueing it. Delivery is a property of the call, not a second door:
+---       everything above this line is the capture both paths share.
+function M.annotate(type_name, range, opts)
   local cfg = config.get()
 
   local type_def = type_name and types.get(cfg.types, type_name)
@@ -211,18 +214,22 @@ function M.annotate(type_name, range)
   -- Read now rather than in the callback: both the composer and the picker are
   -- asynchronous, and a language server can republish diagnostics while either is open.
   -- What rides along should be what was on screen when the note was started.
-  local opts = { note_suffix = diagnostics_note(buf, entry.first, entry.last) }
+  local note_opts = { note_suffix = diagnostics_note(buf, entry.first, entry.last) }
 
   local annotate = require("codereview.annotate")
+  -- The one thing delivery changes about capture: which tail the entry goes down. Both
+  -- collect a note the same way, through the same composer, from the same entry.
+  local finish = (opts and opts.immediate) and annotate.send_entry or annotate.queue_entry
   if type_def then
-    annotate.queue_entry(entry, type_def, opts)
+    finish(entry, type_def, note_opts)
     return
   end
 
   -- The same menu the review view offers, including its way of declining a type outright:
-  -- which types exist, and how you say "none of them", cannot depend on where you asked.
+  -- which types exist, and how you say "none of them", cannot depend on where you asked --
+  -- or on whether this one is being queued or sent.
   annotate.pick_type(cfg.types, function(chosen)
-    annotate.queue_entry(entry, chosen, opts)
+    finish(entry, chosen, note_opts)
   end)
 end
 

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -21,6 +21,11 @@ function M.open(ctx, on_accept, label)
   local draft_key = drafts.key(ctx)
   local restored = drafts.get(draft_key)
 
+  -- The batch's routing by default, because a note written here joins the batch. An
+  -- immediate send hands its own on the context: that note has a target of its own, and
+  -- naming the batch's would name a destination this note is not going to.
+  local routing = ctx.routing or require("codereview.view").routing()
+
   local width = math.min(84, math.max(40, math.floor(vim.o.columns * 0.7)))
   local height = 6
   local cfg_win = {
@@ -43,14 +48,14 @@ function M.open(ctx, on_accept, label)
   vim.wo[win].linebreak = true
 
   ---Redraw the footer. The target is the only part that changes while the composer is
-  ---open, and it is worth showing: it is what decides where the batch ends up.
+  ---open, and it is worth showing: it is what decides where this note ends up.
   local function refresh()
     if not vim.api.nvim_win_is_valid(win) then
       return
     end
     -- Truncated because a target name can be long ("janus · Analyze RUM patterns") and a
     -- footer wider than the float is silently clipped, taking the keys with it.
-    local name = require("codereview.view").target_label()
+    local name = routing.label()
     if #name > 16 then
       name = name:sub(1, 15) .. "…"
     end
@@ -95,9 +100,10 @@ function M.open(ctx, on_accept, label)
   -- reread the note first, and a submit key that only works in one of those is a trap.
   vim.keymap.set({ "i", "n" }, "<C-s>", submit, { buffer = buf, desc = label })
   -- Routing without abandoning the note. The picker answers on a later tick and puts focus
-  -- back here itself, so there is nothing to restore -- only a footer to redraw.
+  -- back here itself, so there is nothing to restore -- only a footer to redraw. What it
+  -- changes is whatever this composer is routing: the batch, or this one note.
   vim.keymap.set({ "i", "n" }, "<C-t>", function()
-    require("codereview.view").pick_target(refresh)
+    routing.pick(refresh)
   end, { buffer = buf, desc = "Choose target" })
   -- The sentinel is written *before* the picker opens, so cancelling leaves the literal
   -- character that was just pressed. The position is remembered rather than re-derived for

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -55,6 +55,10 @@ M.defaults = {
   ---`ctx` carries `scope`, `label`, `rel_path`, `file_path` and `origin_win` -- the window
   ---the annotation was started from. The plugin restores focus there once `on_accept`
   ---runs; a composer that can be dismissed without calling it owns that path itself.
+  ---
+  ---On an immediate send it also carries `routing`: `{ label(), pick(on_done) }` for the
+  ---target *this note* will reach. Name it in the chrome, and change it with `pick`. It is
+  ---absent for a note joining the queue, which is routed by the batch it joins.
   ---@type fun(ctx: table, on_accept: fun(target: table|nil, text: string), label: string)|nil
   compose = nil,
 }

--- a/lua/codereview/init.lua
+++ b/lua/codereview/init.lua
@@ -64,8 +64,10 @@ end
 ---With a visual selection live, captures those lines; otherwise the whole file.
 ---@param type_name string|nil Falls back to the type picker
 ---@param range { first: integer, last: integer }|nil Explicit lines, overriding both
-function M.annotate(type_name, range)
-  require("codereview.capture").annotate(type_name, range)
+---@param opts { immediate?: boolean }|nil `immediate` delivers this one annotation on its
+---       own instead of queueing it -- see `codereview-immediate-send`
+function M.annotate(type_name, range, opts)
+  require("codereview.capture").annotate(type_name, range, opts)
 end
 
 ---Open the queue for review, with drop / route / submit.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -795,22 +795,45 @@ end
 
 --- Delivery -------------------------------------------------------------------
 
----Short name of where the batch is going, or what to call the adapter's own default.
+---Short name for a target, or what to call the adapter's own default.
 ---
----Exposed because the queue float and the composer both name this choice, and it is the
----same choice: routing is a property of the batch, not of whichever window asked.
+---One wording for every piece of chrome that names a destination -- the winbar, the queue
+---float, and a composer footer whichever choice it is naming.
+---@param to table|nil
 ---@return string
-function M.target_label()
-  return (target and target.short) or "local"
+function M.label_of(to)
+  return (to and to.short) or "local"
 end
 
----Choose where the batch goes, through the injected picker.
----@param on_done fun()|nil Runs after a target is chosen, once the picker has closed
-function M.pick_target(on_done)
+---Short name of where the batch is going.
+---
+---Exposed because the queue float and the winbar both name this choice, and it is the
+---same choice: a batch's routing belongs to the batch, not to whichever window asked.
+---@return string
+function M.target_label()
+  return M.label_of(target)
+end
+
+---The batch's routing, in the shape a composer is handed.
+---
+---What a note joining the queue is routed by, and so the composer's default. An immediate
+---send supplies its own instead, because that note has a target of its own.
+---@return { label: fun(): string, pick: fun(on_done: fun()|nil) }
+function M.routing()
+  return { label = M.target_label, pick = M.pick_target }
+end
+
+---Ask the host where something should go, holding focus where the question was asked.
+---
+---Says nothing about *what* is being routed: the batch's target is one caller, a single
+---note being sent on its own is another, and neither should have to reimplement the focus
+---dance around an asynchronous picker to have its own answer.
+---@param cb fun(picked: table|nil) nil is a decline, which every caller reads its own way
+---@return boolean asked false when no picker adapter is wired, so nothing was asked
+function M.choose_target(cb)
   local cfg = config.get()
   if not cfg.pick_target then
-    info("No pick_target adapter configured — submitting locally")
-    return
+    return false
   end
 
   -- Return focus to whichever window asked, not to the diff. Picking a target from the
@@ -819,16 +842,25 @@ function M.pick_target(on_done)
   local return_win = vim.api.nvim_get_current_win()
 
   cfg.pick_target(function(picked)
+    if vim.api.nvim_win_is_valid(return_win) then
+      vim.api.nvim_set_current_win(return_win)
+    elseif V and vim.api.nvim_win_is_valid(V.win) then
+      vim.api.nvim_set_current_win(V.win)
+    end
+    cb(picked)
+  end)
+  return true
+end
+
+---Choose where the batch goes, through the injected picker.
+---@param on_done fun()|nil Runs after a target is chosen, once the picker has closed
+function M.pick_target(on_done)
+  local asked = M.choose_target(function(picked)
     -- Recorded before anything view-shaped is touched. This used to return early with no
     -- view, which meant the picker ran, the user answered, and the answer was dropped.
     target = picked
     if V then
       update_winbar()
-    end
-    if vim.api.nvim_win_is_valid(return_win) then
-      vim.api.nvim_set_current_win(return_win)
-    elseif V and vim.api.nvim_win_is_valid(V.win) then
-      vim.api.nvim_set_current_win(V.win)
     end
     -- The picker is asynchronous, so anything that has to reflect the new target has to
     -- be driven from here; running it after `pick_target` returns repaints too early.
@@ -836,12 +868,48 @@ function M.pick_target(on_done)
       on_done()
     end
   end)
+  if not asked then
+    info("No pick_target adapter configured — submitting locally")
+  end
+end
+
+---Render annotations as one payload and hand it to the send adapter.
+---
+---Shared with the immediate send, which is a batch of one (ADR-0004): one renderer, one
+---delivery, and one fallback for a host that wired no `send` -- rather than a second
+---output shape that could drift from this one.
+---@param items CRAnnotation[]
+---@param to table|nil Where it is going, or nil for whatever the adapter defaults to
+---@param opts { scope_label?: string, files?: integer, reviewed?: integer }|nil
+---@return boolean delivered false when it went to the `+` register instead
+function M.deliver(items, to, opts)
+  local cfg = config.get()
+  local V_ = M.current()
+  local root = V_ and V_.root or (git.root(vim.fn.getcwd()) or vim.fn.getcwd())
+  -- Resolve refs against the directory the payload is actually going to: a routed agent
+  -- reads `@path` relative to its own cwd, not this Neovim's.
+  local base = (to and to.cwd and to.cwd ~= "") and to.cwd or root
+
+  local text = require("codereview.payload").render(items, base, {
+    types = cfg.types,
+    scope_label = opts and opts.scope_label,
+    files = opts and opts.files,
+    reviewed = opts and opts.reviewed,
+  })
+
+  if not cfg.send then
+    warn("No send adapter configured — copied the batch to the + register instead")
+    vim.fn.setreg("+", text)
+    return false
+  end
+
+  cfg.send(text, to)
+  return true
 end
 
 ---Render the queue and hand it to the send adapter.
 function M.submit()
   local queue = require("codereview.queue")
-  local cfg = config.get()
 
   M.ensure_queue()
   if queue.count() == 0 then
@@ -856,12 +924,6 @@ function M.submit()
   end
 
   local V_ = M.current()
-  local root = V_ and V_.root or (git.root(vim.fn.getcwd()) or vim.fn.getcwd())
-  -- Read unconditionally: the target outlives any view, and there may not be one.
-  -- Resolve refs against the directory the batch is actually going to: a routed agent
-  -- reads `@path` relative to its own cwd, not this Neovim's.
-  local base = (target and target.cwd and target.cwd ~= "") and target.cwd or root
-
   local reviewed = 0
   if V_ then
     for _ in pairs(V_.reviewed) do
@@ -869,21 +931,17 @@ function M.submit()
     end
   end
 
-  local text = require("codereview.payload").render(queue.all(), base, {
-    types = cfg.types,
-    scope_label = V_ and V_.scope.label or nil,
-    files = V_ and #V_.files or nil,
-    reviewed = reviewed,
-  })
-
-  if not cfg.send then
-    warn("No send adapter configured — copied the batch to the + register instead")
-    vim.fn.setreg("+", text)
+  local count = queue.count()
+  -- Read unconditionally: the target outlives any view, and there may not be one.
+  if
+    not M.deliver(queue.all(), target, {
+      scope_label = V_ and V_.scope.label or nil,
+      files = V_ and #V_.files or nil,
+      reviewed = reviewed,
+    })
+  then
     return
   end
-
-  local count = queue.count()
-  cfg.send(text, target)
   queue.clear()
   if M.current() then
     M.paint()

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit |
-| `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue |
+| `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
@@ -117,6 +117,11 @@ so the out-of-core language path is still checked locally without ever failing C
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.
+- **An immediate send asks for its target before the composer exists.** Nothing is
+  floating between the two, so a picker stub that answers inline collapses the whole
+  interaction into one tick and no test can observe the order. `composer_spec` holds the
+  picker's callback and fires it by hand, which is also the only way to assert that the
+  composer had not opened yet.
 - **`interactive_spec` must keep its teeth.** To confirm it still reproduces the bug,
   remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -819,6 +819,85 @@ describe("declining to choose a target", function()
   end)
 end)
 
+-- Why a type became optional at all (ADR-0004): a batch of one would otherwise force one
+-- onto the fastest interaction there is, and a remark with no instruction behind it would
+-- have to invent a directive to be sendable.
+describe("sending one annotation with no type", function()
+  queue.clear()
+  steps = {}
+  local before = #sent
+  local orig = vim.ui.select
+  vim.ui.select = function(items, _, cb)
+    steps[#steps + 1] = "type"
+    -- One past the configured types is the decline entry, which is not a dismissal.
+    cb(items[#items], #items)
+  end
+  edit("src/main.lua")
+  codereview.annotate(nil, nil, { immediate = true })
+  vim.ui.select = orig
+  local order = table.concat(steps, " ")
+  local text = sent[#sent].text
+
+  it("delivers it rather than making a type the price of sending", function()
+    assert.same(before + 1, #sent)
+  end)
+
+  -- Both pickers are answered before a word is written; neither hides inside the
+  -- composer's callback, where the answer would arrive too late to matter.
+  it("asks for the type, then the target, then opens the composer", function()
+    assert.same("type target compose", order)
+  end)
+
+  it("lands its one annotation in the untyped group", function()
+    assert.is_truthy(text:find("Code review — 1 annotation", 1, true), text)
+    assert.is_truthy(text:find("## Untyped (1)", 1, true), text)
+    assert.is_truthy(text:find("@src/main.lua", 1, true), text)
+    assert.is_truthy(text:find("the note", 1, true), text)
+  end)
+
+  -- A group with nothing to instruct should not pretend otherwise.
+  it("gives that group no directive", function()
+    assert.is_truthy(text:find("## Untyped (1)\n", 1, true), text)
+  end)
+
+  it("still leaves the queue alone", function()
+    assert.same(0, queue.count())
+  end)
+end)
+
+-- Declining and dismissing were the same gesture until the picker grew a way to say "no
+-- type", and the send path must not quietly put them back together: one delivers an
+-- untyped annotation, the other abandons the send entirely.
+describe("dismissing the type picker on an immediate send", function()
+  queue.clear()
+  steps = {}
+  local before, composed_before = #sent, #composed
+  local orig = vim.ui.select
+  vim.ui.select = function(_, _, cb)
+    steps[#steps + 1] = "type"
+    cb(nil, nil)
+  end
+  edit("src/main.lua")
+  codereview.annotate(nil, nil, { immediate = true })
+  vim.ui.select = orig
+  local order = table.concat(steps, " ")
+
+  it("delivers nothing", function()
+    assert.same(before, #sent)
+  end)
+
+  it("queues nothing either", function()
+    assert.same(0, queue.count())
+  end)
+
+  -- Neither the composer nor the target picker: abandoning before a type is chosen costs
+  -- nothing at all, not even the question of where it would have gone.
+  it("asks nothing further", function()
+    assert.same("type", order)
+    assert.same(composed_before, #composed)
+  end)
+end)
+
 -- The promise the queue makes to a batch half assembled: an errand does not disturb it.
 describe("an immediate send beside a queue with something in it", function()
   queue.clear()

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -18,16 +18,31 @@ local root = assert(vim.uv.fs_realpath(fixture))
 
 local composed = {}
 local sent = {}
+-- What the adapters were asked for, in order. An immediate send has to choose a target
+-- before a word is typed, which is a claim about ordering and nothing else.
+local steps = {}
+local BATCH_TARGET = { short = "agent", pane_id = "wV:p3", cwd = root }
+-- Reassigned by the cases below; read at call time, the way a real picker's answer is.
+local target_answer = BATCH_TARGET
+-- Runs while the composer is open, before it answers. How a case makes the world change
+-- under a composer the way a language server does.
+local compose_hook
+
 codereview.setup({
   syntax = false,
   compose = function(ctx, on_accept, label)
     -- The mode the composer is entered in is part of its contract: a composer opened with
     -- a selection still active gets a buffer it cannot type into cleanly.
+    steps[#steps + 1] = "compose"
     composed[#composed + 1] = { ctx = ctx, label = label, mode = vim.fn.mode() }
+    if compose_hook then
+      compose_hook()
+    end
     on_accept(nil, "the note")
   end,
   pick_target = function(cb)
-    cb({ short = "agent", pane_id = "wV:p3", cwd = root })
+    steps[#steps + 1] = "target"
+    cb(target_answer)
   end,
   send = function(text, target)
     sent[#sent + 1] = { text = text, target = target }
@@ -731,7 +746,221 @@ describe("an untyped annotation in the queue and in the batch", function()
   end)
 end)
 
--- The two cases below reconfigure the plugin, so they come last.
+-- An immediate send: the same capture, delivered on its own instead of joining the queue.
+describe("sending one annotation immediately", function()
+  queue.clear()
+  local before = #sent
+  edit("src/main.lua")
+  codereview.annotate("bug", nil, { immediate = true })
+
+  it("hands a payload to the send adapter", function()
+    assert.same(before + 1, #sent)
+  end)
+
+  it("leaves the queue empty", function()
+    assert.same(0, queue.count())
+  end)
+end)
+
+-- The plugin owns this choice now, and it makes it before a word is typed: a target
+-- declined after the note is written costs the note.
+describe("where an immediate send goes", function()
+  queue.clear()
+  steps = {}
+  target_answer = { short = "solo", pane_id = "wV:p9", cwd = root }
+  edit("src/main.lua")
+  codereview.annotate("bug", nil, { immediate = true })
+  local order = table.concat(steps, " ")
+  target_answer = BATCH_TARGET
+
+  it("asks for a target before the composer opens", function()
+    assert.same("target compose", order)
+  end)
+
+  it("delivers to the target that was chosen for it", function()
+    assert.same("wV:p9", sent[#sent].target.pane_id)
+  end)
+
+  -- Batch routing and immediate-send routing are different things pointing at the same
+  -- kind of destination. An errand must not redirect the batch you are assembling.
+  it("leaves the batch's own target where it was", function()
+    assert.same("agent", require("codereview.view").target_label())
+  end)
+end)
+
+-- Distinct from having no picker at all, which sends to whatever the adapter defaults to.
+-- A picker that ran and came back empty is a reviewer who changed their mind.
+describe("declining to choose a target", function()
+  queue.clear()
+  steps = {}
+  local before = #sent
+  target_answer = nil
+  edit("src/main.lua")
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("bug", nil, { immediate = true })
+  restore()
+  local order = table.concat(steps, " ")
+  target_answer = BATCH_TARGET
+
+  it("never opens the composer, so no note is written for nothing", function()
+    assert.same("target", order)
+  end)
+
+  it("delivers nothing", function()
+    assert.same(before, #sent)
+  end)
+
+  it("queues nothing instead", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("says so rather than failing silently", function()
+    assert.is_true(h.notified(msgs, "No target chosen"), vim.inspect(msgs))
+  end)
+end)
+
+-- The promise the queue makes to a batch half assembled: an errand does not disturb it.
+describe("an immediate send beside a queue with something in it", function()
+  queue.clear()
+  edit("src/main.lua")
+  codereview.annotate("bug")
+  local queued_before = vim.deepcopy(queue.all())
+
+  local before = #sent
+  edit("src/routes.lua")
+  codereview.annotate("nitpick", nil, { immediate = true })
+  local text = sent[#sent].text
+
+  it("leaves what was queued exactly as it was", function()
+    assert.same(1, queue.count())
+    assert.same(queued_before[1].path, queue.all()[1].path)
+    assert.same(queued_before[1].note, queue.all()[1].note)
+  end)
+
+  it("renders one annotation, not the queue", function()
+    assert.same(before + 1, #sent)
+    assert.is_truthy(text:find("Code review — 1 annotation", 1, true), text)
+    assert.is_truthy(text:find("src/routes.lua", 1, true), text)
+    assert.is_nil(text:find("src/main.lua", 1, true), text)
+  end)
+
+  -- The same renderer a batch goes through, which is what keeps one payload format:
+  -- grouped under its type's heading, with that type's directive.
+  it("groups it under its type, as a batch of one", function()
+    assert.is_truthy(text:find("## Nitpicks (1)", 1, true), text)
+    assert.is_truthy(text:find("the note", 1, true), text)
+  end)
+end)
+
+-- Fired from a mapping for the reason `<F5>` is: the selection has to still be live when
+-- capture reads it, which is only true from inside a visual-mode mapping.
+vim.keymap.set({ "n", "x" }, "<F6>", function()
+  codereview.annotate("bug", nil, { immediate = true })
+end, { desc = "capture_spec: send as bug, immediately" })
+
+describe("sending a visual selection immediately", function()
+  queue.clear()
+  local before = #sent
+  edit("src/main.lua")
+  h.feed("1GVj<F6>")
+  local text = sent[#sent].text
+
+  it("delivers it without queueing it", function()
+    assert.same(before + 1, #sent)
+    assert.same(0, queue.count())
+  end)
+
+  it("names exactly the lines that were selected", function()
+    assert.is_truthy(text:find("@src/main.lua#L1-2", 1, true), text)
+  end)
+
+  -- The queued path escapes visual mode before the composer opens; so must this one, or
+  -- the composer is entered with a selection still live.
+  it("leaves visual mode before the composer opens", function()
+    assert.same("n", composed[#composed].mode)
+  end)
+end)
+
+-- A thought with no file behind it is still worth sending on its own.
+describe("sending a bare note immediately", function()
+  queue.clear()
+  local before = #sent
+  vim.cmd("enew")
+  codereview.annotate("bug", nil, { immediate = true })
+  local text = sent[#sent].text
+
+  it("delivers it with nothing to anchor to", function()
+    assert.same(before + 1, #sent)
+    assert.is_truthy(text:find("(no file)", 1, true), text)
+  end)
+
+  it("still leaves the queue alone", function()
+    assert.same(0, queue.count())
+  end)
+end)
+
+-- An `@ref` only resolves relative to whoever reads it, so it is rendered against the
+-- directory this note is going to -- not against this Neovim's.
+describe("sending to a target whose working directory is elsewhere", function()
+  queue.clear()
+  target_answer = { short = "far", pane_id = "wV:p4", cwd = "/nowhere/else" }
+  edit("src/main.lua")
+  h.feed("1GVj<F6>")
+  target_answer = BATCH_TARGET
+  local text = sent[#sent].text
+
+  it("carries the code instead of a reference the target could not follow", function()
+    assert.is_nil(text:find("@src/main.lua", 1, true), text)
+    assert.is_truthy(text:find("```diff", 1, true), text)
+    local source = vim.fn.readfile(vim.fs.joinpath(root, "src/main.lua"))
+    assert.is_truthy(text:find(source[1], 1, true), text)
+  end)
+end)
+
+-- A language server is free to republish while a composer is open. What rides along has to
+-- be what was on screen when the note was started, which is only true if diagnostics are
+-- read before the composer opens rather than inside its callback.
+describe("diagnostics on an immediate send", function()
+  local ns = vim.api.nvim_create_namespace("capture_spec_immediate_diagnostics")
+  local buf = edit("src/main.lua")
+  local S = vim.diagnostic.severity
+
+  ---@param message string
+  local function publish(message)
+    vim.diagnostic.set(ns, buf, {
+      { lnum = 0, col = 0, severity = S.ERROR, message = message, source = "lua_ls" },
+    })
+  end
+
+  publish("on screen when the note was started")
+  local republished = false
+  compose_hook = function()
+    publish("republished while the composer was open")
+    republished = true
+  end
+
+  queue.clear()
+  codereview.annotate("bug", nil, { immediate = true })
+  compose_hook = nil
+  vim.diagnostic.reset(ns, buf)
+  local text = sent[#sent].text
+
+  -- Without this the case below passes whether or not anything republished, which is the
+  -- fixture trap: an assertion that cannot fail is measuring nothing.
+  it("ran a language server that republished under the composer", function()
+    assert.is_true(republished)
+  end)
+
+  it("carries what the language server had when the note was started", function()
+    assert.is_truthy(text:find("on screen when the note was started", 1, true), text)
+  end)
+
+  it("does not carry what it republished while the composer was open", function()
+    assert.is_nil(text:find("republished while the composer was open", 1, true), text)
+  end)
+end)
+
+-- The cases below reconfigure the plugin, so they come last.
 
 -- What a host that wires nothing gets is the plugin's own composer -- from capture exactly
 -- as from the review view, since both arrive through the same tail. `vim.ui.input` is not
@@ -842,5 +1071,66 @@ describe("with a custom type vocabulary", function()
     assert.same(3, #offered)
     assert.is_truthy(offered[1]:find("blocker", 1, true), vim.inspect(offered))
     assert.is_truthy(offered[3]:find("no type", 1, true), vim.inspect(offered))
+  end)
+end)
+
+-- Nothing to choose between, and no way to decline. The plugin carries no opinion about
+-- where a payload goes, so it delivers with no target and lets the adapter decide what
+-- that means -- refusing here would be an opinion about transport.
+describe("an immediate send with no target picker wired", function()
+  local delivered = {}
+  codereview.setup({
+    syntax = false,
+    compose = function(_, on_accept)
+      on_accept(nil, "no picker here")
+    end,
+    send = function(text, to)
+      delivered[#delivered + 1] = { text = text, target = to }
+    end,
+  })
+  queue.clear()
+  edit("src/main.lua")
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("bug", nil, { immediate = true })
+  restore()
+
+  it("delivers it anyway, with no target", function()
+    assert.same(1, #delivered)
+    assert.is_nil(delivered[1].target)
+    assert.is_truthy(delivered[1].text:find("no picker here", 1, true), delivered[1].text)
+  end)
+
+  it("says there was nothing to choose from", function()
+    assert.is_true(h.notified(msgs, "No pick_target adapter configured"), vim.inspect(msgs))
+  end)
+end)
+
+-- The fallback a batch already has, for the same reason: a note is never dropped in
+-- silence because the host wired no delivery.
+describe("an immediate send with no send adapter wired", function()
+  codereview.setup({
+    syntax = false,
+    compose = function(_, on_accept)
+      on_accept(nil, "nowhere to send this")
+    end,
+  })
+  queue.clear()
+  edit("src/main.lua")
+  vim.fn.setreg("+", "")
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("bug", nil, { immediate = true })
+  restore()
+
+  it("falls back to the clipboard", function()
+    assert.is_truthy(vim.fn.getreg("+"):find("nowhere to send this", 1, true), vim.fn.getreg("+"))
+  end)
+
+  it("does not claim to have sent it", function()
+    assert.is_true(h.notified(msgs, "No send adapter configured"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "Sent bug"), vim.inspect(msgs))
+  end)
+
+  it("still leaves the queue alone", function()
+    assert.same(0, queue.count())
   end)
 end)

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -13,12 +13,19 @@ local pending_pick -- the picker's callback, held so it answers on a later tick 
 local file_answer -- what the file picker answers with; nil is a cancel
 local file_picks = 0 -- how many times it was opened at all
 local file_pick_hook -- runs inside the picker, before it answers
+local sent = {} -- what reached the delivery adapter
+-- What the target picker answers with next. Reassigned by the cases that need the batch's
+-- target and a note's target to be different things.
+local pick_answer = { short = "janus · api", pane_id = "wV:p3", cwd = "/elsewhere" }
 require("codereview").setup({
   syntax = false,
   pick_target = function(cb)
     pending_pick = function()
-      cb({ short = "janus · api", pane_id = "wV:p3", cwd = "/elsewhere" })
+      cb(pick_answer)
     end
+  end,
+  send = function(text, to)
+    sent[#sent + 1] = { text = text, target = to }
   end,
   -- Answers inline. A real picker takes focus and gives it back; `file_pick_hook` is how a
   -- test makes it behave like one -- moving the cursor, say -- before it answers.
@@ -752,6 +759,142 @@ describe("a draft old enough to have aged out", function()
   end
 end)
 
+--- Immediate sends ------------------------------------------------------------
+
+---@param win integer
+---@return string
+local function footer_of(win)
+  local cfg_win = vim.api.nvim_win_get_config(win)
+  return cfg_win.footer and tostring(cfg_win.footer[1][1]) or ""
+end
+
+---Start an immediate send from an ordinary buffer, in a tab of its own.
+---
+---Through the public capture seam, because that is the only way in: there is no "open the
+---composer" API and no sibling entry point for sending.
+---@param answer table|nil What the target picker answers with
+---@return integer origin The window it was started from
+local function send_from_buffer(answer)
+  local path = V.files[V.render.anchors[row_of("line")].file].path
+  vim.cmd("tabedit " .. vim.fn.fnameescape(path))
+  local origin = vim.api.nvim_get_current_win()
+  pending_pick = nil
+  pick_answer = answer
+  require("codereview").annotate("bug", nil, { immediate = true })
+  return origin
+end
+
+-- The note carries its own target here, so the footer has to name *that* one and `^T` has
+-- to change it. Both are wrong on the host's equivalent path today: the footer names the
+-- batch's target while the note goes somewhere else entirely.
+describe("the composer on an immediate send", function()
+  reset()
+  local before = #sent
+
+  -- A batch target first, and a different one, so a footer naming the wrong choice is
+  -- visible rather than coincidentally right.
+  pick_answer = { short = "janus · api", pane_id = "wV:p3", cwd = "/elsewhere" }
+  view.pick_target()
+  if pending_pick then
+    pending_pick()
+  end
+
+  local origin = send_from_buffer({ short = "shell", pane_id = "wV:p7", cwd = vim.uv.cwd() })
+
+  it("asks for a target before the composer opens", function()
+    assert.is_nil(floating(), "the composer opened before a target was chosen")
+    assert.is_truthy(pending_pick, "the target picker was never opened")
+  end)
+
+  if pending_pick then
+    pending_pick()
+  end
+  local win = floating()
+  local chosen_footer = win and footer_of(win) or ""
+
+  it("opens the composer once a target is chosen", function()
+    assert.is_truthy(win, "no composer window was opened")
+  end)
+
+  it("names the note's target, not the batch's", function()
+    assert.is_truthy(chosen_footer:find("shell", 1, true), chosen_footer)
+    assert.is_falsy(chosen_footer:find("janus", 1, true), chosen_footer)
+  end)
+
+  it("names the submit key with the verb this path passes", function()
+    assert.is_truthy(chosen_footer:find("send", 1, true), chosen_footer)
+  end)
+
+  pending_pick = nil
+  pick_answer = { short = "third", pane_id = "wV:p9", cwd = vim.uv.cwd() }
+  h.feed("<C-t>")
+  if pending_pick then
+    pending_pick()
+  end
+  local rerouted_footer = win and footer_of(win) or ""
+
+  it("reroutes this note when ^T is pressed, and says where to", function()
+    assert.is_truthy(rerouted_footer:find("third", 1, true), rerouted_footer)
+  end)
+
+  it("leaves the batch pointing where it was", function()
+    assert.same("janus · api", view.target_label())
+  end)
+
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "send this one now" })
+  h.feed("<C-s>")
+
+  it("delivers to the target the note was rerouted to", function()
+    assert.same(before + 1, #sent)
+    assert.same("third", sent[#sent].target.short)
+    assert.is_truthy(sent[#sent].text:find("send this one now", 1, true), sent[#sent].text)
+  end)
+
+  it("queues nothing on the way", function()
+    assert.same(0, queue.count())
+  end)
+
+  vim.cmd("tabclose")
+end)
+
+-- Walking away from an immediate send costs no more than walking away from a queued one.
+describe("abandoning an immediate send", function()
+  reset()
+  local before = #sent
+  local origin = send_from_buffer({ short = "shell", pane_id = "wV:p7", cwd = vim.uv.cwd() })
+  if pending_pick then
+    pending_pick()
+  end
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "half a thought, sent nowhere" })
+  h.feed("q")
+  local landed = settled(origin)
+
+  it("delivers nothing", function()
+    assert.same(before, #sent)
+  end)
+
+  it("returns focus to the window it was started from", function()
+    assert.same(origin, landed)
+  end)
+
+  require("codereview").annotate("bug", nil, { immediate = true })
+  if pending_pick then
+    pending_pick()
+  end
+  local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local win = floating()
+  h.feed("q")
+
+  it("keeps what was written as a draft", function()
+    assert.same({ "half a thought, sent nowhere" }, reopened)
+  end)
+
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+  vim.cmd("tabclose")
+end)
+
 -- Reconfigures, so it comes after everything that wants a picker. The plugin ships none:
 -- every config already has one, and `@` staying a literal `@` is what "the composer is
 -- still fully usable without it" means.
@@ -805,4 +948,83 @@ describe("with a composer wired", function()
     assert.is_truthy(seen.ctx.file_path)
     assert.same(V.win, seen.ctx.origin_win)
   end)
+end)
+
+-- Routing is part of the compose contract, not a private arrangement with the composer the
+-- plugin ships. A host composer has to be able to name this note's target and change it
+-- too, or "the footer names where the note goes" is only true of one composer.
+describe("a host composer on an immediate send", function()
+  local seen
+  local named = {}
+  local host_sent = {}
+  require("codereview").setup({
+    syntax = false,
+    pick_target = function(cb)
+      pending_pick = function()
+        cb(pick_answer)
+      end
+    end,
+    send = function(text, to)
+      host_sent[#host_sent + 1] = { text = text, target = to }
+    end,
+    compose = function(ctx, on_accept, composer_label)
+      seen = { ctx = ctx, label = composer_label }
+      -- A note joining the queue is routed by the batch, so it is handed nothing: a host
+      -- composer written before any of this keeps working untouched.
+      if not ctx.routing then
+        on_accept(nil, "queued through the host's composer")
+        return
+      end
+      named[#named + 1] = ctx.routing.label()
+      pick_answer = { short = "elsewhere", pane_id = "wV:p8", cwd = vim.uv.cwd() }
+      ctx.routing.pick(function()
+        named[#named + 1] = ctx.routing.label()
+        on_accept(nil, "sent through the host's composer")
+      end)
+      -- The picker answers on a later tick, as a real one does.
+      pending_pick()
+    end,
+  })
+
+  reset()
+  send_from_buffer({ short = "first", pane_id = "wV:p1", cwd = vim.uv.cwd() })
+  if pending_pick then
+    pending_pick()
+  end
+
+  it("passes the `send` verb rather than `queue`", function()
+    assert.same("send", seen.label)
+  end)
+
+  it("hands it the rest of the context unchanged", function()
+    assert.same("none", seen.ctx.scope)
+    assert.is_truthy(seen.ctx.label)
+    assert.is_truthy(seen.ctx.rel_path)
+    assert.is_truthy(seen.ctx.file_path)
+    assert.is_truthy(seen.ctx.origin_win)
+  end)
+
+  it("lets it name the target before and after rerouting", function()
+    assert.same({ "first", "elsewhere" }, named)
+  end)
+
+  it("delivers where the host composer rerouted it", function()
+    assert.same(1, #host_sent)
+    assert.same("elsewhere", host_sent[1].target.short)
+    assert.is_truthy(host_sent[1].text:find("sent through the host's composer", 1, true), host_sent[1].text)
+  end)
+
+  it("queues nothing", function()
+    assert.same(0, queue.count())
+  end)
+
+  require("codereview").annotate("bug")
+
+  it("hands no routing to a note that joins the queue", function()
+    assert.is_nil(seen.ctx.routing)
+    assert.same(1, queue.count())
+    assert.same("queued through the host's composer", queue.all()[1].note)
+  end)
+
+  vim.cmd("tabclose")
 end)


### PR DESCRIPTION
Closes #33.

> Stacked on #34 — this PR targets `feat/34-untyped-annotation`, not `master`. Review the
> diff against that base.


One capture path, with delivery as a property of the call rather than a different door.
`codereview.annotate` grows an options argument:

```lua
require("codereview").annotate("bug", nil, { immediate = true })
```

Everything above that branch is the capture both paths already shared — symlink-correct
path resolution, the blob, diagnostics, drafts, `@` references, one entry shape. No
sibling entry point was added and the composer is still unexported.

## What it does

An **immediate send** renders through the same payload renderer a **batch** does,
producing a batch of one, and hands it to the host's `send` adapter. The **queue** is
untouched: the annotation never joins it, and anything already queued is neither delivered
nor cleared.

The **target** is chosen per note, *before* the composer opens, so declining costs no
typing rather than costing the note. Declining abandons the send and says so. With no
`pick_target` wired there is nothing to choose between and no way to decline, so it goes
with no target and the `send` adapter decides what that means — refusing there would be an
opinion about transport, which ADR-0001 says the plugin does not have. With no `send`
either, the payload lands in the `+` register exactly as a batch does.

## The two defects it fixes

Because the plugin now holds that choice, the **composer** can tell the truth about it:

- the footer names the target *this note* will reach, not the batch's;
- `^T` reroutes the note, leaving the batch pointing where it was.

Both were wrong on the host's equivalent path — the footer named the batch target while
the note went somewhere else entirely. Both regression tests were confirmed failing
against the old behaviour before the fix landed.

The seam is `ctx.routing = { label(), pick(on_done) }`, a public extension of the
`compose` adapter's context, documented in the README, `:h codereview-opt-compose` and
`config.lua`. It is absent for a note joining the queue, which the batch routes — so a
host composer written before this keeps working untouched.

## Decisions

ADR-0004 moves from `proposed` to `accepted`; it records the batch-of-one decision and the
alternatives rejected with it.

Diagnostics are read before the composer opens rather than inside its callback, so a
language server republishing under an open composer cannot change what rides along. The
spec republishes from inside the composer stub to prove it, with a positive control so the
assertion cannot pass vacuously.

`view.submit` and the immediate send now share one `deliver` seam and one target picker
(`refactor(view)`, the first commit) — a second copy of either is how two payload formats
and two focus behaviours start.

## With no annotation type

The two slices meet here, and neither had covered the meeting point: an immediate send
where the reviewer declines a type. That is the interaction ADR-0004 names as the reason a
type became optional at all — a batch of one must not be the one thing that forces one onto
a remark carrying no instruction.

Declining now reaches the send tail carrying no type, lands in the `## Untyped (1)` group
with no directive, and leaves the queue alone. Dismissing the same picker still abandons
the send outright and asks nothing further — not the composer, and not where the note would
have gone. Both pickers are answered before a word is written: type, then target, then the
composer.

Taking either side of the rebase alone fails those cases, which is what makes them worth
having: the queued tail queues an immediate send instead of delivering it, and the send tail
indexes a type that is not there.

## Coverage

Driven at the existing capture seam with the delivery adapter stubbed, per the PRD:
`capture_spec` covers the send, the untouched queue, ordering, declining, a visual
selection, a whole file, a bare note, diagnostics, refs against the target's working
directory, and both missing-adapter paths; `composer_spec` covers the footer, the routing
key, drafts and focus on abandonment, and the same contract through a host-injected
composer. `make all` is green — 16 spec files, no failures.
