### PR TITLE
feat(delivery): let a send adapter report a failed delivery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,8 +109,15 @@ The agent session a batch is delivered to.
 _Avoid_: destination, recipient, agent (an agent is the software; a target is the session)
 
 **Submit**:
-Render the batch and hand it to the host's delivery adapter, clearing the queue.
+Render the batch and hand it to the host's delivery adapter, clearing the queue if the
+adapter reports a **dispatch**.
 _Avoid_: send (reserved for the adapter), flush, publish
+
+**Dispatch**:
+A payload handed off to the send adapter, said of the handoff and not of its arrival — the
+adapter cannot know synchronously that an agent took it. A dispatch is the one thing that
+empties the queue.
+_Avoid_: delivered, sent, accepted
 
 **Immediate send**:
 Delivering a single annotation on its own, without it joining the queue.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ force one onto the fastest interaction there is.
 
 The queue is untouched: an annotation sent this way never joins it, and whatever is already
 queued is neither delivered nor cleared. It is governed by the same rule a batch is, though:
-a `send` that reports it did not go says why, and nothing claims the note was sent.
+a `send` that reports it did not go says why — as an error, since something was written and
+nothing received it — and nothing claims the note was sent. The note itself is kept as a
+draft, so annotating that file again offers it back. A batch of one has no queue to wait in,
+and by the time delivery answers, the composer has closed.
 
 You are asked where it goes **before** the composer opens, through `pick_target` — so
 declining costs no typing. Decline and nothing is sent. With no `pick_target` wired there
@@ -298,9 +301,11 @@ opts = {
   -- arrived: return nothing or `true` for dispatched, `false` and a reason for not.
   -- Raising counts as not dispatched too, with the error message as the reason.
   -- A dispatch is the one thing that empties the queue, so a batch that did not go is
-  -- still there to retry. Without this the payload goes to the + register, which is the
-  -- default implementation of this same contract — it reports a non-dispatch, because a
-  -- register is not a consumer, and that is why an unwired host keeps its queue.
+  -- still there to retry, and an immediate send that did not go keeps its note as a
+  -- draft. A refusal is reported as an error. Without this the payload goes to the +
+  -- register, which is the default implementation of this same contract — it reports a
+  -- non-dispatch (a register is not a consumer), which is why an unwired host keeps its
+  -- queue, and it is a warning rather than an error because nothing is broken.
   send = function(payload, target) return true end,
 
   -- Choose a delivery target; call back with anything carrying `short` and `cwd`.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Everything is drawn natively, and the syntax highlighting is recovered with
 ```
 
 Nothing else is required. With no adapters wired the view renders, annotates and queues;
-only delivery falls back (the batch lands in the `+` register).
+the batch lands in the `+` register instead of an agent, and stays queued because nothing
+consumed it.
 
 ## Usage
 
@@ -126,7 +127,8 @@ That a type is optional at all is a consequence of this: a batch of one would ot
 force one onto the fastest interaction there is.
 
 The queue is untouched: an annotation sent this way never joins it, and whatever is already
-queued is neither delivered nor cleared.
+queued is neither delivered nor cleared. It is governed by the same rule a batch is, though:
+a `send` that reports it did not go says why, and nothing claims the note was sent.
 
 You are asked where it goes **before** the composer opens, through `pick_target` — so
 declining costs no typing. Decline and nothing is sent. With no `pick_target` wired there
@@ -292,8 +294,14 @@ optional functions inject that:
 
 ```lua
 opts = {
-  -- Deliver the rendered batch. Without it, the payload goes to the + register.
-  send = function(payload, target) end,
+  -- Deliver the rendered batch. Report whether it was *handed off*, not whether it
+  -- arrived: return nothing or `true` for dispatched, `false` and a reason for not.
+  -- Raising counts as not dispatched too, with the error message as the reason.
+  -- A dispatch is the one thing that empties the queue, so a batch that did not go is
+  -- still there to retry. Without this the payload goes to the + register, which is the
+  -- default implementation of this same contract — it reports a non-dispatch, because a
+  -- register is not a consumer, and that is why an unwired host keeps its queue.
+  send = function(payload, target) return true end,
 
   -- Choose a delivery target; call back with anything carrying `short` and `cwd`.
   -- `cwd` matters: refs are re-resolved against it at submit time.
@@ -317,6 +325,10 @@ opts = {
   compose = function(ctx, on_accept, label) on_accept(nil, "text") end,
 }
 ```
+
+[ADR-0005](docs/adr/0005-a-send-reports-dispatch-not-arrival.md) records why "dispatched"
+is the narrow promise — the adapter most hosts wire is asynchronous, and holding the queue
+until an agent confirmed would keep a sent batch queued for the length of that agent's work.
 
 <details>
 <summary>Wiring it to a Claude session over herdr</summary>

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -320,7 +320,9 @@ That a type is optional at all follows from this: a batch of one would
 otherwise force one onto the fastest interaction there is.
 
 The queue is untouched: an annotation sent this way never joins it, and what is
-already queued is neither delivered nor cleared.
+already queued is neither delivered nor cleared. The same rule a batch submits
+under still governs it: a `send` that reports it did not go says why, and
+nothing claims the note was sent.
 
 You are asked where it goes *before* the composer opens, through
 |codereview-opt-pick_target|, so declining costs no typing -- decline and
@@ -339,12 +341,38 @@ any other note you walked away from.
 
 The plugin has no opinion about where a review goes, or about which pickers
 you use. Four optional functions inject that. With none of them wired
-everything still works except delivery, which falls back to the `+` register,
-and `@` in the composer, which stays a literal `@`.
+everything still works: the payload reaches the `+` register instead of an
+agent and the batch stays queued, and `@` in the composer stays a literal `@`.
 
 send({payload}, {target})                                *codereview-opt-send*
         Deliver the rendered batch. {target} is whatever `pick_target`
         produced, or nil.
+
+        Report whether the payload was *handed off* -- not whether it
+        arrived: >
+            nil     dispatched
+            true    dispatched
+            false   not dispatched; the second return is the reason
+            raises  not dispatched; the error message is the reason
+<
+        Returning nothing therefore keeps working unchanged. Exactly one of
+        these empties the queue -- a dispatch -- so an adapter that answers
+        `false, "the pane is gone"` leaves the batch queued, warns with that
+        sentence, and the submit can be retried without retyping a note. An
+        adapter that raises is caught and reported the same way rather than
+        propagating a traceback.
+
+        "Dispatched" is deliberately the narrow promise. The adapter cannot
+        know synchronously that an agent accepted the batch, and waiting for
+        that would hold the queue open for the length of an agent's work, so
+        a failure that happens after the handoff stays the adapter's own to
+        report. See `docs/adr/0005-a-send-reports-dispatch-not-arrival.md`.
+
+        Without this, the payload is copied to the `+` register -- the
+        default implementation of this contract rather than a fallback beside
+        it. It is handed the same arguments and reports a non-dispatch,
+        because a register is not a consumer, which is why an unwired host
+        keeps its queue.
 
 pick_target({cb})                                 *codereview-opt-pick_target*
         Choose a delivery target and call {cb} with it. The target may carry
@@ -528,7 +556,8 @@ require("codereview").annotate({type}, {range}, {opts})
 require("codereview").queue()                           *codereview.queue()*
         Open the queue float: drop, route, submit.
 require("codereview").submit()                         *codereview.submit()*
-        Submit the queued annotations as one batch.
+        Submit the queued annotations as one batch. The queue is emptied
+        only if |codereview-opt-send| reports it went.
 require("codereview").count()                           *codereview.count()*
         Number of queued annotations -- useful in a statusline.
 require("codereview").is_open()                       *codereview.is_open()*

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -236,7 +236,9 @@ Drafts                                                  *codereview-drafts*
 Abandon the composer with something in it and the text is kept. Annotate that
 file again and it is offered back, with `^D` to discard it and start clean. A
 note you actually submit clears its draft, so what you have already said never
-comes back.
+comes back -- unless it never reached anyone. An |codereview-immediate-send|
+that was not dispatched puts its note back here, because the composer has
+closed by then and a batch of one has no queue to wait in.
 
 A restored draft leaves the cursor at its end, so your next word continues the
 sentence rather than preceding it.
@@ -357,10 +359,19 @@ send({payload}, {target})                                *codereview-opt-send*
 <
         Returning nothing therefore keeps working unchanged. Exactly one of
         these empties the queue -- a dispatch -- so an adapter that answers
-        `false, "the pane is gone"` leaves the batch queued, warns with that
+        `false, "the pane is gone"` leaves the batch queued, reports that
         sentence, and the submit can be retried without retyping a note. An
         adapter that raises is caught and reported the same way rather than
         propagating a traceback.
+
+        A non-dispatch is reported as an *error* when this adapter refused or
+        raised: something was written and nothing received it. With no adapter
+        wired it is a warning instead -- a configuration state rather than a
+        failure, with the payload in the register.
+
+        An |codereview-immediate-send| that was not dispatched keeps its note
+        as a draft (|codereview-drafts|), because a batch of one has no queue
+        to be kept in.
 
         "Dispatched" is deliberately the narrow promise. The adapter cannot
         know synchronously that an agent accepted the batch, and waiting for

--- a/docs/adr/0005-a-send-reports-dispatch-not-arrival.md
+++ b/docs/adr/0005-a-send-reports-dispatch-not-arrival.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+---
+
+# A send reports dispatch, not arrival
+
+A **send** adapter answers whether the payload was **handed off**, not whether it was
+received: returning nothing or `true` means dispatched, `false` with a reason means it was
+not, and raising is a non-dispatch whose reason is the error message. Exactly one of those
+outcomes — a dispatch — empties the queue. What happens to a payload after the handoff is
+the adapter's own business to report, which is what a host adapter already does.
+
+The alternative was the honest-sounding one: have the adapter report completion, and hold
+the batch until it does. It was rejected because the adapter hosts actually wire is
+asynchronous — it hands off to a subprocess and learns the outcome from a callback up to
+half a minute later. Waiting for that would keep the queue open for the length of an
+agent's work, with the annotations that were just sent still counted, still drawn on the
+diff, and still submittable a second time. The narrower promise is the one the plugin can
+keep synchronously, and it is enough for the failure that motivated this: a batch that
+never left.
+
+## Consequences
+
+A delivery that was dispatched and then failed downstream still empties the queue, and the
+review is not recoverable from the plugin — the notification the adapter raises is all
+there is. That is accepted: a **host** that wants a retry owns the payload by then, and the
+plugin holding a copy against a failure it cannot observe would mean two places believing
+they are responsible for the same batch.
+
+Because a raise is caught and reported rather than propagated, a host adapter's bugs are
+now reported as delivery failures. A `nil` field dereferenced inside a `send` reads as
+"the batch did not go" plus a Lua error message, rather than as a traceback out of the
+submit — which is the right trade for a plugin whose delivery is always someone else's
+code, but it does mean the adapter is where such a message has to be diagnosed.

--- a/docs/adr/0005-a-send-reports-dispatch-not-arrival.md
+++ b/docs/adr/0005-a-send-reports-dispatch-not-arrival.md
@@ -27,6 +27,19 @@ there is. That is accepted: a **host** that wants a retry owns the payload by th
 plugin holding a copy against a failure it cannot observe would mean two places believing
 they are responsible for the same batch.
 
+A **batch of one** has no queue to be kept in, so a non-dispatch writes its note back to
+the **draft** store under the key the composer wrote it from, and the reviewer picks it up
+by annotating that file again. Putting it in the queue instead was rejected: an **immediate
+send** is an errand, and an errand that failed must not add itself to a batch someone is
+still assembling. The cost is that the two paths recover from different places — the queue
+for a batch, the draft store for a note.
+
+A non-dispatch is reported as an error where a host adapter refused or broke, because
+something was written and nothing received it. With no adapter wired it stays a warning:
+that is a configuration state rather than a failure, and the payload is in the register.
+It is the one place the shipped default is distinguished from a host's adapter, and only
+in how loudly it speaks — never in what happens to the batch.
+
 Because a raise is caught and reported rather than propagated, a host adapter's bugs are
 now reported as delivery failures. A `nil` field dereferenced inside a `send` reads as
 "the batch did not go" plus a Lua error message, rather than as a traceback out of the

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -423,10 +423,9 @@ function M.queue_entry(entry, type_def, opts)
   -- gets here; capture from a buffer can be the very first thing a session does.
   local staled = require("codereview.state").ensure_queue()
   if staled > 0 then
-    -- Worded exactly as a review reports staleness, and said before the composer opens:
-    -- which path happened to read the queue back is not something a reviewer should be
-    -- able to hear.
-    info(("%d annotation%s now stale"):format(staled, staled == 1 and "" or "s"))
+    -- Said before the composer opens, in the queue's own wording: which path happened to
+    -- read the queue back is not something a reviewer should be able to hear.
+    info(queue.stale_phrase(staled))
   end
   collect(compose_ctx(entry, type_def), "queue", function(text)
     entry.note = note_with(text, opts)
@@ -491,6 +490,10 @@ function M.send_entry(entry, type_def, opts)
       entry.note = note_with(text, opts)
       -- No context to hand over: this note was captured from a buffer, so there is no
       -- review whose root and scope the payload could describe.
+      --
+      -- Confirmed only on a dispatch, which is the rule a batch submits under. A send
+      -- that did not go has already said why; saying it was sent on top of that is the
+      -- one thing that would lose the note in silence.
       if delivery.deliver({ entry }, to) then
         info(
           ("Sent %s %s to %s"):format(

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -8,6 +8,7 @@
 ---  * a hunk is always inlined, for the same reason -- what changed is the point.
 local config = require("codereview.config")
 local delivery = require("codereview.delivery")
+local drafts = require("codereview.drafts")
 local queue = require("codereview.queue")
 local render = require("codereview.render")
 local types = require("codereview.types")
@@ -486,15 +487,15 @@ function M.send_entry(entry, type_def, opts)
   }
 
   local function compose_and_send()
-    collect(compose_ctx(entry, type_def, routing), "send", function(text)
+    -- Held rather than built inside the call, because the draft key is computed from it
+    -- and a note that did not go has to return under exactly the key it was written from.
+    local ctx = compose_ctx(entry, type_def, routing)
+    collect(ctx, "send", function(text)
       entry.note = note_with(text, opts)
       -- No context to hand over: this note was captured from a buffer, so there is no
       -- review whose root and scope the payload could describe.
-      --
-      -- Confirmed only on a dispatch, which is the rule a batch submits under. A send
-      -- that did not go has already said why; saying it was sent on top of that is the
-      -- one thing that would lose the note in silence.
-      if delivery.deliver({ entry }, to) then
+      local dispatched, reason = delivery.deliver({ entry }, to)
+      if dispatched then
         info(
           ("Sent %s %s to %s"):format(
             entry.type or "untyped",
@@ -502,7 +503,30 @@ function M.send_entry(entry, type_def, opts)
             to and (to.short or "agent") or "local"
           )
         )
+        return
       end
+
+      -- Where a batch keeps its payload in the queue, a batch of one has no queue to keep
+      -- it in: an errand must not disturb the batch being assembled (ADR-0004), and by
+      -- now the composer has closed its window, wiped its buffer and committed its draft
+      -- because a submitted note is not an abandoned one. Without this the note the
+      -- reviewer just typed exists nowhere at all. The draft store is what "you may want
+      -- this back" already means, so it goes there, under the composer's own key.
+      --
+      -- The typed text, not `entry.note`: whatever rides along under a note -- buffer
+      -- capture's diagnostics -- is added again on the way out next time.
+      drafts.set(drafts.key(ctx), text)
+      -- Named by the file rather than by the annotation, because that is what a draft is
+      -- keyed by: coming back to it is what offers the note again, whatever the next one
+      -- covers.
+      local where = entry.path or entry.abs_path
+      delivery.report_undelivered(
+        ("%s; the note is kept as a draft — %s"):format(
+          reason,
+          where and ("annotate %s again to pick it up"):format(where)
+            or "the next note with no file behind it picks it up"
+        )
+      )
     end)
   end
 

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -89,7 +89,14 @@ function M.open(ctx, on_accept, label)
   local function submit()
     local text = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
     close(false)
-    -- Committed: there is nothing left worth restoring for this file.
+    -- Committed as far as this composer is concerned: a submitted note is not an
+    -- abandoned one, and nothing of the window that collected it is worth restoring.
+    --
+    -- It is no longer the last word on the note, though. `on_accept` may deliver, and a
+    -- delivery can report that it did not go -- by which time this window is closed and
+    -- its buffer wiped, so the caller writes the note back under this same key rather
+    -- than losing it. Clearing here is still right: it is the caller's business whether
+    -- there is anything left to keep.
     drafts.set(draft_key, nil)
     -- The target argument is the adapter contract's, not this composer's: routing is a
     -- property of the batch and the plugin already holds it.

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -1,9 +1,10 @@
 ---Configuration and adapter injection.
 ---
 ---The three adapters (`send`, `pick_target`, `compose`) are what keep this plugin
----distributable. With none of them wired it still renders, annotates and queues -- only
----delivery degrades to a fallback. A host config injects its own Claude/herdr plumbing
----rather than the plugin hardcoding any.
+---distributable. With none of them wired it still renders, annotates and queues -- the
+---payload just reaches the `+` register instead of an agent, and the batch stays queued
+---because nothing consumed it. A host config injects its own Claude/herdr plumbing rather
+---than the plugin hardcoding any.
 local M = {}
 
 M.defaults = {
@@ -37,7 +38,16 @@ M.defaults = {
 
   --- Adapters (all optional) ---
   ---Deliver a rendered payload. `target` is whatever `pick_target` produced, or nil.
-  ---@type fun(payload: string, target: table|nil)|nil
+  ---
+  ---Report whether the payload was *handed off*, not whether it arrived (ADR-0005):
+  ---return nothing or `true` for dispatched, `false` and a reason for not. Raising is a
+  ---non-dispatch too, with the error message as the reason. Only a dispatch empties the
+  ---queue, so an adapter that says no leaves the batch to be retried.
+  ---
+  ---Replaces the clipboard copy the plugin ships, which is the default implementation of
+  ---this same contract rather than a fallback beside it: it is handed the same arguments
+  ---and reports a non-dispatch, because a register is not a consumer.
+  ---@type (fun(payload: string, target: table|nil): boolean?, string?)|nil
   send = nil,
   ---Choose a delivery target, calling back with it (or nil for the default).
   ---@type fun(cb: fun(target: table|nil))|nil

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -42,7 +42,8 @@ M.defaults = {
   ---Report whether the payload was *handed off*, not whether it arrived (ADR-0005):
   ---return nothing or `true` for dispatched, `false` and a reason for not. Raising is a
   ---non-dispatch too, with the error message as the reason. Only a dispatch empties the
-  ---queue, so an adapter that says no leaves the batch to be retried.
+  ---queue, so an adapter that says no leaves the batch to be retried -- and leaves an
+  ---immediate send's note as a draft, which is the only place a batch of one can wait.
   ---
   ---Replaces the clipboard copy the plugin ships, which is the default implementation of
   ---this same contract rather than a fallback beside it: it is handed the same arguments

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -10,6 +10,9 @@
 ---sitting on the view, sending a single note meant loading the whole review surface to
 ---reach it.
 ---
+---And the submit, which is what holds the rule the other two serve: restore the queue,
+---deliver it, and empty it only if the send reports it went (ADR-0005).
+---
 ---Windows are deliberately not its business. It calls the picker adapter and keeps what
 ---comes back; putting focus back where the question was asked is the one concession, and
 ---only because the picker answers on a later tick, by which time no caller is still on the
@@ -118,11 +121,29 @@ function M.pick_target(on_done)
   end
 end
 
+---The default implementation of the `send` contract, and not a fallback beside it.
+---
+---ADR-0003 settled this shape for the composer; this is the same idea applied to
+---delivery. It is handed exactly what a host adapter is handed and answers through
+---exactly the same return, so there is always a send and nothing anywhere has to ask
+---whether one is wired.
+---
+---It reports a non-dispatch because that is the truth: a register is not a consumer.
+---The behaviour a host with no delivery already had -- the payload reachable, the batch
+---still queued -- then falls out of the one rule that empties the queue rather than
+---being written down a second time.
+---@param payload string
+---@param _to table|nil Nothing to route to; the register is where it goes either way
+---@return boolean dispatched, string reason
+local function to_clipboard(payload, _to)
+  vim.fn.setreg("+", payload)
+  return false, "No send adapter configured — copied the batch to the + register instead"
+end
+
 ---Render annotations as one payload and hand it to the send adapter.
 ---
----Shared with the immediate send, which is a batch of one (ADR-0004): one renderer, one
----delivery, and one fallback for a host that wired no `send` -- rather than a second
----output shape that could drift from this one.
+---Shared with the immediate send, which is a batch of one (ADR-0004): one renderer and
+---one delivery, rather than a second output shape that could drift from this one.
 ---
 ---Everything it renders with is handed to it, the repository root included. It used to
 ---read that off the current review view, which is how a function that has no business
@@ -133,7 +154,7 @@ end
 ---       `root` is the review's, when there is one. Without it the working directory's
 ---       repository stands in, which is the only answer available to a caller -- buffer
 ---       capture sending a single note -- that never had a review behind it.
----@return boolean delivered false when it went to the `+` register instead
+---@return boolean dispatched false when the send said it did not go, or raised trying
 function M.deliver(items, to, opts)
   local cfg = config.get()
   opts = opts or {}
@@ -149,13 +170,82 @@ function M.deliver(items, to, opts)
     reviewed = opts.reviewed,
   })
 
-  if not cfg.send then
-    warn("No send adapter configured — copied the batch to the + register instead")
-    vim.fn.setreg("+", text)
+  -- A raise is a non-dispatch, not a crash. A missing binary raises rather than returning
+  -- anything -- that is how the process API answers -- and letting it unwind would take
+  -- the queue's one rule with it: the batch used to survive only because the error jumped
+  -- past the line that clears it, and the reviewer read a traceback where a sentence
+  -- belongs.
+  local ok, first, second = pcall(cfg.send or to_clipboard, text, to)
+  local dispatched, reason = first, second
+  if not ok then
+    dispatched, reason = false, ("Send adapter failed: %s"):format(first)
+  end
+
+  -- Only an explicit `false` is a refusal: every adapter wired today returns nothing at
+  -- all, and nothing has to keep meaning it went. What "went" means is deliberately
+  -- narrow -- handed off, not arrived (ADR-0005).
+  if dispatched == false then
+    warn(reason or "The send adapter did not deliver the batch")
+    return false
+  end
+  return true
+end
+
+---Read the persisted queue back if this session has not, and say what came back stale.
+---
+---The latch belongs to persistence, which owns the stores it reads and answers with a
+---count. What is owed here is the sentence: submitting can be the first thing a session
+---does, and a batch has to be the one on disk before it can be the one that goes.
+local function ensure_queue()
+  local staled = require("codereview.state").ensure_queue()
+  if staled > 0 then
+    info(require("codereview.queue").stale_phrase(staled))
+  end
+end
+
+---Submit the queue as one batch, emptying it only if the send says it went.
+---
+---The rule this module exists to hold: a dispatch is what empties the queue, and nothing
+---else does. Not a raise, not an adapter that declined, not the register the shipped
+---default copies to -- each of those leaves the batch exactly where it was, to be retried
+---without a note being typed twice and with a count that still describes what is there.
+---
+---Here rather than on the review view because a batch is not a window. It can be
+---submitted with nothing open, and what remains the view's share of this is closing the
+---float that was listing the batch and repainting the diff behind it.
+---@param ctx { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---       What the review the batch came from can say about itself, when there was one.
+---@return boolean dispatched
+function M.submit(ctx)
+  local queue = require("codereview.queue")
+  ctx = ctx or {}
+
+  ensure_queue()
+  local count = queue.count()
+  if count == 0 then
+    info("Queue is empty — annotate something first")
     return false
   end
 
-  cfg.send(text, to)
+  if not M.deliver(queue.all(), target, ctx) then
+    return false
+  end
+  queue.clear()
+
+  -- Written whether or not a review is open: a batch submitted with none still has to
+  -- put the emptied queue on disk, or the entries it just sent come back on the next
+  -- start. The queue alone rather than the whole document, because submitting changes
+  -- nothing about the reviewed marks stored beside it.
+  local state = require("codereview.state")
+  state.persist_queue(ctx.root or state.ambient_root())
+
+  info(
+    ("Submitted %d annotation%s to %s"):format(
+      count,
+      count == 1 and "" or "s",
+      target and (target.short or "agent") or "local"
+    )
+  )
   return true
 end
 

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -27,9 +27,17 @@ local function info(msg)
   vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
 end
 
----@param msg string
-local function warn(msg)
-  vim.notify(msg, vim.log.levels.WARN, { title = "Code review" })
+---Say that a payload did not go, at the level that says whose problem it is.
+---
+---The rule that empties the queue has no branch in it and must not grow one. How loudly a
+---non-dispatch is said is a different question, and it does: an adapter that refused or
+---broke is a failure a reviewer has to act on, because something was written and nothing
+---received it. No adapter wired at all is a configuration state with the payload sitting
+---in the register, and saying that in red would cry wolf about the plugin's own default.
+---@param message string
+function M.report_undelivered(message)
+  local level = config.get().send and vim.log.levels.ERROR or vim.log.levels.WARN
+  vim.notify(message, level, { title = "Code review" })
 end
 
 ---Where the next batch goes, or nil for the adapter's default.
@@ -155,6 +163,10 @@ end
 ---       repository stands in, which is the only answer available to a caller -- buffer
 ---       capture sending a single note -- that never had a review behind it.
 ---@return boolean dispatched false when the send said it did not go, or raised trying
+---@return string|nil reason Always set on a non-dispatch. Returned rather than announced
+---       here, because what a caller has to add to it differs: a batch is still queued and
+---       says so by still being counted, while a batch of one has to say where its note
+---       went instead.
 function M.deliver(items, to, opts)
   local cfg = config.get()
   opts = opts or {}
@@ -185,8 +197,9 @@ function M.deliver(items, to, opts)
   -- all, and nothing has to keep meaning it went. What "went" means is deliberately
   -- narrow -- handed off, not arrived (ADR-0005).
   if dispatched == false then
-    warn(reason or "The send adapter did not deliver the batch")
-    return false
+    -- Given a sentence of its own when the adapter did not bother with one, so that every
+    -- caller can put the reason in a message without checking whether there is one.
+    return false, reason or "The send adapter reported it did not deliver"
   end
   return true
 end
@@ -227,7 +240,11 @@ function M.submit(ctx)
     return false
   end
 
-  if not M.deliver(queue.all(), target, ctx) then
+  local dispatched, reason = M.deliver(queue.all(), target, ctx)
+  if not dispatched then
+    -- Nothing more to add: the batch is still queued, and a queue that still counts what
+    -- it holds is how a reviewer sees that for themselves.
+    M.report_undelivered(reason)
     return false
   end
   queue.clear()

--- a/lua/codereview/queue.lua
+++ b/lua/codereview/queue.lua
@@ -91,6 +91,18 @@ function M.at(key)
   return M.by_key()[key] or {}
 end
 
+---How a reviewer is told that annotations came back untrustworthy.
+---
+---One wording for every surface that reports staleness -- a reconcile against the diff on
+---screen, a restore with nothing open, a capture that restored on its way past, and a
+---submit that did. Which of them happened to notice is not something a reviewer should be
+---able to hear, and four copies of a sentence is how that stops being true.
+---@param n integer
+---@return string
+function M.stale_phrase(n)
+  return ("%d annotation%s now stale"):format(n, n == 1 and "" or "s")
+end
+
 ---@return integer
 function M.stale_count()
   local n = 0

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -222,8 +222,12 @@ function M.restore_queue(root)
 end
 
 ---The repository the queue belongs to when no view is open.
+---
+---Public because more than the restore has to ask it: writing the queue with nothing open
+---and emptying it after a submit both write to the store this names, and a second copy of
+---the question is a second chance to answer it differently.
 ---@return string|nil
-local function ambient_root()
+function M.ambient_root()
   return require("codereview.git").root(vim.fn.getcwd())
 end
 
@@ -251,7 +255,7 @@ function M.ensure_queue()
   queue_restored = true
   -- No root is not a reason to skip: annotations with no repository behind them live in a
   -- store that does not need one, and they would otherwise never come back.
-  return M.restore_queue(ambient_root())
+  return M.restore_queue(M.ambient_root())
 end
 
 ---Restore saved progress into a freshly opened view.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -194,12 +194,6 @@ function M.paint(keep_file)
   end
 end
 
----The repository the queue belongs to when no view is open.
----@return string|nil
-local function ambient_root()
-  return git.root(vim.fn.getcwd())
-end
-
 ---Write progress to disk. Called from every mutation rather than from `paint`, which
 ---also runs on resize and would turn a window drag into a stream of file writes.
 ---
@@ -207,13 +201,14 @@ end
 ---the queue -- there are no marks to write, and writing the document anyway would blank
 ---the ones a review left behind.
 function M.persist()
+  local state = require("codereview.state")
   if V then
-    require("codereview.state").persist(V)
+    state.persist(V)
     return
   end
   -- Passed even when nil: there may still be annotations with no repository to write, and
   -- skipping would leave a submitted batch's entries on disk to come back next start.
-  require("codereview.state").persist_queue(ambient_root())
+  state.persist_queue(state.ambient_root())
 end
 
 ---Read the persisted queue back if this session has not, and say what came back stale.
@@ -225,7 +220,7 @@ end
 local function ensure_queue()
   local staled = require("codereview.state").ensure_queue()
   if staled > 0 then
-    info(("%d annotation%s now stale"):format(staled, staled == 1 and "" or "s"))
+    info(require("codereview.queue").stale_phrase(staled))
   end
 end
 
@@ -505,7 +500,7 @@ function M.reconcile()
     parts[#parts + 1] = ("%d file%s changed since review"):format(unmarked, unmarked == 1 and "" or "s")
   end
   if staled > 0 then
-    parts[#parts + 1] = ("%d annotation%s now stale"):format(staled, staled == 1 and "" or "s")
+    parts[#parts + 1] = require("codereview.queue").stale_phrase(staled)
   end
   if #parts > 0 then
     info(table.concat(parts, ", "))
@@ -795,16 +790,13 @@ function M.pick_target(on_done)
   end)
 end
 
----Render the queue and hand it to the send adapter.
+---Submit the batch, and put the windows back the way a sent batch leaves them.
+---
+---The rule -- restore, deliver, empty only on a dispatch -- is delivery's, because none of
+---it is about a window and all of it happens with nothing open. What is left here is the
+---float that was listing the batch, the diff behind it, and telling delivery what this
+---review can say about itself.
 function M.submit()
-  local queue = require("codereview.queue")
-
-  ensure_queue()
-  if queue.count() == 0 then
-    info("Queue is empty — annotate something first")
-    return
-  end
-
   -- Submitting empties the queue, so any open queue float is now describing nothing.
   if V and V.queue_win and vim.api.nvim_win_is_valid(V.queue_win) then
     vim.api.nvim_win_close(V.queue_win, true)
@@ -819,35 +811,19 @@ function M.submit()
     end
   end
 
-  local count = queue.count()
-  -- Read unconditionally: the target outlives any view, and there may not be one.
-  local target = delivery.target()
-  if
-    not delivery.deliver(queue.all(), target, {
-      -- Handed over rather than read back: delivery knows nothing about views, and a batch
-      -- submitted with none open is answered from the working directory instead.
-      root = V_ and V_.root or nil,
-      scope_label = V_ and V_.scope.label or nil,
-      files = V_ and #V_.files or nil,
-      reviewed = reviewed,
-    })
-  then
-    return
-  end
-  queue.clear()
-  if M.current() then
+  local dispatched = delivery.submit({
+    -- Handed over rather than read back: delivery knows nothing about views, and a batch
+    -- submitted with none open is answered from the working directory instead.
+    root = V_ and V_.root or nil,
+    scope_label = V_ and V_.scope.label or nil,
+    files = V_ and #V_.files or nil,
+    reviewed = reviewed,
+  })
+  -- A batch that did not go is still queued and still drawn on the diff, so there is
+  -- nothing to repaint -- and the reviewer has already been told why.
+  if dispatched then
     M.paint()
   end
-  -- Outside the `M.current()` guard: a batch submitted with no view still has to write the
-  -- emptied queue, or the entries it just sent come back on the next start.
-  M.persist()
-  info(
-    ("Submitted %d annotation%s to %s"):format(
-      count,
-      count == 1 and "" or "s",
-      target and (target.short or "agent") or "local"
-    )
-  )
 end
 
 --- The queue review float ------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # open-time report, not a 
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 258 cases in ~5 seconds.
+The whole suite is about 600 cases in ~5 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -41,6 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
+| `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, and the one condition that empties the queue |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
@@ -57,7 +58,7 @@ interchangeable, and the assertions know which one they are looking at.
   modified, deleted, added, renamed-and-edited, staged, unstaged, untracked, untracked
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
-  `viewless_spec`, `capture_spec` and `interactive_spec`.
+  `viewless_spec`, `capture_spec`, `delivery_spec` and `interactive_spec`.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec` and `focus_spec`.
@@ -100,6 +101,12 @@ so the out-of-core language path is still checked locally without ever failing C
   therefore does *not* simulate a restart — the latch is still set, nothing reloads, and an
   assertion about restoring is measuring nothing. `capture_spec` spawns
   `capture_child.lua` twice for this reason.
+- **A send adapter that raises takes the whole `describe` with it.** Plenary runs a
+  describe body immediately, so an adapter that propagates its error aborts the block
+  instead of failing one case — the `it`s below it never run. `delivery_spec` asserts on
+  the queue and the notification *after* the submit returns, which is only meaningful
+  because delivery catches the raise; remove that catch and the case reports as an error
+  rather than a failure.
 - **`nvim -l` sends `print` to stderr, not stdout.** A child spawned with `-l` that reports
   its result through `print` has to be read from `stderr`, or from both streams. Asserting
   against `stdout` alone silently never matches.

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
-| `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, and the one condition that empties the queue |
+| `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, and the draft an undispatched immediate send leaves behind |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |

--- a/tests/codereview/delivery_spec.lua
+++ b/tests/codereview/delivery_spec.lua
@@ -1,0 +1,238 @@
+-- What a send adapter is allowed to say, and the one condition that empties the queue.
+--
+-- The seam is the injected adapter, because that is the plugin's real contract with a
+-- host. Every case drives `setup` and the ordinary entry points and asserts on what the
+-- stub was handed, on the queue behind it, on the `+` register and on what the reviewer
+-- was told -- never on how a surface hands a batch over, which is the plugin's business
+-- and has already moved once.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+local codereview = require("codereview")
+local config = require("codereview.config")
+local queue = require("codereview.queue")
+
+local sent = {}
+
+---The adapter every case starts from: it dispatches, and says nothing about it.
+local function records(text, target)
+  sent[#sent + 1] = { text = text, target = target }
+end
+
+codereview.setup({ syntax = false, send = records })
+
+-- Swapped in place rather than through `setup`, which would reset every other adapter
+-- with it. Each case puts back what it found.
+local cfg = config.get()
+
+---One queued annotation, so every batch is of a known size and carries its own marker.
+---@param note string
+local function queue_one(note)
+  queue.clear()
+  queue.add({
+    type = "bug",
+    kind = "file",
+    path = "src/main.lua",
+    abs_path = vim.fs.joinpath(fixture, "src/main.lua"),
+    key = "src/main.lua:f:0",
+    note = note,
+  })
+end
+
+describe("an adapter that returns nothing", function()
+  queue_one("returns nothing at all")
+  local msgs, restore = h.capture_notify()
+  codereview.submit()
+  restore()
+
+  it("is handed the rendered batch", function()
+    assert.same(1, #sent)
+    assert.is_truthy(sent[1].text:find("returns nothing at all", 1, true), sent[1].text)
+  end)
+
+  -- The compatibility rule the optional return exists to protect: every adapter wired
+  -- today returns nothing, and nothing has to keep meaning it went.
+  it("empties the queue", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("confirms what was submitted", function()
+    assert.is_true(h.notified(msgs, "Submitted 1 annotation"), vim.inspect(msgs))
+  end)
+end)
+
+describe("an adapter that returns true", function()
+  cfg.send = function(text, target)
+    records(text, target)
+    return true
+  end
+  queue_one("returns true")
+  codereview.submit()
+  cfg.send = records
+
+  it("is handed the batch", function()
+    assert.same(2, #sent)
+    assert.is_truthy(sent[2].text:find("returns true", 1, true), sent[2].text)
+  end)
+
+  it("empties the queue", function()
+    assert.same(0, queue.count())
+  end)
+end)
+
+describe("an adapter that returns false with a reason", function()
+  cfg.send = function(text, target)
+    records(text, target)
+    return false, "the agent pane is gone"
+  end
+  queue_one("declined by the adapter")
+  local msgs, restore = h.capture_notify()
+  codereview.submit()
+  restore()
+  cfg.send = records
+
+  it("was still handed the batch", function()
+    assert.same(3, #sent)
+  end)
+
+  -- Nothing consumed it, so dropping it would lose the review.
+  it("keeps the queue", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("warns with the reason the adapter gave", function()
+    assert.is_true(h.notified(msgs, "the agent pane is gone"), vim.inspect(msgs))
+  end)
+
+  it("does not claim to have submitted anything", function()
+    assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
+  end)
+
+  -- The point of keeping it: the note was typed once, and a host that comes back should
+  -- not cost it. The count still describes what is really there.
+  it("can be retried without retyping the note", function()
+    codereview.submit()
+    assert.same(4, #sent)
+    assert.is_truthy(sent[4].text:find("declined by the adapter", 1, true), sent[4].text)
+    assert.same(0, queue.count())
+  end)
+end)
+
+describe("an adapter that raises", function()
+  cfg.send = function()
+    error("herdr: no such pane")
+  end
+  queue_one("raised at the adapter")
+  local msgs, restore = h.capture_notify()
+  codereview.submit()
+  restore()
+  cfg.send = records
+
+  -- Preserved by the rule rather than by the error unwinding past the line that clears
+  -- the queue, which is how a missing binary used to leave it intact.
+  it("keeps the queue", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("reads as a sentence rather than a traceback", function()
+    assert.is_true(h.notified(msgs, "herdr: no such pane"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
+  end)
+end)
+
+describe("no adapter at all", function()
+  cfg.send = nil
+  vim.fn.setreg("+", "")
+  queue_one("nothing consumed this")
+  local msgs, restore = h.capture_notify()
+  codereview.submit()
+  restore()
+  cfg.send = records
+
+  it("copies the payload to the + register", function()
+    assert.is_truthy(vim.fn.getreg("+"):find("nothing consumed this", 1, true), vim.fn.getreg("+"))
+  end)
+
+  -- The same rule as an adapter declining, reached without a branch: the default
+  -- implementation of the contract reports that nothing took the batch.
+  it("keeps the queue", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("says where it went instead", function()
+    assert.is_true(h.notified(msgs, "No send adapter configured"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
+  end)
+end)
+
+-- Submitted through the review's own key, because what a surface hands delivery is not
+-- something to assert on directly -- it is observable in the payload the adapter receives.
+describe("a batch submitted from a review view", function()
+  codereview.open("branch")
+  queue_one("submitted from the view")
+  local before = #sent
+  h.feed("<C-s>")
+
+  it("carries what the review can say about itself", function()
+    assert.same(before + 1, #sent)
+    local header = vim.split(sent[#sent].text, "\n")[1]
+    assert.is_truthy(header:find("on branch vs ", 1, true), header)
+    assert.is_truthy(header:find("reviewed)", 1, true), header)
+  end)
+
+  it("empties the queue and repaints what is left", function()
+    assert.same(0, queue.count())
+    assert.same(0, #h.virt_marks(assert(require("codereview.view").current())))
+  end)
+end)
+
+describe("an immediate send that was dispatched", function()
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "an errand that landed")
+  end
+  queue.clear()
+  codereview.close()
+  vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/main.lua")))
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("bug", nil, { immediate = true })
+  restore()
+
+  it("says it was sent", function()
+    assert.is_truthy(sent[#sent].text:find("an errand that landed", 1, true), sent[#sent].text)
+    assert.is_true(h.notified(msgs, "Sent bug"), vim.inspect(msgs))
+  end)
+end)
+
+-- A batch of one is governed by the same rule (ADR-0004, ADR-0005): a note that did not
+-- go is not silently lost, because nothing claims it went and the reason is said out loud.
+describe("an immediate send that was not dispatched", function()
+  cfg.send = function(text, target)
+    records(text, target)
+    return false, "the pane went away mid-errand"
+  end
+  local before = #sent
+  local msgs, restore = h.capture_notify()
+  codereview.annotate("bug", nil, { immediate = true })
+  restore()
+  cfg.send = records
+  cfg.compose = nil
+
+  it("was handed the note", function()
+    assert.same(before + 1, #sent)
+  end)
+
+  it("warns with the reason the adapter gave", function()
+    assert.is_true(h.notified(msgs, "the pane went away mid-errand"), vim.inspect(msgs))
+  end)
+
+  it("does not claim to have sent it", function()
+    assert.is_false(h.notified(msgs, "Sent bug"), vim.inspect(msgs))
+  end)
+
+  -- An errand still does not disturb a batch, whichever way it ended.
+  it("leaves the queue out of it", function()
+    assert.same(0, queue.count())
+  end)
+end)

--- a/tests/codereview/delivery_spec.lua
+++ b/tests/codereview/delivery_spec.lua
@@ -12,7 +12,13 @@ local fixture = h.cd_fixture("mkfixture")
 
 local codereview = require("codereview")
 local config = require("codereview.config")
+local drafts = require("codereview.drafts")
 local queue = require("codereview.queue")
+
+-- Resolved, because capture realpaths every path it records and a draft is keyed by the
+-- absolute one. On macOS the fixture lives under a `/var` symlink, so the unresolved form
+-- would look up a key nothing ever wrote.
+local main = assert(vim.uv.fs_realpath(vim.fs.joinpath(fixture, "src/main.lua")))
 
 local sent = {}
 
@@ -35,7 +41,7 @@ local function queue_one(note)
     type = "bug",
     kind = "file",
     path = "src/main.lua",
-    abs_path = vim.fs.joinpath(fixture, "src/main.lua"),
+    abs_path = main,
     key = "src/main.lua:f:0",
     note = note,
   })
@@ -189,12 +195,13 @@ describe("a batch submitted from a review view", function()
 end)
 
 describe("an immediate send that was dispatched", function()
+  drafts.clear()
   cfg.compose = function(_, on_accept)
     on_accept(nil, "an errand that landed")
   end
   queue.clear()
   codereview.close()
-  vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/main.lua")))
+  vim.cmd("edit " .. vim.fn.fnameescape(main))
   local msgs, restore = h.capture_notify()
   codereview.annotate("bug", nil, { immediate = true })
   restore()
@@ -203,27 +210,39 @@ describe("an immediate send that was dispatched", function()
     assert.is_truthy(sent[#sent].text:find("an errand that landed", 1, true), sent[#sent].text)
     assert.is_true(h.notified(msgs, "Sent bug"), vim.inspect(msgs))
   end)
+
+  -- The composer committed its draft on submit, and a note that reached someone has
+  -- nothing left to restore.
+  it("leaves no draft behind", function()
+    assert.is_nil(drafts.get(main))
+  end)
 end)
 
--- A batch of one is governed by the same rule (ADR-0004, ADR-0005): a note that did not
--- go is not silently lost, because nothing claims it went and the reason is said out loud.
+-- A batch of one is governed by the same rule (ADR-0004, ADR-0005), and it has nowhere
+-- else to put a note that did not go: the queue is not where an errand lands, and by the
+-- time delivery answers, the composer has closed its window, wiped its buffer and
+-- committed its draft. Without somewhere to put it, the note the reviewer just typed is
+-- unrecoverable.
 describe("an immediate send that was not dispatched", function()
+  drafts.clear()
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "an errand nobody took")
+  end
   cfg.send = function(text, target)
     records(text, target)
     return false, "the pane went away mid-errand"
   end
   local before = #sent
-  local msgs, restore = h.capture_notify()
+  local msgs, restore = h.capture_notify_levels()
   codereview.annotate("bug", nil, { immediate = true })
   restore()
   cfg.send = records
-  cfg.compose = nil
 
   it("was handed the note", function()
     assert.same(before + 1, #sent)
   end)
 
-  it("warns with the reason the adapter gave", function()
+  it("says why it did not go", function()
     assert.is_true(h.notified(msgs, "the pane went away mid-errand"), vim.inspect(msgs))
   end)
 
@@ -234,5 +253,87 @@ describe("an immediate send that was not dispatched", function()
   -- An errand still does not disturb a batch, whichever way it ended.
   it("leaves the queue out of it", function()
     assert.same(0, queue.count())
+  end)
+
+  it("keeps the note as a draft for the file it was about", function()
+    assert.same("an errand nobody took", drafts.get(main))
+  end)
+
+  it("says the note was kept, and names the file to get it back from", function()
+    assert.is_true(h.notified(msgs, "kept as a draft"), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, "src/main.lua"), vim.inspect(msgs))
+  end)
+
+  -- An annotation that reached nobody is a failure, not a remark about the weather.
+  it("reports it at error level", function()
+    assert.same(vim.log.levels.ERROR, h.notified_level(msgs, "the pane went away mid-errand"))
+  end)
+end)
+
+-- The proof that "kept" means what it says: the draft store is what the composer reads on
+-- the way in, so the note comes back the next time that file is annotated.
+describe("the note an undispatched send kept", function()
+  -- The shipped composer, because it is the one that restores drafts -- a host that wires
+  -- its own owns that, exactly as it owns everything else about collecting text.
+  cfg.compose = nil
+  codereview.annotate("bug", nil, { immediate = true })
+  local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  h.feed("q")
+
+  it("is offered back the next time that file is annotated", function()
+    assert.same({ "an errand nobody took" }, reopened)
+  end)
+end)
+
+describe("an immediate send whose adapter raised", function()
+  drafts.clear()
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "an errand that blew up")
+  end
+  cfg.send = function()
+    error("herdr: no such pane")
+  end
+  local msgs, restore = h.capture_notify_levels()
+  codereview.annotate("bug", nil, { immediate = true })
+  restore()
+  cfg.send = records
+
+  it("keeps the note as a draft too", function()
+    assert.same("an errand that blew up", drafts.get(main))
+  end)
+
+  it("reads as a sentence at error level, not a traceback", function()
+    assert.is_true(h.notified(msgs, "herdr: no such pane"), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, "kept as a draft"), vim.inspect(msgs))
+    assert.same(vim.log.levels.ERROR, h.notified_level(msgs, "herdr: no such pane"))
+  end)
+
+  it("still leaves the queue out of it", function()
+    assert.same(0, queue.count())
+  end)
+end)
+
+-- Nothing wired is a configuration state, not a failure: the payload is in the register,
+-- and saying it in red would cry wolf on the plugin's own default. The note is still kept.
+describe("an immediate send with no adapter wired", function()
+  drafts.clear()
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "an errand with nowhere to go")
+  end
+  cfg.send = nil
+  local msgs, restore = h.capture_notify_levels()
+  codereview.annotate("bug", nil, { immediate = true })
+  restore()
+  cfg.send = records
+  cfg.compose = nil
+
+  it("reports it at warning level", function()
+    assert.same(vim.log.levels.WARN, h.notified_level(msgs, "No send adapter configured"))
+  end)
+
+  -- The register holding the payload is not the note having reached anyone, and a
+  -- reviewer who wires an adapter tomorrow should still find what they wrote.
+  it("keeps the note as a draft anyway", function()
+    assert.same("an errand with nowhere to go", drafts.get(main))
   end)
 end)

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -60,16 +60,44 @@ function M.capture_notify()
   end
 end
 
----@param messages string[]
+---Collect notifications with the level each was reported at, which `capture_notify`
+---drops. For the cases where *how loudly* something was said is the point.
+---@return { msg: string, level: integer }[] records, fun() restore
+function M.capture_notify_levels()
+  local records = {}
+  local orig = vim.notify
+  vim.notify = function(msg, level, ...)
+    records[#records + 1] = { msg = msg, level = level }
+    return orig(msg, level, ...)
+  end
+  return records, function()
+    vim.notify = orig
+  end
+end
+
+---@param messages string[]|{ msg: string, level: integer }[] Either capture's shape
 ---@param needle string
 ---@return boolean
 function M.notified(messages, needle)
   for _, m in ipairs(messages) do
-    if type(m) == "string" and m:find(needle, 1, true) then
+    local text = type(m) == "table" and m.msg or m
+    if type(text) == "string" and text:find(needle, 1, true) then
       return true
     end
   end
   return false
+end
+
+---The level a matching notification was reported at.
+---@param records { msg: string, level: integer }[]
+---@param needle string
+---@return integer|nil level nil when nothing matched
+function M.notified_level(records, needle)
+  for _, r in ipairs(records) do
+    if type(r.msg) == "string" and r.msg:find(needle, 1, true) then
+      return r.level
+    end
+  end
 end
 
 ---Feed keys and let them run to completion.


### PR DESCRIPTION
Closes #45

The last of the four payload slices, and the only one a user can see.

## A send can now say it did not go

```
send(payload, target) -> boolean?, string?

  nil    -> dispatched   (every adapter wired today)
  true   -> dispatched
  false  -> not dispatched; second value is the reason
  raises -> not dispatched; the error message is the reason
```

`nil` meaning dispatched is what keeps every wired adapter working untouched. The adapter
call is wrapped, so a raise — what a missing binary does, since the process API raises
rather than returning a failure — becomes a non-dispatch that reads as a sentence instead
of a traceback that happened to leave the batch behind.

**Dispatched means handed off, not arrived.** The adapter hosts actually wire reports its
real outcome from a callback up to half a minute later, and waiting for that would hold
the queue open for the length of an agent's work. Downstream failures stay the adapter's
own to report, which is what it already does. ADR-0005 records that, and records
asynchronous completion reporting as the rejected alternative.

## One rule empties the queue

The clipboard is now the default *implementation* of the `send` contract rather than a
branch inside the handoff, following ADR-0003 for the composer. It is handed the same
arguments as any adapter, copies the payload, and reports that nothing consumed the batch.
There is therefore always a send, the "is an adapter wired" branch is gone, and the
existing behaviour where an unwired host keeps its queue falls out of the single rule —
a dispatch, and nothing else, empties the queue.

The batch submit moves into `delivery` with it: restore, deliver, empty only on a clean
dispatch, and write the emptied queue whether or not a review is open. The review view
keeps what is about windows — closing the queue float and repainting after a submit.

## A batch of one keeps its note too

The queue is where a batch waits, and an immediate send has no queue — an errand must not
disturb a batch being assembled (ADR-0004). But the composer commits its draft the moment
a note is submitted, so by the time delivery answers, the window is closed, the buffer
wiped and the draft cleared. Adding failure paths to `deliver` would therefore have made
one new way to lose a note outright.

So a note that was not dispatched goes back to the draft store under the key the composer
wrote it from: annotate that file again and it is offered back, exactly as an abandoned
note is. The message says the note was kept and names the file to pick it up from. The
queue is still untouched on every path, and no adapter contract changed.

A delivery nothing received is reported at **error** level — something was written and
nobody has it. No adapter wired stays a **warning**: a configuration state rather than a
failure, with the payload in the register. That is the one place the shipped default is
distinguished from a host's adapter, and only in how loudly it speaks.

## Clean-up

The staleness sentence had three copies and this made a fourth, so it has one home on the
queue. The ambient-root helper existed in both persistence and the review view; the view's
last use was the persist path this touches, so persistence owns it now. The composer's
`-- Committed: there is nothing left worth restoring` comment was made conditional by this
work and now says what is actually true.

## Verifying

`make all` is green (611 cases). Every new case was watched failing first, one mutation at
a time:

| Removed | What broke |
| --- | --- |
| the whole change | a declining adapter emptied the queue and reported a submission (4 cases); an immediate send that never went claimed it had (2 cases) |
| the raise wrap | the error propagated out of `submit`, aborting the block rather than failing a case |
| the `false` handling | the same 6 cases, **plus** `payload_spec`'s existing "submitting with no send adapter keeps the queue" — the clipboard contract is genuinely enforced by the one rule now, not by a branch of its own |
| the post-submit persist | `viewless_spec`'s "clears the persisted queue too" |
| the draft write-back | all 4 draft cases, including the end-to-end one that re-annotates the file and reads the composer |
| the error level (always warn) | both "reports it at error level" cases, while the no-adapter warning case kept passing |
| the warning level (always error) | only the no-adapter case, which is the point of keeping the two apart |
| the dispatch guard (draft written unconditionally) | "an immediate send that was dispatched leaves no draft behind" |

Two cases cannot fail before the change and are regression guards rather than proofs: an
adapter returning nothing, and one returning `true`. `payload_spec`'s and `capture_spec`'s
clipboard cases pass unedited.