### PR TITLE
refactor(delivery): give routing a module of its own

### DIFF
--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -7,6 +7,7 @@
 ---    line it names no longer exists and that number now belongs to unrelated code;
 ---  * a hunk is always inlined, for the same reason -- what changed is the point.
 local config = require("codereview.config")
+local delivery = require("codereview.delivery")
 local queue = require("codereview.queue")
 local render = require("codereview.render")
 local types = require("codereview.types")
@@ -456,14 +457,14 @@ function M.send_entry(entry, type_def, opts)
   local to = nil
 
   ---What the composer names in its footer and changes with its routing key. The batch's
-  ---equivalent is `view.routing()`; this is the same shape for a note that owns its own
+  ---equivalent is `delivery.routing()`; this is the same shape for a note that owns its own
   ---destination, which is what lets one composer tell the truth on both paths.
   local routing = {
     label = function()
-      return view.label_of(to)
+      return delivery.label_of(to)
     end,
     pick = function(on_done)
-      local asked = view.choose_target(function(picked)
+      local asked = delivery.choose_target(function(picked)
         -- Declining a reroute is "never mind", not "send it nowhere". The note is written
         -- by now, and dropping the target it already had would redirect it in the one
         -- direction nobody asked for.
@@ -497,7 +498,7 @@ function M.send_entry(entry, type_def, opts)
 
   -- Asked before the composer opens, not after it closes: declining then costs nothing,
   -- where declining after the note is written costs the note.
-  local asked = view.choose_target(function(picked)
+  local asked = delivery.choose_target(function(picked)
     -- A picker that ran and came back empty is a reviewer who chose not to send. Said out
     -- loud, because a note that goes nowhere in silence looks exactly like one that was
     -- delivered.

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -24,7 +24,7 @@ function M.open(ctx, on_accept, label)
   -- The batch's routing by default, because a note written here joins the batch. An
   -- immediate send hands its own on the context: that note has a target of its own, and
   -- naming the batch's would name a destination this note is not going to.
-  local routing = ctx.routing or require("codereview.view").routing()
+  local routing = ctx.routing or require("codereview.delivery").routing()
 
   local width = math.min(84, math.max(40, math.floor(vim.o.columns * 0.7)))
   local height = 6

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -1,0 +1,110 @@
+---Where a batch is going, and how that choice is made.
+---
+---Routing is a property of the batch, not of whichever window asked. Holding it here is
+---what lets the winbar, the queue float and the composer all name the same choice without
+---any of them loading a review view to read it -- and what lets it be chosen at all with
+---nothing open.
+---
+---Windows are deliberately not its business. It calls the picker adapter and keeps what
+---comes back; putting focus back where the question was asked is the one concession, and
+---only because the picker answers on a later tick, by which time no caller is still on the
+---stack to do it. What a surface then has to repaint is the surface's own affair.
+local config = require("codereview.config")
+
+local M = {}
+
+---@param msg string
+local function info(msg)
+  vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
+
+---Where the next batch goes, or nil for the adapter's default.
+---
+---Module-level for the reason the queue is: it describes what you are submitting to, not
+---what you are looking at. Held on the view, choosing a target with nothing open ran the
+---picker and discarded the answer, and the batch went to the default having just asked.
+---
+---Deliberately not persisted. The queue is worth keeping across a restart; a target
+---identifies a live destination -- a herdr pane id, say -- and restoring a dead one would
+---route a batch into nothing, which is worse than asking again.
+---@type table|nil
+local target = nil
+
+---The batch's target, as the send adapter is handed it.
+---@return table|nil
+function M.target()
+  return target
+end
+
+---Short name for a target, or what to call the adapter's own default.
+---
+---One wording for every piece of chrome that names a destination -- the winbar, the queue
+---float, and a composer footer whichever choice it is naming.
+---@param to table|nil
+---@return string
+function M.label_of(to)
+  return (to and to.short) or "local"
+end
+
+---Short name of where the batch is going.
+---@return string
+function M.target_label()
+  return M.label_of(target)
+end
+
+---The batch's routing, in the shape a composer is handed.
+---
+---What a note joining the queue is routed by, and so the composer's default. An immediate
+---send supplies its own instead, because that note has a target of its own.
+---@return { label: fun(): string, pick: fun(on_done: fun()|nil) }
+function M.routing()
+  return { label = M.target_label, pick = M.pick_target }
+end
+
+---Ask the host where something should go, holding focus where the question was asked.
+---
+---Says nothing about *what* is being routed: the batch's target is one caller, a single
+---note being sent on its own is another, and neither should have to reimplement the focus
+---dance around an asynchronous picker to have its own answer.
+---@param cb fun(picked: table|nil) nil is a decline, which every caller reads its own way
+---@return boolean asked false when no picker adapter is wired, so nothing was asked
+function M.choose_target(cb)
+  local cfg = config.get()
+  if not cfg.pick_target then
+    return false
+  end
+
+  -- Return focus to whichever window asked, not to whatever the picker last left current.
+  -- Picking a target from the queue float used to dump the cursor into the diff buffer,
+  -- where `<C-s>` hits the main buffer's mapping -- which submits but leaves the float open
+  -- behind it.
+  local return_win = vim.api.nvim_get_current_win()
+
+  cfg.pick_target(function(picked)
+    if vim.api.nvim_win_is_valid(return_win) then
+      vim.api.nvim_set_current_win(return_win)
+    end
+    cb(picked)
+  end)
+  return true
+end
+
+---Choose where the batch goes, through the injected picker.
+---@param on_done fun()|nil Runs after a target is chosen, once the picker has closed
+function M.pick_target(on_done)
+  local asked = M.choose_target(function(picked)
+    -- Recorded before any surface is touched. This used to return early with no view, which
+    -- meant the picker ran, the user answered, and the answer was dropped.
+    target = picked
+    -- The picker is asynchronous, so anything that has to reflect the new target has to be
+    -- driven from here; running it after `pick_target` returns repaints too early.
+    if on_done then
+      on_done()
+    end
+  end)
+  if not asked then
+    info("No pick_target adapter configured — submitting locally")
+  end
+end
+
+return M

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -7,6 +7,7 @@ local git = require("codereview.git")
 local render = require("codereview.render")
 local panel = require("codereview.panel")
 local hl = require("codereview.hl")
+local delivery = require("codereview.delivery")
 
 local M = {}
 
@@ -31,18 +32,6 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 
 ---@type CRView|nil
 local V = nil
-
----Where the next batch goes, or nil for the adapter's default.
----
----Module-level for the reason the queue is: it describes what you are submitting to, not
----what you are looking at. Held on the view, choosing a target with nothing open ran the
----picker and discarded the answer, and the batch went to the default having just asked.
----
----Deliberately not persisted. The queue is worth keeping across a restart; a target
----identifies a live destination -- a herdr pane id, say -- and restoring a dead one would
----route a batch into nothing, which is worse than asking again.
----@type table|nil
-local target = nil
 
 ---@param msg string
 local function warn(msg)
@@ -152,8 +141,9 @@ local function update_winbar()
   if notes > 0 then
     bar = bar .. (" · %d note%s"):format(notes, notes == 1 and "" or "s")
   end
-  if target and target.short then
-    bar = bar .. (" · → %s"):format(target.short)
+  local to = delivery.target()
+  if to and to.short then
+    bar = bar .. (" · → %s"):format(to.short)
   end
   vim.wo[V.win].winbar = bar:gsub("%%", "%%%%")
 end
@@ -795,82 +785,28 @@ end
 
 --- Delivery -------------------------------------------------------------------
 
----Short name for a target, or what to call the adapter's own default.
+---Choose where the batch goes, from a surface this module owns.
 ---
----One wording for every piece of chrome that names a destination -- the winbar, the queue
----float, and a composer footer whichever choice it is naming.
----@param to table|nil
----@return string
-function M.label_of(to)
-  return (to and to.short) or "local"
-end
-
----Short name of where the batch is going.
----
----Exposed because the queue float and the winbar both name this choice, and it is the
----same choice: a batch's routing belongs to the batch, not to whichever window asked.
----@return string
-function M.target_label()
-  return M.label_of(target)
-end
-
----The batch's routing, in the shape a composer is handed.
----
----What a note joining the queue is routed by, and so the composer's default. An immediate
----send supplies its own instead, because that note has a target of its own.
----@return { label: fun(): string, pick: fun(on_done: fun()|nil) }
-function M.routing()
-  return { label = M.target_label, pick = M.pick_target }
-end
-
----Ask the host where something should go, holding focus where the question was asked.
----
----Says nothing about *what* is being routed: the batch's target is one caller, a single
----note being sent on its own is another, and neither should have to reimplement the focus
----dance around an asynchronous picker to have its own answer.
----@param cb fun(picked: table|nil) nil is a decline, which every caller reads its own way
----@return boolean asked false when no picker adapter is wired, so nothing was asked
-function M.choose_target(cb)
-  local cfg = config.get()
-  if not cfg.pick_target then
-    return false
-  end
-
-  -- Return focus to whichever window asked, not to the diff. Picking a target from the
-  -- queue float used to dump the cursor into the diff buffer, where `<C-s>` hits the main
-  -- buffer's mapping -- which submits but leaves the float open behind it.
-  local return_win = vim.api.nvim_get_current_win()
-
-  cfg.pick_target(function(picked)
-    if vim.api.nvim_win_is_valid(return_win) then
-      vim.api.nvim_set_current_win(return_win)
-    elseif V and vim.api.nvim_win_is_valid(V.win) then
-      vim.api.nvim_set_current_win(V.win)
-    end
-    cb(picked)
-  end)
-  return true
-end
-
----Choose where the batch goes, through the injected picker.
+---The choice is delivery's; what is left here is windows. Delivery puts focus back in the
+---window that asked, so all this adds is the case delivery cannot know about: that window
+---being gone by the time the picker answers -- the queue float closed under it, say -- in
+---which case the diff is where a reviewer belongs.
 ---@param on_done fun()|nil Runs after a target is chosen, once the picker has closed
 function M.pick_target(on_done)
-  local asked = M.choose_target(function(picked)
-    -- Recorded before anything view-shaped is touched. This used to return early with no
-    -- view, which meant the picker ran, the user answered, and the answer was dropped.
-    target = picked
+  local asked_from = vim.api.nvim_get_current_win()
+  delivery.pick_target(function()
+    if not vim.api.nvim_win_is_valid(asked_from) and M.current() then
+      vim.api.nvim_set_current_win(V.win)
+    end
+    -- The winbar names the target, and the picker is asynchronous: repainting after
+    -- `pick_target` returns paints before there is anything new to say.
     if V then
       update_winbar()
     end
-    -- The picker is asynchronous, so anything that has to reflect the new target has to
-    -- be driven from here; running it after `pick_target` returns repaints too early.
     if on_done then
       on_done()
     end
   end)
-  if not asked then
-    info("No pick_target adapter configured — submitting locally")
-  end
 end
 
 ---Render annotations as one payload and hand it to the send adapter.
@@ -933,6 +869,7 @@ function M.submit()
 
   local count = queue.count()
   -- Read unconditionally: the target outlives any view, and there may not be one.
+  local target = delivery.target()
   if
     not M.deliver(queue.all(), target, {
       scope_label = V_ and V_.scope.label or nil,
@@ -1042,7 +979,7 @@ function M.review_queue()
     vim.bo[buf].modifiable = false
 
     local n, stale = queue.count(), queue.stale_count()
-    local name = M.target_label()
+    local name = delivery.target_label()
     cfg_win.title = (" Review queue · %d annotation%s%s "):format(
       n,
       n == 1 and "" or "s",

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -784,7 +784,7 @@ describe("where an immediate send goes", function()
   -- Batch routing and immediate-send routing are different things pointing at the same
   -- kind of destination. An errand must not redirect the batch you are assembling.
   it("leaves the batch's own target where it was", function()
-    assert.same("agent", require("codereview.view").target_label())
+    assert.same("agent", require("codereview.delivery").target_label())
   end)
 end)
 

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -876,7 +876,7 @@ describe("the composer on an immediate send", function()
   end)
 
   it("leaves the batch pointing where it was", function()
-    assert.same("janus · api", view.target_label())
+    assert.same("janus · api", require("codereview.delivery").target_label())
   end)
 
   vim.api.nvim_buf_set_lines(0, 0, -1, false, { "send this one now" })

--- a/tests/codereview/focus_spec.lua
+++ b/tests/codereview/focus_spec.lua
@@ -169,7 +169,6 @@ describe("submitting from the diff while a float is open", function()
 end)
 
 describe("routing from the diff", function()
-  V.target = nil
   vim.api.nvim_set_current_win(V.win)
   view.pick_target()
   pending_pick()


### PR DESCRIPTION
Introduces `lua/codereview/delivery.lua` and moves routing into it: the chosen target, the
wording for a target, the current routing a composer is handed, and the picker dispatch.

Where a batch goes is a property of the batch, not of whichever window asked. Holding it on
the review view meant the composer loaded the largest module in the plugin to read a label
and open a picker; it now asks delivery and no longer depends on the review view at all.

**The split with the review view is routing against windows.** Delivery calls the picker
adapter, keeps what comes back, and puts focus back in the window that asked — that last
part is not a window concern it wants but one no caller is left on the stack to do, since
the picker answers on a later tick. The review view keeps the origin window, the fallback
into the diff when that window is gone by the time the picker answers, and the winbar
repaint. Choosing a target from the queue float still returns the cursor to the float rather
than the diff underneath, where `<C-s>` hits a different buffer's mapping.

Two documented properties of the target are unchanged: it stays module-level, so it outlives
a review and can be chosen with nothing open, and it stays unpersisted, so a restart cannot
route a batch at a destination that no longer exists. Only its owning module changed.

The payload handoff and the batch submit are untouched beyond reading the target from its new
home — they move in #44 and #45.

One consequence of the split worth naming: rerouting the *batch* from inside the composer and
then abandoning the note no longer repaints the winbar on the spot, because the pick no longer
runs through the view. It catches up on the next paint, and the accept path already repaints.

Test changes are consequential: two label assertions follow the function to delivery, and the
vestigial `V.target` assignment in the focus spec is deleted — nothing read it and nothing ever
did. The focus spec still asserts the recorded target through the winbar rather than the field
behind it, which is what made this move safe.

Closes #43