### PR TITLE
feat(view): jump from the queue float to the annotation you picked

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,26 @@ and `s` would shadow back-word, find-char, next-search and (if you use it) flash
 inside the buffer. `a` is append, which is dead in a `nomodifiable` buffer, so the prefix
 costs a keystroke and no motion.
 
+### In the queue float
+
+| Key | Action |
+| --- | --- |
+| `<CR>` | Jump to the annotation under the cursor |
+| `x` | Drop it |
+| `<C-t>` | Choose the delivery target |
+| `<C-s>` | Submit the batch |
+| `q` / `<Esc>` | Close, keeping the queue |
+
+A jump closes the float and centres the line the annotation is about, expanding the file
+first if it was collapsed — so the queue is a way of navigating a review and not only of
+auditing it before you send.
+
+The queue is shared with the capture path and the float opens with or without a review, so
+some of what it lists has nowhere to go: a bare note is about no file, there may be no
+review open, or the file may be outside the current scope. Each says which, and leaves the
+float open — the remedies are nothing, open a review, and change scope, and one shared
+message would name none of them.
+
 ### What gets annotated
 
 | Cursor is on | Target |

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -110,8 +110,16 @@ from there on, for the rest of that review. Dismissing it from inside the tree
 hands focus back to the diff. Collapsed directories belong to the review, not
 to the tree, so they are exactly as you left them when it comes back.
 
-In the queue float: x drops an entry, <C-t> routes, <C-s> submits, q closes
-and keeps the queue.
+In the queue float: <CR> jumps to the annotation under the cursor, x drops an
+entry, <C-t> routes, <C-s> submits, q closes and keeps the queue.
+
+A jump closes the float and centres the line the annotation is about,
+expanding the file first if it was collapsed. The queue is shared with the
+capture path and the float opens with or without a review, so some entries
+have nowhere to go: a bare note has no file at all, there may be no review
+view open, and a file may lie outside the current scope. Each says which, and
+leaves the float open -- the remedies are nothing, open a review, and change
+scope.
 
 Annotation keys are prefixed with `a` rather than bound bare. Bare `b`, `f`,
 `n` and `s` would shadow back-word, find-char and next-search inside the

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -828,6 +828,81 @@ end
 
 --- The queue review float ------------------------------------------------------
 
+---Put the cursor on the place a queued annotation is about.
+---
+---Says why not rather than doing nothing when it cannot, and says it differently each
+---time: a **bare note** will never have a destination, a missing review view means open
+---one, and a file the scope does not cover means change scope. One shared "cannot jump
+---there" would name none of the three remedies.
+---@param entry CRAnnotation
+---@return boolean jumped Whether the cursor actually moved; false has already reported why
+function M.jump_to_entry(entry)
+  -- One queue holds both paths' entries, and the capture path can produce an annotation
+  -- with no file behind it at all. Checked before the view, because opening a review would
+  -- not give this one anywhere to go either.
+  if entry.kind == "note" then
+    info("A bare note is about no file — there is nowhere to jump to")
+    return false
+  end
+  if not M.current() then
+    info("No review view open — open one to jump to an annotation")
+    return false
+  end
+
+  local index
+  for i, file in ipairs(V.files) do
+    if file.path == entry.path then
+      index = i
+      break
+    end
+  end
+  -- An entry captured outside a checkout has no repository-relative path, so it names the
+  -- only path it has and falls in here too: no scope of this review covers it.
+  if not index then
+    info(
+      ("%s is not in the %s scope — change scope to jump to it"):format(entry.path or entry.abs_path, V.scope.label)
+    )
+    return false
+  end
+
+  -- A file collapsed because it is reviewed must open when you deliberately jump into it,
+  -- otherwise the jump lands on a header with nothing beneath it -- the same courtesy the
+  -- file picker extends. Reviewed with nothing recorded reads as collapsed too, which is
+  -- how the render decides it.
+  local expanded = V.expanded[entry.path]
+  if expanded == nil then
+    expanded = V.reviewed[entry.path] == nil
+  end
+  if not expanded then
+    V.expanded[entry.path] = true
+    M.paint()
+  end
+
+  -- The scan `]a` already makes: the anchor map is the only thing that knows which row a
+  -- key is on now, which is what lets a stale annotation still land wherever its anchor
+  -- points. A whole-file entry's key matches no line, and neither does a line that this
+  -- diff no longer renders; both mean the file, so both land on its header.
+  local row = V.render.file_rows[index]
+  local file = V.files[index]
+  for r, a in pairs(V.render.anchors) do
+    if
+      a.file == index
+      and a.kind == "line"
+      and render.line_key(file.path, file.hunks[a.hunk].lines[a.line]) == entry.key
+    then
+      row = r
+      break
+    end
+  end
+
+  vim.api.nvim_set_current_win(V.win)
+  goto_row(row, false)
+  vim.api.nvim_win_call(V.win, function()
+    vim.cmd("normal! zz")
+  end)
+  return true
+end
+
 ---List the queued annotations, drop any of them, then submit the batch.
 function M.review_queue()
   local queue = require("codereview.queue")
@@ -916,7 +991,7 @@ function M.review_queue()
       n == 1 and "" or "s",
       stale > 0 and (" · %d stale"):format(stale) or ""
     )
-    cfg_win.footer = (" ^T %s · x drop · ^S submit · q close "):format(
+    cfg_win.footer = (" ^T %s · ⏎ jump · x drop · ^S submit · q close "):format(
       #name > 24 and (name:sub(1, 23) .. "…") or name
     )
     if vim.api.nvim_win_is_valid(win) then
@@ -935,6 +1010,29 @@ function M.review_queue()
     end
     return best and best.id or nil
   end
+
+  ---That entry as it sits in the queue.
+  ---@param id integer|nil
+  ---@return CRAnnotation|nil
+  local function queued(id)
+    for _, item in ipairs(queue.all()) do
+      if item.id == id then
+        return item
+      end
+    end
+  end
+
+  vim.keymap.set("n", "<CR>", function()
+    local entry = queued(entry_at_cursor())
+    if not entry then
+      return
+    end
+    -- Only a jump that happened costs the list: a reviewer who pressed a key that could
+    -- not act did not ask to lose what they were reading.
+    if M.jump_to_entry(entry) then
+      close()
+    end
+  end, { buffer = buf, desc = "Jump to the annotation" })
 
   vim.keymap.set("n", "x", function()
     local id = entry_at_cursor()

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,6 +48,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
+| `queue_jump_panel_spec` | That jump with the tree dismissed, summoned, and never there — the one surface neither slice could test alone |
 | `interactive_spec` | The insert-mode leak, and where a completed or cancelled `@` leaves you, in a real pty-backed Neovim |
 
 ## Fixtures
@@ -63,7 +64,7 @@ interchangeable, and the assertions know which one they are looking at.
   `interactive_spec`.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
-  so it must not. Used by `panel_spec` and `focus_spec`.
+  so it must not. Used by `panel_spec`, `focus_spec` and `queue_jump_panel_spec`.
 - **`mkbig.sh`** — 60 files, 12k changed lines, for `perf.lua` only.
 
 The sources are Lua and Markdown rather than TypeScript because Neovim core ships both
@@ -135,6 +136,11 @@ so the out-of-core language path is still checked locally without ever failing C
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.
+- **"The tree followed" needs the tree to have been somewhere else first.** It repaints only
+  when the diff cursor crosses into a *different* file than the one it last painted for, so
+  an assertion that it points at a file it was already pointing at passes with nothing
+  syncing it. `queue_jump_panel_spec` puts the highlight on another file, and asserts that
+  guard, before every case that claims a jump moved it.
 - **An immediate send asks for its target before the composer exists.** Nothing is
   floating between the two, so a picker stub that answers inline collapses the whole
   interaction into one tick and no test can observe the order. `composer_spec` holds the

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
+| `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
 | `interactive_spec` | The insert-mode leak, and where a completed or cancelled `@` leaves you, in a real pty-backed Neovim |
 
 ## Fixtures
@@ -58,7 +59,8 @@ interchangeable, and the assertions know which one they are looking at.
   modified, deleted, added, renamed-and-edited, staged, unstaged, untracked, untracked
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
-  `viewless_spec`, `capture_spec`, `delivery_spec` and `interactive_spec`.
+  `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec` and
+  `interactive_spec`.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec` and `focus_spec`.

--- a/tests/codereview/queue_jump_panel_spec.lua
+++ b/tests/codereview/queue_jump_panel_spec.lua
@@ -1,0 +1,242 @@
+-- The queue float's jump and the file tree, together.
+--
+-- Neither slice could cover this. The jump was written against a base where the tree was
+-- constant for the life of a review -- always there or never -- and the toggle against one
+-- where the float could not move the cursor at all. What their combination implies is that
+-- `V.panel_win` now transitions at runtime *underneath* a jump, which drives the tree twice
+-- on its way: once through the repaint that expands a collapsed file, and once through the
+-- cursor move that follows it.
+local h = require("tests.helpers")
+
+-- The nested fixture, as panel_spec uses: a tree whose rows are compacted directory chains
+-- rather than one row per file, so "which row is highlighted" is a real question.
+h.ui(120, 45)
+h.cd_fixture("mktree")
+
+---@param panel table|nil Panel options, or nil for the default: enabled, on the left
+local function setup(panel)
+  require("codereview").setup({
+    syntax = false,
+    panel = panel,
+    compose = function(_, on_accept)
+      on_accept(nil, "a note")
+    end,
+  })
+end
+
+setup(nil)
+
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+local annotate = require("codereview.annotate")
+
+view.open("branch")
+local V = view.current()
+queue.clear()
+
+local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
+
+---@param kind "file"|"line"
+---@param path string|nil
+---@return integer|nil
+local function row_of(kind, path)
+  for row = 1, vim.api.nvim_buf_line_count(V.buf) do
+    local a = V.render.anchors[row]
+    if a and a.kind == kind and (not path or V.files[a.file].path == path) then
+      return row
+    end
+  end
+end
+
+---@param row integer
+---@return integer row
+local function annotate_row(row)
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  annotate.annotate("bug")
+  return row
+end
+
+local function park()
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+end
+
+---@return integer win
+local function open_float()
+  view.review_queue()
+  return vim.api.nvim_get_current_win()
+end
+
+---Put the float's cursor on the only entry it is listing, and press the jump key.
+---@param win integer
+local function jump_from(win)
+  for row, text in ipairs(vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, -1, false)) do
+    if text:match("^1%. ") then
+      vim.api.nvim_win_set_cursor(win, { row, 0 })
+      h.feed("<CR>")
+      return
+    end
+  end
+  error("nothing listed in the float")
+end
+
+local function shown()
+  return V.panel_win ~= nil and vim.api.nvim_win_is_valid(V.panel_win)
+end
+
+---Tree row carrying the current-file highlight, as panel_spec reads it.
+---@return integer
+local function selected_row()
+  local sel = vim.tbl_filter(function(m)
+    return m[4].line_hl_group == "CodeReviewPanelSel"
+  end, vim.api.nvim_buf_get_extmarks(V.panel_buf, NS_PANEL, 0, -1, { details = true }))
+  assert.same(1, #sel)
+  return sel[1][2] + 1
+end
+
+---Read a file in the diff the way a reviewer does, autocmd and all -- which is what moves
+---the tree's latch, and the only thing that does.
+---@param path string
+---@return integer index
+local function look_at(path)
+  local index = assert(h.file_index(V, path))
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index], 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+  return index
+end
+
+describe("jumping with the tree dismissed", function()
+  local path = "apps/api/src/main.lua"
+  local index = assert(h.file_index(V, path))
+  annotate_row(assert(row_of("line", path)))
+
+  -- Reviewed, so the file collapses and the row the annotation is about stops being
+  -- rendered at all. The jump therefore has to repaint before it can land, and that
+  -- repaint now runs with no tree beside it to repaint.
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index], 0 })
+  view.toggle_reviewed()
+  view.toggle_panel()
+
+  local dismissed = shown()
+  local while_collapsed = row_of("line", path)
+
+  park()
+  local win = open_float()
+  jump_from(win)
+
+  local landed = vim.api.nvim_win_get_cursor(V.win)[1]
+  local reopened = row_of("line", path)
+
+  -- Guards the test itself: with a tree still up, or a file still expanded, neither half
+  -- of what this is about would be exercised.
+  it("really had no tree, and nothing to land on", function()
+    assert.is_false(dismissed)
+    assert.is_nil(while_collapsed)
+  end)
+
+  it("expands the file and lands on its code", function()
+    assert.is_true(V.expanded[path])
+    assert.is_truthy(reopened)
+    assert.same(reopened, landed)
+  end)
+
+  it("leaves focus in the diff and closes the float", function()
+    assert.same(V.win, vim.api.nvim_get_current_win())
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+
+  it("conjures no tree on the way", function()
+    assert.is_false(shown())
+    assert.is_nil(V.panel_render)
+  end)
+end)
+
+describe("summoning the tree after that jump", function()
+  local index = assert(h.file_index(V, "apps/api/src/main.lua"))
+  view.toggle_panel()
+
+  it("comes back", function()
+    assert.is_true(shown())
+  end)
+
+  it("highlights the file the jump landed in", function()
+    assert.same(V.panel_render.file_row[index], selected_row())
+  end)
+end)
+
+-- The sharp one. The tree repaints only when the diff cursor crosses into a *different*
+-- file than the one it last painted for, so the file being read when the tree is dismissed
+-- is precisely the file a latch left behind would refuse to repaint for. Reaching it by a
+-- jump rather than by scrolling is what neither slice tested: the jump moves the cursor
+-- itself and syncs the tree itself, without waiting for CursorMoved.
+describe("jumping into the file the tree was dismissed on", function()
+  queue.clear()
+  view.paint()
+
+  local home, away = "apps/web/src/index.lua", "docs/guide.md"
+  local hi = look_at(home)
+  annotate_row(assert(row_of("line", home)))
+  look_at(home)
+
+  local home_row = V.panel_render.file_row[hi]
+  local selected_before = selected_row()
+
+  view.toggle_panel()
+  local ai = look_at(away)
+  view.toggle_panel()
+
+  local away_row = V.panel_render.file_row[ai]
+  local selected_on_return = selected_row()
+
+  local win = open_float()
+  jump_from(win)
+
+  local selected_after = selected_row()
+  local panel_cursor = vim.api.nvim_win_get_cursor(V.panel_win)[1]
+  local home_row_now = V.panel_render.file_row[hi]
+
+  it("was following the diff before the tree went away", function()
+    assert.same(home_row, selected_before)
+  end)
+
+  -- Guards the test itself: if the tree came back already pointing at the jump's
+  -- destination, the assertion below would pass with nothing having moved it.
+  it("comes back pointing at what was read while it was gone", function()
+    assert.is_true(home_row ~= away_row)
+    assert.same(away_row, selected_on_return)
+  end)
+
+  it("follows the jump back into the file it was dismissed on", function()
+    assert.same(home_row_now, selected_after)
+  end)
+
+  it("takes the tree's own cursor there too", function()
+    assert.same(home_row_now, panel_cursor)
+  end)
+end)
+
+-- Last: this reopens the review, so every `V` above it is gone.
+describe("a review that opens with no tree at all", function()
+  view.close()
+  setup({ enabled = false })
+  view.open("branch")
+  V = view.current()
+  queue.clear()
+
+  local target = annotate_row(assert(row_of("line", "packages/shared/src/types.lua")))
+  park()
+  local win = open_float()
+  jump_from(win)
+
+  it("never had a tree", function()
+    assert.is_false(shown())
+    assert.is_nil(V.panel_render)
+  end)
+
+  it("jumps anyway", function()
+    assert.same(target, vim.api.nvim_win_get_cursor(V.win)[1])
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+end)

--- a/tests/codereview/queue_jump_spec.lua
+++ b/tests/codereview/queue_jump_spec.lua
@@ -1,0 +1,375 @@
+-- Jumping from the queue float to the annotation under the cursor.
+--
+-- The float lists a queue that is shared with the capture path and is reachable with no
+-- review view open, so several of the annotations it lists have nowhere to go. Those are
+-- three different failures with three different remedies -- nothing, open a review, change
+-- scope -- which is why the messages are asserted apart rather than merely counted.
+local h = require("tests.helpers")
+
+-- Deliberately short: whether a landing row is *centred* is only observable when the diff
+-- outruns the window and there is somewhere else the cursor could have been put.
+h.ui(100, 20)
+h.cd_fixture("mkfixture")
+
+require("codereview").setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "a note")
+  end,
+  send = function() end,
+})
+
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+local annotate = require("codereview.annotate")
+
+view.open("branch")
+local V = view.current()
+queue.clear()
+
+---A row carrying an anchor of `kind`, scanned in buffer order.
+---
+---In buffer order rather than through `pairs` over the anchor map: which row an assertion
+---is about is the whole point here, and `pairs` would pick an arbitrary one.
+---@param kind "file"|"line"
+---@param path string|nil Restrict to one file
+---@param last boolean|nil Scan from the bottom instead
+---@return integer|nil
+local function row_of(kind, path, last)
+  local from, to, step = 1, vim.api.nvim_buf_line_count(V.buf), 1
+  if last then
+    from, to, step = to, from, -1
+  end
+  for row = from, to, step do
+    local a = V.render.anchors[row]
+    if a and a.kind == kind and (not path or V.files[a.file].path == path) then
+      return row
+    end
+  end
+end
+
+---@param row integer
+---@return integer row
+local function annotate_row(row)
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  annotate.annotate("bug")
+  return row
+end
+
+---Park the diff at the top, so a jump is a move rather than a coincidence.
+local function park()
+  vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+  vim.api.nvim_win_call(V.win, function()
+    vim.cmd("normal! zt")
+  end)
+end
+
+local function fresh_queue()
+  queue.clear()
+  if view.current() then
+    view.paint()
+  end
+end
+
+---@return integer win
+local function open_float()
+  view.review_queue()
+  return vim.api.nvim_get_current_win()
+end
+
+---Put the float's cursor inside the numbered entry.
+---@param win integer
+---@param index integer The number the float printed against the entry
+---@param offset integer|nil Rows below the heading, for the "cursor is inside it" case
+local function cursor_on(win, index, offset)
+  local buf = vim.api.nvim_win_get_buf(win)
+  for row, text in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
+    if text:match("^" .. index .. "%. ") then
+      vim.api.nvim_win_set_cursor(win, { row + (offset or 0), 0 })
+      return row
+    end
+  end
+  error(("entry %d is not listed in the float"):format(index))
+end
+
+---@param win integer
+---@return string
+local function footer(win)
+  local cfg = vim.api.nvim_win_get_config(win)
+  return cfg.footer and tostring(cfg.footer[1][1]) or ""
+end
+
+---What each unavailable case said, in the order the cases run.
+local said = {}
+
+---Press the jump key in the focused float and collect what it reported.
+---@return string[] messages
+local function jump()
+  local messages, restore = h.capture_notify()
+  h.feed("<CR>")
+  restore()
+  return messages
+end
+
+describe("jumping to a line annotation", function()
+  fresh_queue()
+  local target = annotate_row(row_of("line", nil, true))
+  park()
+  local win = open_float()
+  cursor_on(win, 1)
+  jump()
+
+  local height = vim.api.nvim_win_get_height(V.win)
+  local landed = vim.api.nvim_win_get_cursor(V.win)[1]
+  local winline = vim.api.nvim_win_call(V.win, vim.fn.winline)
+
+  -- Guards the test itself: a target already on screen would pass the centring assertion
+  -- with nothing scrolling it.
+  it("is a jump that has to scroll", function()
+    assert.is_true(target > height, ("row %d, window height %d"):format(target, height))
+  end)
+
+  it("closes the float", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+    assert.is_nil(V.queue_win)
+  end)
+
+  it("leaves focus in the diff", function()
+    assert.same(V.win, vim.api.nvim_get_current_win())
+  end)
+
+  it("lands on the line the annotation is about", function()
+    assert.same(target, landed)
+  end)
+
+  it("centres it", function()
+    assert.is_true(
+      math.abs(winline - math.ceil(height / 2)) <= 1,
+      ("cursor on screen row %d of %d"):format(winline, height)
+    )
+  end)
+end)
+
+describe("the entry the cursor is inside", function()
+  fresh_queue()
+  local first = annotate_row(row_of("line"))
+  local second = annotate_row(row_of("line", nil, true))
+  park()
+  local win = open_float()
+  -- Below the heading rather than on it: the float resolves an entry the same way dropping
+  -- one does, which is the nearest heading at or above the cursor.
+  cursor_on(win, 2, 1)
+  jump()
+  local landed = vim.api.nvim_win_get_cursor(V.win)[1]
+
+  it("is the one the cursor was inside, not the first one listed", function()
+    assert.is_true(first ~= second)
+    assert.same(second, landed)
+  end)
+end)
+
+describe("jumping to a whole-file annotation", function()
+  fresh_queue()
+  local header = annotate_row(row_of("file", "src/newname.lua"))
+  park()
+  local win = open_float()
+  cursor_on(win, 1)
+  jump()
+
+  it("lands on that file's header", function()
+    assert.same(header, vim.api.nvim_win_get_cursor(V.win)[1])
+  end)
+end)
+
+describe("jumping into a collapsed file", function()
+  fresh_queue()
+  local path = "src/main.lua"
+  annotate_row(row_of("line", path))
+
+  -- Marking it reviewed collapses it, so the row the annotation is about stops being
+  -- rendered at all -- the case where landing on the header would be landing on nothing.
+  vim.api.nvim_win_set_cursor(V.win, { row_of("file", path), 0 })
+  view.toggle_reviewed()
+  local while_collapsed = row_of("line", path)
+
+  park()
+  local win = open_float()
+  cursor_on(win, 1)
+  jump()
+  local landed = vim.api.nvim_win_get_cursor(V.win)[1]
+  local reopened = row_of("line", path)
+
+  -- Put it back, so the cases below see the diff the ones above did.
+  vim.api.nvim_win_set_cursor(V.win, { row_of("file", path), 0 })
+  view.toggle_reviewed()
+
+  it("had nothing to land on before the jump", function()
+    assert.is_nil(while_collapsed)
+  end)
+
+  it("expands the file", function()
+    assert.is_true(V.expanded[path])
+    assert.is_truthy(reopened)
+  end)
+
+  it("lands on the code rather than the header", function()
+    assert.same(reopened, landed)
+  end)
+end)
+
+describe("jumping to a stale annotation", function()
+  fresh_queue()
+  local at_capture = row_of("line", nil, true)
+  local path = V.files[V.render.anchors[at_capture].file].path
+  annotate_row(at_capture)
+  queue.all()[1].stale = true
+
+  -- Collapsing a file above it moves the row this annotation is drawn on while leaving the
+  -- anchor it is keyed by alone. What the jump resolves against has to be the diff now, not
+  -- a row that was true when the note was written.
+  local above = "src/main.lua"
+  vim.api.nvim_win_set_cursor(V.win, { row_of("file", above), 0 })
+  view.toggle_reviewed()
+  local moved = row_of("line", path, true)
+
+  park()
+  local win = open_float()
+  cursor_on(win, 1)
+  jump()
+  local landed = vim.api.nvim_win_get_cursor(V.win)[1]
+
+  vim.api.nvim_win_set_cursor(V.win, { row_of("file", above), 0 })
+  view.toggle_reviewed()
+
+  it("is drawn somewhere else than when it was captured", function()
+    assert.is_true(moved ~= at_capture, ("row %d either way"):format(moved))
+  end)
+
+  it("still goes wherever its anchor now points", function()
+    assert.same(moved, landed)
+  end)
+end)
+
+describe("the keys the float already had", function()
+  -- `<C-t>` and `<C-s>` are focus_spec's, which drives both across the asynchronous
+  -- picker; what is left to pin here is that neither has lost its place in the footer.
+  fresh_queue()
+  annotate_row(row_of("line"))
+  annotate_row(row_of("line", nil, true))
+  local win = open_float()
+  local advertised = footer(win)
+
+  cursor_on(win, 2)
+  h.feed("x")
+  local left = queue.count()
+  local open_after_drop = vim.api.nvim_win_is_valid(win)
+  h.feed("q")
+
+  it("advertises the jump alongside them", function()
+    for _, key in ipairs({ "^T", "jump", "x drop", "^S submit", "q close" }) do
+      assert.is_truthy(advertised:find(key, 1, true), advertised)
+    end
+  end)
+
+  it("still drops the entry under the cursor", function()
+    assert.same(1, left)
+  end)
+
+  it("keeps the float open after a drop", function()
+    assert.is_true(open_after_drop)
+  end)
+
+  it("still closes on q", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+end)
+
+describe("a bare note", function()
+  fresh_queue()
+  -- An unnamed buffer has nothing on disk to anchor to, which is the one kind that will
+  -- never have a destination.
+  vim.cmd("tabnew")
+  require("codereview").annotate("bug")
+  vim.cmd("tabclose")
+
+  park()
+  local win = open_float()
+  cursor_on(win, 1)
+  local messages = jump()
+  said[#said + 1] = messages[1]
+  local still_open = vim.api.nvim_win_is_valid(win)
+  h.feed("q")
+
+  it("queued a note with no file behind it", function()
+    assert.same("note", queue.all()[1].kind)
+  end)
+
+  it("says there is nowhere to go", function()
+    assert.same(1, #messages)
+    assert.is_true(h.notified(messages, "nowhere to jump"), messages[1])
+  end)
+
+  it("leaves the float open", function()
+    assert.is_true(still_open)
+  end)
+end)
+
+describe("an annotation whose file is outside the scope", function()
+  fresh_queue()
+  annotate_row(row_of("line", "src/main.lua"))
+  -- Only `src/routes.lua` is staged, so the annotated file is genuinely not in the review
+  -- any more -- and changing scope is the only thing that would bring it back.
+  view.set_scope("staged")
+
+  park()
+  local win = open_float()
+  cursor_on(win, 1)
+  local messages = jump()
+  said[#said + 1] = messages[1]
+  local still_open = vim.api.nvim_win_is_valid(win)
+
+  it("really is out of scope", function()
+    assert.is_nil(h.file_index(V, "src/main.lua"))
+  end)
+
+  it("names the file and blames the scope", function()
+    assert.same(1, #messages)
+    assert.is_true(h.notified(messages, "src/main.lua"), messages[1])
+    assert.is_true(h.notified(messages, "scope"), messages[1])
+  end)
+
+  it("leaves the float open", function()
+    assert.is_true(still_open)
+  end)
+end)
+
+describe("with no review view open", function()
+  fresh_queue()
+  annotate_row(row_of("line"))
+  view.close()
+
+  local win = open_float()
+  cursor_on(win, 1)
+  local messages = jump()
+  said[#said + 1] = messages[1]
+  local still_open = vim.api.nvim_win_is_valid(win)
+
+  it("says the review view is what is missing", function()
+    assert.same(1, #messages)
+    assert.is_true(h.notified(messages, "No review view open"), messages[1])
+  end)
+
+  it("leaves the float open", function()
+    assert.is_true(still_open)
+  end)
+end)
+
+describe("the three unavailable cases", function()
+  it("give three distinct messages, not one shared one", function()
+    assert.same(3, #said)
+    assert.is_true(said[1] ~= said[2], said[1])
+    assert.is_true(said[2] ~= said[3], said[2])
+    assert.is_true(said[1] ~= said[3], said[3])
+  end)
+end)


### PR DESCRIPTION
Closes #53.

The queue float lists every queued **annotation** and could reach none of them. `<CR>` now
jumps to the one under the cursor: the float closes, focus returns to the diff, and the
line the annotation is about is centred. A file that is collapsed is expanded first.

## How it resolves

Nothing here answers a question the view already answers.

- **Which entry** is the one the float's `x` already resolves — the nearest heading at or
  above the cursor — so dropping and jumping cannot disagree about what you are pointing at.
- **Which row** comes from scanning the anchor map for the entry's key, the scan `]a`
  already makes. That is what makes a stale annotation still land wherever its anchor now
  points, rather than on a row that was true when the note was written.
- **Expanding a collapsed file** matches `<C-p>`'s courtesy, extended to the case a file
  renders collapsed with nothing recorded against it because it is reviewed.
- A whole-file entry's key matches no line, and neither does a line this diff no longer
  renders. Both mean the file, so both land on its header.

## Where it cannot go

ADR-0002 keeps one **entry** shape whichever path captured it, so the float necessarily
lists annotations with nowhere to go — and it is reachable with no **review view** open at
all. Three cases therefore report and leave the float open, because a reviewer who pressed
a key that could not act did not ask to lose their list:

| Case | Message | Remedy |
| --- | --- | --- |
| A **bare note** | `A bare note is about no file — there is nowhere to jump to` | none, ever |
| No review view | `No review view open — open one to jump to an annotation` | open a review |
| Outside the **scope** | `src/main.lua is not in the branch scope — change scope to jump to it` | change scope |

Three messages, not one, because three remedies. The entry captured outside a checkout —
which has no repository-relative path — falls into the third: no scope of this review
covers it.

Every existing float key is untouched: `x` drops, `<C-t>` routes, `<C-s>` submits, `q` and
`<Esc>` close.

## Red first

`tests/codereview/queue_jump_spec.lua` was written and run before the mapping existed.

| | Before | After |
| --- | --- | --- |
| Cases | 24 | 25 |
| Passing | 10 | 25 |
| Failing | **14** | 0 |

The 10 that passed before are the self-guards and the pre-existing behaviour: that the
landing row really is off-screen (row 41, window height 17), that the collapsed file really
had no row to land on, that `x` and `q` still work, and that the out-of-scope file really
is absent from `V.files`.

Observed before → after on the failures:

- Line jump: float still open → closed; focus `1004` (the float) → `1001` (the diff);
  cursor row `1` → `41`; cursor on screen row `1 of 17` → centred.
- Entry under the cursor: row `1` → `41`, the second entry rather than the first.
- Whole file: row `1` → `16`, the header.
- Collapsed file: `V.expanded["src/main.lua"]` `nil` → `true`, and a row to land on where
  there had been none.
- Stale: row `1` → the row it moved to after a file above it collapsed.
- Each unavailable case: `0` notifications → `1`, and the three are distinct.
- Footer: ` ^T local · x drop · ^S submit · q close ` → ` ^T local · ⏎ jump · x drop · ^S
  submit · q close `.

`make all` is green: 654 cases, 0 failures, lint clean.