### PR TITLE
fix(composer): say when there is no file picker to reference with

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,8 @@ opts = {
   pick_target = function(cb) cb({ short = "agent", cwd = "/path" }) end,
 
   -- Choose a file to reference from `@` inside the composer. The plugin ships no picker,
-  -- so without this `@` stays a literal `@`. `first`/`last` are optional — omit them and
-  -- the reference is to the file rather than to a range in it.
+  -- so without this `@` stays a literal `@` and says so. `first`/`last` are optional —
+  -- omit them and the reference is to the file rather than to a range in it.
   pick_file = function(cb) cb({ path = "src/main.lua", first = 12, last = 20 }) end,
 
   -- Collect note text. Without it you get the composer the plugin ships, which implements

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -225,6 +225,12 @@ and the space after it, or past the `@` if you cancelled, and back in insert
 mode. A picker takes focus and insert mode with it, and asking for a reference
 mid-sentence is not asking to stop writing.
 
+With no |codereview-opt-pick_file| wired at all, the `@` is all you get and the
+composer says so rather than doing nothing quietly -- a key that reports
+nothing is indistinguishable from a broken one. It costs you the reference and
+nothing else: the composer stays open, at the same place, and the note carries
+on around the `@`.
+
 Drafts                                                  *codereview-drafts*
 
 Abandon the composer with something in it and the text is kept. Annotate that
@@ -358,7 +364,7 @@ pick_target({cb})                                 *codereview-opt-pick_target*
 pick_file({cb})                                     *codereview-opt-pick_file*
         Choose a file to reference from inside the composer and call {cb} with
         it. The plugin ships no picker -- every config already has one -- so
-        without this `@` stays a literal `@` and opens nothing: >
+        without this `@` stays a literal `@` and says so: >
             cb({ path = "src/main.lua", first = 12, last = 20 })
 <
         `first` and `last` are optional. A picker that cannot select lines

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -126,6 +126,15 @@ function M.open(ctx, on_accept, label)
 
     local pick_file = config.get().pick_file
     if not pick_file then
+      -- Said out loud, because a host that wires its adapters up incompletely otherwise
+      -- gets a key that does nothing, which is indistinguishable from one that is broken.
+      -- The sentinel stays where it was written: what is missing is the reference, not the
+      -- character the reviewer just typed.
+      vim.notify(
+        "No file picker configured — set pick_file to reference a file",
+        vim.log.levels.WARN,
+        { title = "Code review" }
+      )
       return
     end
     pick_file(function(chosen)

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -330,9 +330,11 @@ end)
 describe("referencing a file", function()
   reset()
   file_answer = { path = "apps/web/src/index.lua" }
+  local msgs, restore = h.capture_notify()
   annotate_line()
   local composer_win = floating()
   h.feed("i@")
+  restore()
   local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
   -- Closed through the API, not by feeding `q`: abandoning has its own test, and a stray
   -- `q` that arrives after the composer has gone reaches the review buffer, where it
@@ -350,6 +352,12 @@ describe("referencing a file", function()
   -- a note, not the end of one.
   it("splices a reference to the chosen file", function()
     assert.same("@apps/web/src/index.lua ", line)
+  end)
+
+  -- The warning a host without a picker gets is for that host alone. One wired up properly
+  -- is told nothing, because there is nothing the matter.
+  it("says nothing about a missing picker", function()
+    assert.is_false(h.notified(msgs, "file picker"), vim.inspect(msgs))
   end)
 end)
 
@@ -926,15 +934,23 @@ describe("abandoning an immediate send", function()
 end)
 
 -- Reconfigures, so it comes after everything that wants a picker. The plugin ships none:
--- every config already has one, and `@` staying a literal `@` is what "the composer is
--- still fully usable without it" means.
+-- every config already has one, so a host is entitled to have wired none up -- but it is
+-- entitled to be told, rather than to a key that appears broken.
+--
+-- Where the sentinel leaves the cursor is deliberately not asserted here. `h.feed` ends
+-- insert with an implied <Esc>, so the column readable from a headless spec is the one
+-- normal mode clamped it to, not the one a reviewer would be typing at. That half belongs
+-- to `interactive_spec`, which drives a pty.
 describe("with no file picker wired", function()
   require("codereview").setup({ syntax = false })
   reset()
+  local msgs, restore = h.capture_notify()
   annotate_line()
   local composer_win = floating()
   h.feed("ilook at @")
+  restore()
   local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
+  local open = composer_win ~= nil and vim.api.nvim_win_is_valid(composer_win)
   h.feed("<Esc>")
   if composer_win and vim.api.nvim_win_is_valid(composer_win) then
     vim.api.nvim_win_close(composer_win, true)
@@ -942,6 +958,34 @@ describe("with no file picker wired", function()
 
   it("inserts a literal @ and opens nothing", function()
     assert.same("look at @", line)
+  end)
+
+  -- A host that wired its adapters up incompletely gets told. Silence here is what made
+  -- the original defect read as intermittent rather than broken.
+  it("says the picker is missing rather than returning silently", function()
+    assert.is_true(h.notified(msgs, "file picker"), vim.inspect(msgs))
+  end)
+
+  it("leaves the composer open", function()
+    assert.is_true(open)
+  end)
+end)
+
+-- Open is not the same as usable. Being told the picker is missing has to cost the
+-- reference and nothing else: the note carries on around the `@` and still reaches the
+-- queue.
+describe("carrying on after a missing file picker", function()
+  reset()
+  annotate_line()
+  -- One feed, so the typing after the warning arrives in the insert mode the `@` was
+  -- pressed in rather than in normal mode.
+  h.feed("iread @ yourself")
+  -- A second feed, which normal mode is fine for: `^S` is bound in both.
+  h.feed("<C-s>")
+
+  it("keeps what was typed on either side of the sentinel, and queues it", function()
+    assert.same(1, queue.count())
+    assert.same("read @ yourself", queue.all()[1].note)
   end)
 end)
 


### PR DESCRIPTION
`@` writes its sentinel, consults `pick_file`, and returned silently when a host had wired none up. A key that reports nothing is indistinguishable from a broken one — and that is exactly how the load-order defect behind this presented: every adapter was `nil`, `@` did nothing at all, and triggering the plugin properly first made it start working, so it read as intermittent rather than as broken.

That cause is fixed host-side, so this is defensive. It is worth having anyway: the next host to wire its adapters up incompletely gets told, and the plugin is the only side that can tell it.

## What changed

- The composer warns when a reference is requested and no `pick_file` adapter is configured.
- The sentinel still stays where it was written — what is missing is the reference, not the character just typed. The composer stays open at the same place and the note carries on around the `@`.
- A host with a picker wired sees no warning and no change in behaviour, asserted at the same seam.
- `doc/codereview.txt` and the README no longer describe the silent path.

## Notes

Where the sentinel leaves the cursor is deliberately not asserted headless: `h.feed` ends insert with an implied `<Esc>`, so the column a spec can read there is the one normal mode clamped it to, not the one a reviewer would be typing at. That half belongs to the pty. Verified interactively instead, against a config with no picker — the composer is still in insert mode after the warning, the cursor is past the `@`, and typing carries straight on into the queued note.

Each new assertion was confirmed able to fail before being kept: the warning case against the unfixed composer, and the "no warning when a picker is wired" and "composer stays open" cases against a mutated one.

`make all`: 592 assertions, 0 failures, lint clean.

Closes #36