### PR TITLE
refactor(state): move the queue restore latch to persistence

### DIFF
--- a/docs/agents/HANDOFF.md
+++ b/docs/agents/HANDOFF.md
@@ -53,7 +53,7 @@ its own throwaway fixture.
 
 Four of those drive a second Neovim rather than asserting in-process —
 `viewless_child.lua`, `capture_child.lua`, `norepo_child.lua`, `state_child.lua`. The queue
-restores **once per session** (`view.ensure_queue` latches), so anything testing restore or
+restores **once per session** (`state.ensure_queue` latches), so anything testing restore or
 clobbering needs a second *process*, not an in-process reset.
 
 Decisions worth not re-litigating, and the four things that changed along the way:

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -420,7 +420,13 @@ function M.queue_entry(entry, type_def, opts)
   -- document, so queueing into a queue this session has never read back would drop
   -- whatever the last session left. A review view has already restored by the time it
   -- gets here; capture from a buffer can be the very first thing a session does.
-  require("codereview.view").ensure_queue()
+  local staled = require("codereview.state").ensure_queue()
+  if staled > 0 then
+    -- Worded exactly as a review reports staleness, and said before the composer opens:
+    -- which path happened to read the queue back is not something a reviewer should be
+    -- able to hear.
+    info(("%d annotation%s now stale"):format(staled, staled == 1 and "" or "s"))
+  end
   collect(compose_ctx(entry, type_def), "queue", function(text)
     entry.note = note_with(text, opts)
     queue.add(entry)

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -221,6 +221,39 @@ function M.restore_queue(root)
   return M.reconcile_queue(root)
 end
 
+---The repository the queue belongs to when no view is open.
+---@return string|nil
+local function ambient_root()
+  return require("codereview.git").root(vim.fn.getcwd())
+end
+
+-- Restored lazily, and once. `count()` is the sort of thing a statusline calls on every
+-- redraw, so reading the state file each time is not an option; and eagerly at startup is
+-- worse, because the working directory that decides which repository's queue to load may
+-- not be the one the user ends up in.
+local queue_restored = false
+
+---Load the persisted queue if this session has not seen it yet.
+---
+---Public because adding to the queue has to be able to demand it, not just reading it:
+---`persist_queue` writes memory over the document, so anything that queues an annotation
+---before the session has read the queue back would silently drop what the last session
+---left. Capture makes that reachable as the very first thing a session does.
+---
+---Counted rather than announced, as reconciliation is: how many restored annotations are
+---untrustworthy is a fact about the store, and the sentence a reviewer reads belongs to
+---whichever surface asked.
+---@return integer staled 0 once the queue has already been read back this session
+function M.ensure_queue()
+  if queue_restored then
+    return 0
+  end
+  queue_restored = true
+  -- No root is not a reason to skip: annotations with no repository behind them live in a
+  -- store that does not need one, and they would otherwise never come back.
+  return M.restore_queue(ambient_root())
+end
+
 ---Restore saved progress into a freshly opened view.
 ---@param view CRView
 ---@param scope_key string

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -226,29 +226,15 @@ function M.persist()
   require("codereview.state").persist_queue(ambient_root())
 end
 
--- Restored lazily, and once. `count()` is the sort of thing a statusline calls on every
--- redraw, so reading the state file each time is not an option; and eagerly at startup is
--- worse, because the working directory that decides which repository's queue to load may
--- not be the one the user ends up in.
-local queue_restored = false
-
----Load the persisted queue if this session has not seen it yet.
+---Read the persisted queue back if this session has not, and say what came back stale.
 ---
----Public because adding to the queue has to be able to demand it, not just reading it:
----`persist_queue` writes memory over the document, so anything that queues an annotation
----before the session has read the queue back would silently drop what the last session
----left. Capture makes that reachable as the very first thing a session does.
-function M.ensure_queue()
-  if queue_restored then
-    return
-  end
-  queue_restored = true
-  -- No root is not a reason to skip: annotations with no repository behind them live in a
-  -- store that does not need one, and they would otherwise never come back.
-  local staled = require("codereview.state").restore_queue(ambient_root())
+---The latch itself belongs to persistence, which owns the stores it reads and returns a
+---count rather than phrasing one. What is left here is the sentence, worded exactly as a
+---review reports staleness: with no view open this is the only moment a restored
+---annotation's untrustworthy line anchors would otherwise go unmentioned.
+local function ensure_queue()
+  local staled = require("codereview.state").ensure_queue()
   if staled > 0 then
-    -- Worded exactly as the review view reports it. With no view open this is the only
-    -- moment a restored annotation's staleness would otherwise go unmentioned.
     info(("%d annotation%s now stale"):format(staled, staled == 1 and "" or "s"))
   end
 end
@@ -911,7 +897,7 @@ end
 function M.submit()
   local queue = require("codereview.queue")
 
-  M.ensure_queue()
+  ensure_queue()
   if queue.count() == 0 then
     info("Queue is empty — annotate something first")
     return
@@ -963,7 +949,7 @@ end
 ---List the queued annotations, drop any of them, then submit the batch.
 function M.review_queue()
   local queue = require("codereview.queue")
-  M.ensure_queue()
+  ensure_queue()
   if queue.count() == 0 then
     info("Queue is empty — annotate something first")
     return

--- a/tests/README.md
+++ b/tests/README.md
@@ -95,7 +95,7 @@ so the out-of-core language path is still checked locally without ever failing C
   the whole file instead. Feed the keys and the mapping together (`h.feed("1GVj<F5>")`), as
   `annotate_spec` does for the review path.
 - **The queue is restored once per session, so a second session means a second process.**
-  `view.ensure_queue()` latches after the first read, which is what stops a statusline
+  `state.ensure_queue()` latches after the first read, which is what stops a statusline
   calling `count()` from hitting the disk on every redraw. Clearing the queue in-process
   therefore does *not* simulate a restart — the latch is still set, nothing reloads, and an
   assertion about restoring is measuring nothing. `capture_spec` spawns

--- a/tests/codereview/norepo_child.lua
+++ b/tests/codereview/norepo_child.lua
@@ -26,7 +26,7 @@ codereview.setup({
 })
 
 local queue = require("codereview.queue")
-local view = require("codereview.view")
+local state = require("codereview.state")
 
 if mode == "write" then
   vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/main.lua")))
@@ -40,8 +40,10 @@ if mode == "write" then
 
   print("queued: " .. queue.count())
 else
-  -- What any new session does the first time it touches the queue.
-  view.ensure_queue()
+  -- What any new session does the first time it touches the queue. Called on the
+  -- persistence module rather than through the review view: reading the queue back does
+  -- not need a view, and this process deliberately never opens one.
+  state.ensure_queue()
   local kinds = {}
   for _, item in ipairs(queue.all()) do
     kinds[#kinds + 1] = ("%s/%s"):format(item.type, item.kind)


### PR DESCRIPTION
The queue is restored from disk lazily and exactly once per session. That latch lived on
the review view, so anything needing a restored queue had to load the largest module in the
plugin to get one — including capture, which can reach it as the very first thing a session
does, and including delivery once it moves out.

It now lives in the module that owns persistence, which already holds the restore it calls
and the reconciliation that judges what came back.

Both properties the latch exists for are preserved:

- **Once per session** — a statusline asking for the annotation count must not read the
  state file on every redraw.
- **Lazy, not eager** — the working directory that decides which repository's queue to load
  is not necessarily the one the editor started in, so the repository root is still resolved
  at call time.

Following the convention reconciliation already sets, the latch returns how many restored
annotations were found stale rather than notifying; the review view and capture each phrase
it. The sentence a reviewer sees is unchanged, and appears at the same moment.

Capture still restores before it queues, so a first-thing-in-a-session capture cannot write
an unread queue over what the previous session left.

`norepo_child.lua` calls the latch in its new home rather than being collapsed into its
parent process — the latch is once per session by design, so clearing state in-process
would prove nothing about a restart. The testing guide and the agent handoff note are
updated to name the latch where it now lives.

`make all` is green: lint plus 16 spec files, no failures and no errors.

Closes #42