### PR TITLE
refactor(delivery): give the payload handoff its own home

### DIFF
--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -451,7 +451,6 @@ end
 ---@param opts? { note_suffix?: string }
 function M.send_entry(entry, type_def, opts)
   entry.type = type_def and type_def.name
-  local view = require("codereview.view")
 
   -- Said the same way from both places the absence can be discovered: before the composer
   -- opens, and from the routing key once it is.
@@ -490,7 +489,9 @@ function M.send_entry(entry, type_def, opts)
   local function compose_and_send()
     collect(compose_ctx(entry, type_def, routing), "send", function(text)
       entry.note = note_with(text, opts)
-      if view.deliver({ entry }, to) then
+      -- No context to hand over: this note was captured from a buffer, so there is no
+      -- review whose root and scope the payload could describe.
+      if delivery.deliver({ entry }, to) then
         info(
           ("Sent %s %s to %s"):format(
             entry.type or "untyped",

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -1,21 +1,32 @@
----Where a batch is going, and how that choice is made.
+---Where a batch is going, how that choice is made, and what is handed over when it goes.
 ---
 ---Routing is a property of the batch, not of whichever window asked. Holding it here is
 ---what lets the winbar, the queue float and the composer all name the same choice without
 ---any of them loading a review view to read it -- and what lets it be chosen at all with
 ---nothing open.
 ---
+---The handoff is here for the same reason. A batch and a batch of one go out the same way
+---(ADR-0004), and the batch of one has no review view behind it at all; with the renderer
+---sitting on the view, sending a single note meant loading the whole review surface to
+---reach it.
+---
 ---Windows are deliberately not its business. It calls the picker adapter and keeps what
 ---comes back; putting focus back where the question was asked is the one concession, and
 ---only because the picker answers on a later tick, by which time no caller is still on the
 ---stack to do it. What a surface then has to repaint is the surface's own affair.
 local config = require("codereview.config")
+local git = require("codereview.git")
 
 local M = {}
 
 ---@param msg string
 local function info(msg)
   vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
+
+---@param msg string
+local function warn(msg)
+  vim.notify(msg, vim.log.levels.WARN, { title = "Code review" })
 end
 
 ---Where the next batch goes, or nil for the adapter's default.
@@ -105,6 +116,47 @@ function M.pick_target(on_done)
   if not asked then
     info("No pick_target adapter configured — submitting locally")
   end
+end
+
+---Render annotations as one payload and hand it to the send adapter.
+---
+---Shared with the immediate send, which is a batch of one (ADR-0004): one renderer, one
+---delivery, and one fallback for a host that wired no `send` -- rather than a second
+---output shape that could drift from this one.
+---
+---Everything it renders with is handed to it, the repository root included. It used to
+---read that off the current review view, which is how a function that has no business
+---knowing about views ended up depending on one being open.
+---@param items CRAnnotation[]
+---@param to table|nil Where it is going, or nil for whatever the adapter defaults to
+---@param opts { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---       `root` is the review's, when there is one. Without it the working directory's
+---       repository stands in, which is the only answer available to a caller -- buffer
+---       capture sending a single note -- that never had a review behind it.
+---@return boolean delivered false when it went to the `+` register instead
+function M.deliver(items, to, opts)
+  local cfg = config.get()
+  opts = opts or {}
+  local root = opts.root or (git.root(vim.fn.getcwd()) or vim.fn.getcwd())
+  -- Resolve refs against the directory the payload is actually going to: a routed agent
+  -- reads `@path` relative to its own cwd, not this Neovim's.
+  local base = (to and to.cwd and to.cwd ~= "") and to.cwd or root
+
+  local text = require("codereview.payload").render(items, base, {
+    types = cfg.types,
+    scope_label = opts.scope_label,
+    files = opts.files,
+    reviewed = opts.reviewed,
+  })
+
+  if not cfg.send then
+    warn("No send adapter configured — copied the batch to the + register instead")
+    vim.fn.setreg("+", text)
+    return false
+  end
+
+  cfg.send(text, to)
+  return true
 end
 
 return M

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -795,40 +795,6 @@ function M.pick_target(on_done)
   end)
 end
 
----Render annotations as one payload and hand it to the send adapter.
----
----Shared with the immediate send, which is a batch of one (ADR-0004): one renderer, one
----delivery, and one fallback for a host that wired no `send` -- rather than a second
----output shape that could drift from this one.
----@param items CRAnnotation[]
----@param to table|nil Where it is going, or nil for whatever the adapter defaults to
----@param opts { scope_label?: string, files?: integer, reviewed?: integer }|nil
----@return boolean delivered false when it went to the `+` register instead
-function M.deliver(items, to, opts)
-  local cfg = config.get()
-  local V_ = M.current()
-  local root = V_ and V_.root or (git.root(vim.fn.getcwd()) or vim.fn.getcwd())
-  -- Resolve refs against the directory the payload is actually going to: a routed agent
-  -- reads `@path` relative to its own cwd, not this Neovim's.
-  local base = (to and to.cwd and to.cwd ~= "") and to.cwd or root
-
-  local text = require("codereview.payload").render(items, base, {
-    types = cfg.types,
-    scope_label = opts and opts.scope_label,
-    files = opts and opts.files,
-    reviewed = opts and opts.reviewed,
-  })
-
-  if not cfg.send then
-    warn("No send adapter configured — copied the batch to the + register instead")
-    vim.fn.setreg("+", text)
-    return false
-  end
-
-  cfg.send(text, to)
-  return true
-end
-
 ---Render the queue and hand it to the send adapter.
 function M.submit()
   local queue = require("codereview.queue")
@@ -857,7 +823,10 @@ function M.submit()
   -- Read unconditionally: the target outlives any view, and there may not be one.
   local target = delivery.target()
   if
-    not M.deliver(queue.all(), target, {
+    not delivery.deliver(queue.all(), target, {
+      -- Handed over rather than read back: delivery knows nothing about views, and a batch
+      -- submitted with none open is answered from the working directory instead.
+      root = V_ and V_.root or nil,
       scope_label = V_ and V_.scope.label or nil,
       files = V_ and #V_.files or nil,
       reviewed = reviewed,

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,7 +40,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
-| `viewless_spec` | The queue with no review view open: persist, restore, submit |
+| `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |

--- a/tests/codereview/viewless_spec.lua
+++ b/tests/codereview/viewless_spec.lua
@@ -212,3 +212,46 @@ describe("a target chosen while a review was open", function()
     assert.same("wV:p9", sent[#sent].target.pane_id)
   end)
 end)
+
+-- The caller that has no review view by construction: it captures from an ordinary buffer
+-- and never opens one. It therefore hands delivery no root, and the repository the working
+-- directory sits in has to stand in for one. Get that wrong and nothing errors -- every
+-- `@ref` in the payload just quietly becomes an absolute path with the code pasted after.
+describe("sending one annotation immediately with no review view", function()
+  local cfg = require("codereview.config").get()
+  local chooses_agent = cfg.pick_target
+  local before_sent = #sent
+
+  -- A target with no `cwd` of its own, so the payload is rendered against the root
+  -- delivery derived and not against one the adapter reported.
+  cfg.pick_target = function(cb)
+    cb({ short = "solo", pane_id = "wV:p1" })
+  end
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "sent with nothing open")
+  end
+
+  queue.clear()
+  vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/routes.lua")))
+  assert(view.current() == nil, "this case is about having no view")
+  require("codereview").annotate("bug", nil, { immediate = true })
+
+  cfg.pick_target = chooses_agent
+  cfg.compose = nil
+
+  it("delivers it with no view to read a root from", function()
+    assert.same(before_sent + 1, #sent)
+    assert.same("wV:p1", sent[#sent].target.pane_id)
+    assert.is_nil(view.current(), "sending opened a review view")
+  end)
+
+  it("resolves its @ref against the working directory's repository", function()
+    local text = sent[#sent].text
+    assert.is_truthy(text:find("@src/routes.lua", 1, true), text)
+    assert.is_truthy(text:find("sent with nothing open", 1, true), text)
+  end)
+
+  it("leaves the queue out of it", function()
+    assert.same(0, queue.count())
+  end)
+end)


### PR DESCRIPTION
The payload handoff — rendering a set of annotations and handing the result to the send
adapter — moves off the review view and into the delivery module.

ADR-0004 says a batch and a batch of one go out the same way: one renderer, one delivery,
one fallback. With that function sitting on the view, the invariant was upheld by
convention rather than by structure — the annotation path loaded the largest module in the
plugin purely to deliver a single note, and a note captured from an ordinary buffer has no
review behind it to load one for.

The one real change is the repository root. The handoff used to read it off the current
review view, the last piece of context it reached for rather than received. Callers supply
it now: the batch submit passes the review's when there is one, and the immediate send
passes nothing, so the working directory's repository stands in — the only answer buffer
capture ever had. The handoff no longer knows views exist.

Reference resolution is unchanged. The destination's own `cwd` still wins where it has
one, still resolved to its real path once per delivery rather than once per entry, and the
path predicate stays a pure string comparison.

No user-visible behaviour changes. The clipboard path is still the branch it is and still
keeps the queue; the batch submit stays on the review view and moves with the adapter
contract in #45, as do the two duplications #42 left behind.

`viewless_spec` gains the case this slice makes possible: an immediate send with no review
view open, to a target carrying no `cwd`, still emits an `@ref` resolved against the
working directory's repository. It fails if that fallback is broken.

Stacked on #47, which has since landed; `origin/master` is merged in so this diff is only
its own work.

Closes #44