### PR TITLE
feat(view): let the file tree be dismissed and summoned

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ batch pointing where it was.
 | `za` | Toggle expansion without marking reviewed |
 | `gs` | Cycle scope, re-rendering in place |
 | `gr` | Re-read the diff from git |
+| `gp` | Show or hide the file tree |
 | `<CR>` | Open the real file here, in a new tab |
 | `Q` | Review the queue |
 | `<C-t>` | Choose the delivery target |
@@ -189,10 +190,17 @@ cursor last was.
 | `R` | Toggle reviewed — **on a directory, the whole subtree** |
 | `<C-p>` | Jump to a file by name |
 | `<Tab>` | Back to the diff |
+| `gp` | Dismiss the tree, landing back in the diff |
 | `q` | Close |
 
 Jumping to a file that was collapsed because it is reviewed expands it: you asked to look
 at it.
+
+`panel.enabled` decides whether a review *opens* with a tree; `gp` decides it from there
+on, for the rest of that review. Dismissing it hands focus back to the diff, because a
+reviewer who dismisses the tree is not asking to be left in a window that no longer
+exists. Collapsed directories belong to the review rather than to the tree, so they are
+exactly as you left them when it comes back.
 
 Annotation keys are prefixed with `a` rather than bound bare, because bare `b`, `f`, `n`
 and `s` would shadow back-word, find-char, next-search and (if you use it) flash.nvim

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -62,6 +62,7 @@ Buffer-local, inside the review view:
     za               Toggle expansion without marking reviewed
     gs               Cycle scope, re-rendering in place
     gr               Re-read the diff from git
+    gp               Show or hide the file tree
     <CR>             Open the real file here, in a new tab
     Q                Review the queue
     <C-t>            Choose the delivery target
@@ -96,12 +97,18 @@ In the file tree:                                         *codereview-tree*
     R                Toggle reviewed; on a directory, the whole subtree
     <C-p>            Jump to a file by name
     <Tab>            Back to the diff
+    gp               Dismiss the tree, landing back in the diff
     q                Close the review
 
 The tree collapses single-child directory chains, so a monorepo shows
 `apps/api/src` on one row rather than burning three rows and six columns of
 indent on segments that carry no information. Directories sort before files,
 and each directory carries a reviewed tally for its subtree.
+
+`panel.enabled` decides whether a review opens with a tree; `gp` decides it
+from there on, for the rest of that review. Dismissing it from inside the tree
+hands focus back to the diff. Collapsed directories belong to the review, not
+to the tree, so they are exactly as you left them when it comes back.
 
 In the queue float: x drops an entry, <C-t> routes, <C-s> submits, q closes
 and keeps the queue.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1069,6 +1069,7 @@ local function setup_main_keymaps()
       "Cycle scope",
     },
     ["gr"] = { M.refresh, "Reload the diff" },
+    ["gp"] = { M.toggle_panel, "Show or hide the file tree" },
     ["<CR>"] = { M.open_file, "Open the real file here" },
     ["Q"] = { M.review_queue, "Review the queue" },
     ["<C-t>"] = { M.pick_target, "Choose the delivery target" },
@@ -1137,6 +1138,7 @@ local function setup_panel_keymaps()
     },
     ["<C-p>"] = { M.pick_file, "Jump to a file" },
     ["<Tab>"] = { M.toggle_focus, "Focus the diff" },
+    ["gp"] = { M.toggle_panel, "Hide the file tree" },
     ["R"] = { M.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { M.close, "Close the review" },
   })
@@ -1164,6 +1166,66 @@ local function window_opts(win)
   vim.wo[win].list = false
   vim.wo[win].spell = false
 end
+
+--- The panel window ------------------------------------------------------------
+
+---Build the panel: its window, its buffer and its keymaps.
+---
+---An operation of its own rather than a step inside `open`, because the toggle has to be
+---able to run it again. The panel buffer is `bufhidden = "wipe"`, so a dismissed panel
+---leaves nothing to re-attach: the buffer is gone and every keymap bound to it with it.
+local function show_panel()
+  local cfg = config.get()
+  vim.api.nvim_set_current_win(V.win)
+  vim.cmd(cfg.panel.position == "right" and "botright vsplit" or "topleft vsplit")
+  local pwin = vim.api.nvim_get_current_win()
+  local pbuf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_win_set_buf(pwin, pbuf)
+  scratch(pbuf, "codereviewpanel")
+  window_opts(pwin)
+  vim.api.nvim_win_set_width(pwin, cfg.panel.width)
+  vim.wo[pwin].winfixwidth = true
+  V.panel_buf, V.panel_win = pbuf, pwin
+  setup_panel_keymaps()
+  vim.api.nvim_set_current_win(V.win)
+end
+
+---Dismiss the panel. Collapsed directories are untouched: they live on the review.
+local function hide_panel()
+  local win = V.panel_win
+  V.panel_buf, V.panel_win, V.panel_render = nil, nil, nil
+  -- The tree follows the diff by repainting only when the cursor crosses into a different
+  -- file. With no tree to repaint, that latch would sit on whatever was being read when it
+  -- was dismissed, and reading that file again once it is back would repaint nothing.
+  V.panel_current = nil
+  -- A reviewer who dismisses the tree is not asking to be left in the window they
+  -- dismissed, so leave it deliberately rather than letting Neovim pick a successor.
+  if vim.api.nvim_get_current_win() == win then
+    vim.api.nvim_set_current_win(V.win)
+  end
+  pcall(vim.api.nvim_win_close, win, true)
+end
+
+---Show or dismiss the file tree, from the diff or from the tree itself.
+---
+---Configuration decides the state a review opens in; this decides it from there on.
+function M.toggle_panel()
+  if not M.current() then
+    return
+  end
+  if V.panel_win and vim.api.nvim_win_is_valid(V.panel_win) then
+    hide_panel()
+  else
+    show_panel()
+  end
+  -- The diff just changed width and its file headers are padded to that width, so this has
+  -- to repaint. The resize autocmd does not cover it: WinResized is fired from the main
+  -- loop, so it lands after the toggle has returned -- and never at all if nothing else
+  -- pumps the loop, which is exactly the headless case.
+  M.paint()
+end
+
+--- Opening --------------------------------------------------------------------
 
 ---@param spec string|nil
 function M.open(spec)
@@ -1226,17 +1288,7 @@ function M.open(spec)
   M.reconcile()
 
   if cfg.panel.enabled then
-    vim.cmd(cfg.panel.position == "right" and "botright vsplit" or "topleft vsplit")
-    local pwin = vim.api.nvim_get_current_win()
-    local pbuf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_win_set_buf(pwin, pbuf)
-    scratch(pbuf, "codereviewpanel")
-    window_opts(pwin)
-    vim.api.nvim_win_set_width(pwin, cfg.panel.width)
-    vim.wo[pwin].winfixwidth = true
-    V.panel_buf, V.panel_win = pbuf, pwin
-    setup_panel_keymaps()
-    vim.api.nvim_set_current_win(main_win)
+    show_panel()
   end
 
   setup_main_keymaps()

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,7 +45,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
-| `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker |
+| `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `interactive_spec` | The insert-mode leak, and where a completed or cancelled `@` leaves you, in a real pty-backed Neovim |
 
@@ -121,6 +121,15 @@ so the out-of-core language path is still checked locally without ever failing C
 - **Counts are derived from git, not hardcoded.** `diff_spec` cross-checks every file
   against `git diff --numstat` at runtime. Hardcoded totals went stale three times while
   this was being written. Keep them derived.
+- **A dismissed panel is a wiped buffer.** Panel buffers are `bufhidden = "wipe"`, so
+  closing the window destroys the buffer and every keymap bound to it. Nothing that drives
+  the view's exported actions can notice: `panel_spec` therefore asserts that the tree
+  comes back in a *different* buffer carrying the same mappings, and drives one of them
+  through the keys. Without that, a panel that comes back with no keymaps at all passes.
+- **`WinResized` is no use to a test.** It is fired from the main loop, so it lands after
+  whatever changed the width has returned — and in a headless spec, which never pumps the
+  loop, it does not land at all. Anything that changes a window's width has to repaint for
+  itself; the resize autocmd is for the reviewer dragging a border, nothing else.
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.

--- a/tests/codereview/panel_spec.lua
+++ b/tests/codereview/panel_spec.lua
@@ -308,3 +308,185 @@ describe("the file picker", function()
     assert.is_true(V.expanded[path])
   end)
 end)
+
+-- Dismissing the panel wipes the buffer it was drawn into -- `bufhidden = "wipe"` -- so
+-- bringing it back is a rebuild, not an unhide. What survives is what lives on the review:
+-- the collapsed directories, the reviewed marks, the queue.
+describe("dismissing and summoning the tree", function()
+  local function shown()
+    return V.panel_win ~= nil and vim.api.nvim_win_is_valid(V.panel_win)
+  end
+
+  ---Normal-mode mappings bound to a buffer, by their lhs.
+  local function maps_of(buf)
+    local out = {}
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+      out[#out + 1] = m.lhs
+    end
+    table.sort(out)
+    return out
+  end
+
+  ---The diff's file headers are padded to the diff window's width, which is exactly what
+  ---changes when the tree appears or goes away.
+  local function header_width()
+    local row = V.render.file_rows[1]
+    return vim.fn.strdisplaywidth(vim.api.nvim_buf_get_lines(V.buf, row - 1, row, false)[1])
+  end
+
+  ---Row carrying the current-file highlight.
+  local function selected_row()
+    local sel = vim.tbl_filter(
+      function(m)
+        return m[4].line_hl_group == "CodeReviewPanelSel"
+      end,
+      vim.api.nvim_buf_get_extmarks(V.panel_buf, vim.api.nvim_create_namespace("codereview_panel"), 0, -1, {
+        details = true,
+      })
+    )
+    assert.same(1, #sel)
+    return sel[1][2] + 1
+  end
+
+  -- Collapsed *before* the tree goes away. Collapsed state belongs to the review; the
+  -- buffer it was drawn into does not survive.
+  vim.api.nvim_set_current_win(V.win)
+  pcur(row_of_dir("apps"))
+  view.panel_fold(true)
+  local folded = panel_lines()
+  local maps_before = maps_of(V.panel_buf)
+  local buf_before = V.panel_buf
+  local narrow = vim.api.nvim_win_get_width(V.win)
+
+  it("hides the tree", function()
+    view.toggle_panel()
+    assert.is_false(shown())
+  end)
+
+  it("wipes the buffer the tree was drawn into", function()
+    assert.is_false(vim.api.nvim_buf_is_valid(buf_before))
+  end)
+
+  it("repaints the diff against the width it now has", function()
+    assert.is_true(vim.api.nvim_win_get_width(V.win) > narrow)
+    assert.same(vim.api.nvim_win_get_width(V.win), header_width())
+  end)
+
+  it("brings it back on the same keystroke", function()
+    view.toggle_panel()
+    assert.is_true(shown())
+    assert.same(narrow, vim.api.nvim_win_get_width(V.win))
+    assert.same(narrow, header_width())
+  end)
+
+  it("brings it back in a buffer of its own", function()
+    assert.is_true(vim.api.nvim_buf_is_valid(V.panel_buf))
+    assert.is_true(V.panel_buf ~= buf_before, "the wiped buffer came back")
+  end)
+
+  it("leaves collapsed directories exactly as they were", function()
+    assert.is_true(V.collapsed["apps"])
+    assert.same(folded, panel_lines())
+  end)
+
+  it("rebinds every panel keymap", function()
+    assert.same(maps_before, maps_of(V.panel_buf))
+  end)
+
+  -- Bound is not the same as working: assert through the keys themselves.
+  it("rebinds them as live mappings", function()
+    vim.api.nvim_set_current_win(V.panel_win)
+    pcur(row_of_dir("apps"))
+    h.feed("za")
+    assert.is_nil(V.collapsed["apps"])
+    h.feed("za")
+    assert.is_true(V.collapsed["apps"])
+    vim.api.nvim_set_current_win(V.win)
+  end)
+
+  it("does not shadow the tab-switching keys", function()
+    for _, buf in ipairs({ V.buf, V.panel_buf }) do
+      assert.is_false(vim.tbl_contains(maps_of(buf), "gt"))
+      assert.is_false(vim.tbl_contains(maps_of(buf), "gT"))
+    end
+  end)
+
+  it("is the same keystroke in the diff and in the tree", function()
+    vim.api.nvim_set_current_win(V.win)
+    h.feed("gp")
+    assert.is_false(shown())
+    h.feed("gp")
+    assert.is_true(shown())
+
+    vim.api.nvim_set_current_win(V.panel_win)
+    h.feed("gp")
+    assert.is_false(shown())
+    assert.same(V.win, vim.api.nvim_get_current_win())
+    h.feed("gp")
+    assert.is_true(shown())
+  end)
+
+  it("hands focus back to the diff when dismissed from inside the tree", function()
+    vim.api.nvim_set_current_win(V.panel_win)
+    view.toggle_panel()
+    assert.is_false(shown())
+    assert.same(V.win, vim.api.nvim_get_current_win())
+  end)
+
+  it("shows what changed while it was hidden", function()
+    view.panel_fold_all(false)
+    local path = "apps/web/src/index.lua"
+    local i = assert(h.file_index(V, path))
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[i], 0 })
+    view.toggle_reviewed()
+
+    view.toggle_panel()
+    assert.is_truthy(panel_lines()[row_of_file(path)]:find("✓", 1, true))
+    view.toggle_reviewed()
+  end)
+
+  -- The tree repaints only when the diff cursor crosses into a different file, and while
+  -- there is no tree to repaint that latch is holding a file nobody is reading any more.
+  it("follows the diff cursor again once it is back", function()
+    local function look_at(index)
+      vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index], 0 })
+      vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+    end
+
+    look_at(3)
+    look_at(1)
+    assert.same(V.panel_render.file_row[1], selected_row())
+
+    view.toggle_panel()
+    look_at(3)
+    view.toggle_panel()
+    assert.same(V.panel_render.file_row[3], selected_row())
+
+    look_at(1)
+    assert.same(V.panel_render.file_row[1], selected_row())
+  end)
+end)
+
+-- Last: this reopens the review, so every `V` above it is gone.
+describe("a review configured to start without a tree", function()
+  require("codereview").setup({
+    syntax = false,
+    panel = { enabled = false },
+    compose = function(_, on_accept, _)
+      on_accept(nil, "n")
+    end,
+  })
+  view.open("branch")
+  local W = assert(view.current())
+
+  it("opens with none", function()
+    assert.is_nil(W.panel_win)
+  end)
+
+  it("summons one on the keystroke", function()
+    view.toggle_panel()
+    assert.is_not_nil(W.panel_win)
+    assert.is_true(vim.api.nvim_win_is_valid(W.panel_win))
+    assert.same(#W.files, #W.panel_render.file_rows)
+  end)
+end)


### PR DESCRIPTION
The file tree is no longer something that is simply there for the whole review. `gp` shows
and hides it, from the diff and from the tree itself, and dismissing it from inside the
tree hands focus back to the diff. `panel.enabled` still decides the state a review *opens*
in; the keystroke decides it from there on.

Panel creation moves out of `M.open` into `show_panel`, an operation that can be invoked
again — the extraction #54 depends on. Nothing about the panel's behaviour while it is
shown changed, and the queue is untouched.

`gp` was chosen from the `g` family already carrying `gs` and `gr`, and deliberately not
from the tab-switching keys that `<CR>` on a diff line depends on to get back.

### Why the toggle repaints rather than leaning on the resize autocmd

There is already a `VimResized`/`WinResized` autocmd that repaints, and it is not enough.
`WinResized` is fired from Neovim's main loop, so it lands after the toggle has returned —
and measured on a bare Neovim, opening a vsplit and closing it again fires nothing at all
before the next loop iteration:

```
main width before: 80
main width after open: 45
fired synchronously after open: {}
main width after close: 80
fired synchronously after close: {}
```

That autocmd is for a reviewer dragging a window border. Anything that changes a window's
width in one call has to repaint for itself.

### Red first

The spec was written against a `view.toggle_panel` that did not exist (`attempt to call
field 'toggle_panel' (a nil value)`), then run against a deliberately naive hide/show to
record what each trap actually produces. Observed, on the `mktree` fixture at 120 columns
with a 34-column tree:

| Held back | Observed | Expected |
| --- | --- | --- |
| The repaint | first file header padded to **85** columns | **120** — the width the diff now has |
| Rebuilding the buffer's contents | tree comes back as `{ "" }` | the 8-row tree, `apps` still collapsed |
| Rebinding the keymaps | **0** normal-mode mappings | the same **15** it had (`<C-P> <CR> <Tab> R [f ]f h l o q zM zR za zc zo`) |
| Clearing the follow-the-cursor latch | highlight stuck on tree row **4** | row **14**, the file the cursor is actually on |

The last one is the subtle one: the tree repaints only when the diff cursor crosses into a
different file, and while there is no tree that latch keeps the file that was being read
when it was dismissed. Come back, read that file again, and nothing repaints.

Two of these are invisible to any test that only drives the view's exported actions —
before this branch, nothing in the suite asserted the panel keymaps were bound at all, so
removing `setup_panel_keymaps()` outright left the whole spec green. The keymap cases
therefore assert the buffer's mappings and drive `za` through the keys.

### Coverage

15 new cases in `panel_spec`, driving `view.toggle_panel` and the `gp` mapping: the round
trip, the wiped buffer and the live one that replaces it, collapsed directories surviving
untouched, every keymap rebound and working, focus returning to the diff, contents catching
up on a file marked reviewed while the tree was hidden, the current-file highlight tracking
again afterwards, `gt`/`gT` unshadowed, and a review configured with `panel.enabled = false`
summoning a tree with the keystroke.

`make all` — 643 cases, lint clean.

Closes #52
