### PR TITLE
feat(view): render a diff as two panes side by side

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,8 +14,25 @@ git revspec.
 _Avoid_: mode, filter, range (a range is a span of lines, see **Range**)
 
 **Review view**:
-The unified, syntax-highlighted diff of a scope, with annotations projected onto its lines.
+The syntax-highlighted diff of a scope, with annotations projected onto its lines. Means
+the whole surface in either **layout**.
 _Avoid_: diff view, buffer
+
+**Layout**:
+How the review view arranges a diff: **unified**, deleted and added lines stacked in one
+column, or **split**, the before- and after-images as two **panes** side by side.
+_Avoid_: mode, diff view
+
+**Pane**:
+One of the two windows in a split layout, holding the before- or the after-image. Not
+_side_: a diff line's side is already add/del/ctx, and one word must not do two jobs.
+_Avoid_: side, column, window
+
+**Filler**:
+A blank row emitted in one pane where the other has no counterpart — a pure addition, a
+pure deletion, a file that exists on only one side — so the two stay row-aligned. Distinct
+from a **pad**, the blank row after a hunk, which both panes draw.
+_Avoid_: padding, spacer
 
 **Review path**:
 Annotating from inside the review view, where the diff and its anchors decide what an

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 [![Neovim 0.12+](https://img.shields.io/badge/Neovim-0.12%2B-57A143?logo=neovim&logoColor=white)](https://neovim.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-A code review surface for Neovim: one unified, syntax-highlighted diff of everything a
-branch changed, with vim-native navigation, typed annotations that queue up, reviewed-file
-collapsing, and a batch submit that hands the whole review to an agent as a single message.
+A code review surface for Neovim: one syntax-highlighted diff of everything a branch
+changed — unified or side by side — with vim-native navigation, typed annotations that queue
+up, reviewed-file collapsing, and a batch submit that hands the whole review to an agent as
+a single message.
 
 ```
 ┌─ tree ──────────────┐┌─ Code review · branch vs origin/master · 2/7 · +9 -4 ──┐
@@ -140,6 +141,66 @@ Because the note owns that choice rather than the batch, the composer's footer n
 target *this note* will reach, and `^T` in the composer reroutes the note, leaving the
 batch pointing where it was.
 
+### Layouts
+
+The review view arranges a diff one of two ways. **Unified** is what has always existed and
+stays the default: deleted and added lines stacked in one column. **Split** draws the same
+diff as two **panes** — the before-image on the left, the after-image on the right — with
+corresponding code on the same screen row.
+
+```lua
+opts = { layout = "split" }   -- "unified" (default) or "split"
+```
+
+```
+┌─ tree ─────────┐┌─ Before · origin/master ────┐┌─ Code review · branch · 2/7 ─┐
+│ ▾ apps     1/4 ││     apps/api/src/main.ts    ││ ● ▾ apps/api/src/main.ts +12 │
+│   ▾ api/src1/2 ││ @@ -19,6 @@                 ││ @@ +19,8 @@ function boot()  │
+│     ● main.ts 3││  19 │  const app = express()││  19 │  const app = express() │
+│   ▾ web/src0/2 ││ ▌20 │ -const cfg = load()   ││ ▌20 │ +const cfg = loadCon…  │
+│     ✓ index.ts ││                             ││ ▌    │   🐞 why the rename?  │
+│ ○ README.md    ││                             ││ ▌21 │ +cfg.validate()       │
+│ 2/7 reviewed   ││  21 │  app.listen(cfg.port) ││  22 │  app.listen(cfg.port) │
+└────────────────┘└─────────────────────────────┘└──────────────────────────────┘
+```
+
+The blank rows on the left are **filler**: the addition on row 21 has no counterpart in the
+before-image, so the left pane holds its place rather than letting the two drift apart. The
+note is drawn once, in the pane its line belongs to, and the opposite pane holds that place
+too.
+
+The value is validated at `setup()`, so a typo fails loudly instead of quietly rendering
+unified. Everything the view does works in both: files collapse and expand, files are
+marked reviewed, annotations are captured and displayed on the lines they are about,
+navigation moves by file, hunk and annotation, and both panes are syntax-highlighted — the
+left from the pre-image, the right from the post-image.
+
+Where one image has no counterpart — a pure addition, a pure deletion, a file that exists on
+only one side — the other pane draws **filler**: a blank row that keeps the two in step and
+that resolves to the whole file if you annotate from it, rather than to whatever code
+happens to be above it.
+
+Chrome is split too, so headers stay aligned as well: a hunk header shows its pre-image
+range on the left and its post-image range plus git's section heading on the right, and a
+renamed file shows its old path on the left and its new path on the right. The right pane's
+winbar carries the review status; the left names the revision it is showing.
+
+You can annotate from either pane, and the pane you are in decides what is captured — a
+deleted line on the left, the post-image line on the right. **The entry is the same either
+way.** A layout is a rendering choice and nothing else, so which one was on screen never
+reaches the receiving agent
+([ADR-0002](docs/adr/0002-one-queue-one-entry-shape.md)). Notes are drawn in the pane the
+line belongs to, wrapped to that pane's width, with the opposite pane holding its place so
+reading one never knocks the two out of alignment.
+
+The panes scroll and move together. Horizontal scrolling does not, because synchronising it
+would mean changing `scrollopt`, which is a global option this plugin does not own.
+
+One behavioural difference, and only one: a visual **range** cannot span both images,
+because the two runs live in different windows and cannot be in one selection.
+Pure-addition and pure-deletion ranges work, and annotating the hunk header captures both
+images inlined — so what a split range cannot express is still one keystroke away.
+
 ### Inside the view
 
 | Key | Action |
@@ -235,6 +296,7 @@ message would name none of them.
 | A visual selection | Those lines |
 | A hunk header | The whole hunk |
 | A file header | The whole file |
+| A filler row (split layout) | The whole file |
 
 ## Annotation types
 
@@ -390,6 +452,7 @@ opts = {
   untracked = true,                -- show untracked files in branch/worktree scopes
   syntax = true,                   -- treesitter highlighting
   max_syntax_bytes = 256 * 1024,   -- skip syntax above this size
+  layout = "unified",              -- "unified" or "split"; validated at setup
   panel = { enabled = true, width = 34, position = "left" },
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
             collapsed = "▸", expanded = "▾", change_bar = "▌" },

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -7,21 +7,23 @@ CONTENTS                                                          *codereview*
   2. Commands ............................. |codereview-commands|
   3. Mappings ............................. |codereview-mappings|
   4. Scopes ............................... |codereview-scopes|
-  5. Annotations .......................... |codereview-annotations|
-  6. Capture ............................... |codereview-capture|
-  7. Adapters ............................. |codereview-adapters|
-  8. Configuration ........................ |codereview-configuration|
-  9. Highlights ........................... |codereview-highlights|
- 10. Persistence .......................... |codereview-persistence|
- 11. Lua API .............................. |codereview-api|
- 12. License .............................. |codereview-license|
+  5. Layouts .............................. |codereview-layouts|
+  6. Annotations .......................... |codereview-annotations|
+  7. Capture ............................... |codereview-capture|
+  8. Adapters ............................. |codereview-adapters|
+  9. Configuration ........................ |codereview-configuration|
+ 10. Highlights ........................... |codereview-highlights|
+ 11. Persistence .......................... |codereview-persistence|
+ 12. Lua API .............................. |codereview-api|
+ 13. License .............................. |codereview-license|
 
 ==============================================================================
 1. INTRODUCTION                                    *codereview-introduction*
 
-A unified, syntax-highlighted diff of everything a branch changed, in one
-buffer, with a file panel beside it. Annotate lines, selections, hunks or whole
-files with a type; the annotations queue up; submit them as one batch.
+A syntax-highlighted diff of everything a branch changed, with a file panel
+beside it -- unified in one buffer, or side by side as two panes. Annotate
+lines, selections, hunks or whole files with a type; the annotations queue up;
+submit them as one batch. See |codereview-layouts|.
 
 Requires Neovim 0.12 or newer and `git`. Treesitter parsers are optional --
 files without one fall back to flat diff colours.
@@ -159,7 +161,54 @@ set `untracked = false` to hide them. `git diff` never reports them, so a
 brand-new file would otherwise be invisible to the review.
 
 ==============================================================================
-5. ANNOTATIONS                                      *codereview-annotations*
+5. LAYOUTS                                              *codereview-layouts*
+
+The review view arranges a diff one of two ways: >
+    require("codereview").setup({ layout = "split" })
+<
+    unified     deleted and added lines stacked in one column (default)
+    split       the before-image and the after-image as two panes, side by
+                side, with corresponding code on the same screen row
+
+The value is validated at |codereview.setup()|, so a mistyped one fails there
+rather than silently rendering unified.
+
+Everything the view does works in both. Files collapse and expand, files are
+marked reviewed, annotations are captured and displayed on the lines they are
+about, navigation moves by file, hunk and annotation, and both panes are
+syntax-highlighted -- the left pane from the pre-image, the right from the
+post-image.
+
+Where one image has no counterpart -- a pure addition, a pure deletion, a file
+that exists on only one side -- the other pane draws *filler*: a blank row that
+keeps the two in step. Annotating from a filler row resolves to the whole
+file, never to whatever code happens to be above it.
+
+Chrome is split too, so headers stay aligned as well. A hunk header shows its
+pre-image range on the left and its post-image range plus git's section
+heading on the right; a renamed file shows its old path on the left and its
+new path on the right. The right pane's winbar carries the review status; the
+left names the revision it is showing.
+
+Both panes accept annotations, and the pane the cursor is in decides what is
+captured: a deleted line on the left, the post-image line on the right. The
+entry is the same either way -- a layout is a rendering choice and nothing
+else, so which one was on screen never reaches the receiving agent. Notes are
+drawn in the pane their line belongs to, wrapped to that pane's width, with
+the opposite pane holding its place so the two stay aligned.
+
+The panes are held together with |scrollbind| and |cursorbind|, which are
+window-local. |scrollopt| is global and is deliberately not touched, so
+vertical movement is synchronised and horizontal scrolling is not.
+
+One behavioural difference, and only one: a visual range cannot span both
+images, because the two runs live in different windows and cannot be in one
+selection. Pure-addition and pure-deletion ranges work, and annotating the
+hunk header captures both images inlined -- so what a split range cannot
+express is still one keystroke away.
+
+==============================================================================
+6. ANNOTATIONS                                      *codereview-annotations*
 
 What gets annotated depends on where the cursor is:
 
@@ -167,6 +216,7 @@ What gets annotated depends on where the cursor is:
     a visual selection  those lines
     a hunk header       the whole hunk
     a file header       the whole file
+    a filler row        the whole file (split layout)
 
 A selection spanning more than one file is clamped to the file it started in,
 and says so. Anything touching a deleted line is inlined as a diff block
@@ -274,7 +324,7 @@ abandoned.
 Wire |codereview-opt-compose| to replace this composer with your own.
 
 ==============================================================================
-6. CAPTURE                                              *codereview-capture*
+7. CAPTURE                                              *codereview-capture*
 
 Annotating does not need a review open. |:CodeReviewAnnotate| and
 |codereview.annotate()| queue a note about the buffer you are looking at.
@@ -354,7 +404,7 @@ batch pointing where it was. Abandon it and the text is kept as a draft, like
 any other note you walked away from.
 
 ==============================================================================
-7. ADAPTERS                                            *codereview-adapters*
+8. ADAPTERS                                            *codereview-adapters*
 
 The plugin has no opinion about where a review goes, or about which pickers
 you use. Four optional functions inject that. With none of them wired
@@ -466,7 +516,7 @@ compose({ctx}, {on_accept}, {label})                  *codereview-opt-compose*
         moment the composer opens a picker of its own.
 
 ==============================================================================
-8. CONFIGURATION                                  *codereview-configuration*
+9. CONFIGURATION                                  *codereview-configuration*
 
 Defaults: >
     require("codereview").setup({
@@ -474,6 +524,7 @@ Defaults: >
       untracked = true,
       syntax = true,
       max_syntax_bytes = 256 * 1024,
+      layout = "unified",
       panel = { enabled = true, width = 34, position = "left" },
       icons = {
         reviewed = "✓", annotated = "●", unreviewed = "○",
@@ -488,7 +539,7 @@ Files above it, files with no parser, and binary files all fall back to flat
 diff colours individually -- never the whole view.
 
 ==============================================================================
-9. HIGHLIGHTS                                        *codereview-highlights*
+10. HIGHLIGHTS                                        *codereview-highlights*
 
 Every group is a `default = true` link to something a colorscheme already
 defines, so overriding any of them works without the plugin fighting back: >
@@ -513,7 +564,7 @@ defines, so overriding any of them works without the plugin fighting back: >
     CodeReviewIssue        -> DiagnosticOk
 <
 ==============================================================================
-10. PERSISTENCE                                     *codereview-persistence*
+11. PERSISTENCE                                     *codereview-persistence*
 
 Reviewed marks and the queue are written to
 `stdpath("state")/codereview/{repo}.json`, keyed by scope and diff base.
@@ -566,7 +617,7 @@ claim a line span that has since moved, and nothing will flag it -- the
 accepted cost of not making those annotations second-class.
 
 ==============================================================================
-11. LUA API                                                 *codereview-api*
+12. LUA API                                                 *codereview-api*
 
 require("codereview").setup({opts})                     *codereview.setup()*
 require("codereview").open({scope})                      *codereview.open()*
@@ -589,7 +640,7 @@ require("codereview").count()                           *codereview.count()*
 require("codereview").is_open()                       *codereview.is_open()*
 
 ==============================================================================
-12. LICENSE                                               *codereview-license*
+13. LICENSE                                               *codereview-license*
 
 MIT. Copyright (c) 2026 Felipe Valencia. See the LICENSE file in the plugin
 root for the full text.

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -50,11 +50,18 @@ local function selected_rows(win)
 end
 
 ---Resolve what the cursor or selection is pointing at.
+---
+---Read from the pane that has focus rather than from the view's window, so that in the
+---split layout annotating a deleted line on the left captures the deleted line and
+---annotating an added line on the right captures the post-image one -- the same entries the
+---unified layout produces for the same code. In the unified layout there is one pane and
+---this is the window it always was.
 ---@param view CRView
 ---@return CRTarget|nil
 function M.resolve(view)
-  local first, last, visual = selected_rows(view.win)
-  local anchors = view.render and view.render.anchors
+  local win, rendered = require("codereview.view").focused_pane()
+  local first, last, visual = selected_rows(win)
+  local anchors = rendered and rendered.anchors
   if not anchors then
     return nil
   end

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -17,6 +17,10 @@ M.defaults = {
   max_syntax_bytes = 256 * 1024, ---@type integer Skip syntax above this size
 
   --- UI ---
+  ---How the review view arranges a diff. `unified` stacks deleted and added lines in one
+  ---column; `split` draws the before-image and the after-image as two panes side by side.
+  ---Unified is the default, so upgrading the plugin does not change how a review looks.
+  layout = "unified", ---@type "unified"|"split"
   panel = {
     enabled = true,
     width = 34,
@@ -89,9 +93,33 @@ local function resolve_types(options)
   return types.normalise(options.types or types.defaults, { icon = options.icons.annotated })
 end
 
+---Reject a layout the render has no rendering for.
+---
+---Loudly, at `setup()`, in the same voice as a bad type list: a mistyped `layout` that
+---silently fell back to unified would leave a reviewer wondering why their configuration
+---did nothing, and the answer would be nowhere on screen.
+---@param layout any
+local function validate_layout(layout)
+  if not vim.tbl_contains(require("codereview.render").LAYOUTS, layout) then
+    error(
+      ("codereview.setup: unknown `layout` %s — expected one of %s"):format(
+        vim.inspect(layout),
+        table.concat(
+          vim.tbl_map(function(name)
+            return ("%q"):format(name)
+          end, require("codereview.render").LAYOUTS),
+          ", "
+        )
+      ),
+      0
+    )
+  end
+end
+
 ---@param opts table|nil
 function M.setup(opts)
   M.options = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults), opts or {})
+  validate_layout(M.options.layout)
   M.options.types = resolve_types(M.options)
   return M.options
 end

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -4,10 +4,16 @@
 ---produces is the single source of truth that navigation, annotation targeting, collapse
 ---and the syntax replay all read -- every "which change is row 47?" question is answered
 ---here and nowhere else.
+---
+---`build` returns **two** renders from **one** walk: the after-pane render, and the
+---before-pane render, which is nil in the unified layout. One walk rather than two calls is
+---what makes row alignment a property of the returned data, guaranteed by construction,
+---rather than an emergent property of two independent calls agreeing -- and it is what lets
+---every property that makes the split layout correct be asserted with no window on screen.
 local M = {}
 
 ---@class CRAnchor
----@field kind "file"|"sep"|"hunk"|"line"|"pad"|"note"
+---@field kind "file"|"sep"|"hunk"|"line"|"pad"|"note"|"fill"
 ---@field file integer        Index into the file list
 ---@field hunk integer|nil    Index into that file's hunks
 ---@field line integer|nil    Index into that hunk's lines
@@ -22,6 +28,10 @@ local M = {}
 
 local SEP = " │ "
 
+---The layouts a review can be rendered in. `unified` is what has always existed; `split`
+---draws the same diff as two panes, the before-image beside the after-image.
+M.LAYOUTS = { "unified", "split" }
+
 ---Explicit so the layers compose predictably: diff backgrounds sit underneath, the
 ---treesitter foregrounds `syntax.lua` adds sit on top. Leaving these at the extmark
 ---default makes the result depend on insertion order, which changes as the view repaints.
@@ -32,6 +42,9 @@ M.PRIORITY = { diff = 100, gutter = 110, syntax = 150 }
 ---Sided because a deleted line and an added line can share a number: `foo.ts:o:20` and
 ---`foo.ts:n:20` are different places, and collapsing them would move annotations onto
 ---code they were never about.
+---
+---Also what decides which **pane** a note is drawn in, since the side is already in the
+---key: no second rule is introduced for the split layout.
 ---@param path string
 ---@param line CRLine
 ---@return string
@@ -50,10 +63,21 @@ function M.file_key(path)
   return path .. ":f:0"
 end
 
+---Whether a key names a place in the pre-image, and so belongs to the before pane.
+---
+---Only a pure deletion produces one: a context line exists on both sides and its key
+---prefers the post-image, which is why context reads in the after pane.
+---@param key string|nil
+---@return boolean
+function M.is_before_key(key)
+  return key ~= nil and key:find(":o:%d+$") ~= nil
+end
+
 ---Widest line number anywhere in the diff.
 ---
 ---Computed across all files, not just expanded ones, so the gutter does not resize --
----and every row shift -- when a file is expanded.
+---and every row shift -- when a file is expanded. Shared by both panes, so their gutters
+---are the same width and their code starts at the same column.
 ---@param files CRFile[]
 ---@return integer
 local function gutter_digits(files)
@@ -89,44 +113,147 @@ local function truncate(text, width)
   return vim.fn.strcharpart(text, 0, math.max(1, width - 1)) .. "…"
 end
 
+---Longest prefix of `text` that fits in `width` display columns, and what is left.
+---
+---By display width rather than by characters: a note containing CJK or an emoji occupies
+---more columns than it has characters, and cutting by character count would overflow.
+---@param text string
+---@param width integer
+---@return string head, string tail
+local function take(text, width)
+  local lo, hi = 0, vim.fn.strchars(text)
+  while lo < hi do
+    local mid = math.floor((lo + hi + 1) / 2)
+    if vim.fn.strdisplaywidth(vim.fn.strcharpart(text, 0, mid)) <= width then
+      lo = mid
+    else
+      hi = mid - 1
+    end
+  end
+  lo = math.max(1, lo)
+  return vim.fn.strcharpart(text, 0, lo), vim.fn.strcharpart(text, lo)
+end
+
+---Break `text` into lines no wider than `width` display columns.
+---
+---Virtual lines clip at the window edge rather than wrapping, so a note that arrives
+---unbroken is silently truncated in a narrow pane. Breaking on whitespace where there is
+---one, and mid-word only when a single word is wider than the pane -- which loses nothing,
+---where clipping loses the tail.
+---@param text string
+---@param width integer
+---@return string[]
+local function wrap(text, width)
+  if width < 1 then
+    return vim.split(text, "\n", { plain = true })
+  end
+  local out = {}
+  for _, para in ipairs(vim.split(text, "\n", { plain = true })) do
+    local rest = para
+    if rest == "" then
+      out[#out + 1] = ""
+    end
+    while rest ~= "" do
+      if vim.fn.strdisplaywidth(rest) <= width then
+        out[#out + 1] = rest
+        rest = ""
+      else
+        local head, tail = take(rest, width)
+        -- Last whitespace inside the part that fits. `head` is a byte-prefix of `rest`, so
+        -- the position it reports is a position in `rest` too.
+        local cut = head:match("^.*()%s")
+        if cut and cut > 1 then
+          out[#out + 1] = (head:sub(1, cut - 1):gsub("%s+$", ""))
+          rest = (rest:sub(cut):gsub("^%s+", ""))
+        else
+          out[#out + 1] = head
+          rest = tail
+        end
+      end
+    end
+  end
+  return out
+end
+
+---Split a hunk header into the halves each pane draws.
+---@param header string "@@ -19,6 +19,8 @@ heading"
+---@param hunk CRHunk
+---@return string old, string new
+local function header_ranges(header, hunk)
+  local old, new = header:match("^@@ (%-[%d,]+) (%+[%d,]+) @@")
+  return old or ("-%d"):format(hunk.old_start), new or ("+%d"):format(hunk.new_start)
+end
+
+---@return table
+local function new_pane()
+  return { lines = {}, anchors = {}, marks = {}, file_rows = {}, hunk_rows = {} }
+end
+
 ---Build the view.
+---
+---Returns the after-pane render first because the after-image is the primary one
+---throughout: context lines are attributed to it, line keys prefer it, an entry's line
+---numbers prefer it, and opening a file resolves through it. In the unified layout the
+---second return value is nil, which is what every existing caller already ignores.
 ---@param files CRFile[]
----@param opts { width: integer, icons: table, expanded: table<string, boolean>, reviewed: table<string, string>, notes: table<string, table[]>, types: CRType[] }
----@return CRRender
+---@param opts { width: integer, before_width: integer|nil, layout: string|nil, icons: table, expanded: table<string, boolean>, reviewed: table<string, string>, notes: table<string, table[]>, types: CRType[] }
+---@return CRRender after, CRRender|nil before
 function M.build(files, opts)
   local icons = opts.icons
+  local split = opts.layout == "split"
   local width = math.max(40, opts.width or 80)
+  local before_width = math.max(40, opts.before_width or width)
   local digits = gutter_digits(files)
 
-  local lines, anchors, marks = {}, {}, {}
-  local file_rows, hunk_rows = {}, {}
+  local after = new_pane()
+  local before = split and new_pane() or nil
 
+  ---@param pane table
   ---@param row integer 1-indexed
   ---@param col integer 0-indexed byte
   ---@param opts_ table
-  local function mark(row, col, opts_)
+  local function mark(pane, row, col, opts_)
     if opts_.priority == nil and not opts_.virt_lines then
       opts_.priority = opts_.line_hl_group and M.PRIORITY.diff or M.PRIORITY.gutter
     end
-    marks[#marks + 1] = { row = row - 1, col = col, opts = opts_ }
+    pane.marks[#pane.marks + 1] = { row = row - 1, col = col, opts = opts_ }
   end
 
+  ---@param pane table
   ---@param text string
   ---@param anchor CRAnchor
   ---@return integer row
-  local function push(text, anchor)
-    lines[#lines + 1] = text
-    anchors[#lines] = anchor
-    return #lines
+  local function push(pane, text, anchor)
+    pane.lines[#pane.lines + 1] = text
+    pane.anchors[#pane.lines] = anchor
+    return #pane.lines
   end
 
-  ---Annotations attached to a row, rendered as virtual lines beneath it.
-  ---@param row integer
+  ---One logical row, drawn in both panes.
+  ---
+  ---Every chrome row goes through here, which is what makes parity structural rather than
+  ---something to remember: a row cannot be added to one pane without the other.
+  ---@param atext string
+  ---@param aanchor CRAnchor
+  ---@param btext string|nil
+  ---@param banchor CRAnchor|nil
+  ---@return integer row
+  local function row2(atext, aanchor, btext, banchor)
+    local r = push(after, atext, aanchor)
+    if before then
+      push(before, btext or "", banchor or { kind = "fill", file = aanchor.file, hunk = aanchor.hunk })
+    end
+    return r
+  end
+
+  ---The virtual lines an annotated row draws, or nil when nothing is attached to it.
   ---@param key string
-  local function attach_notes(row, key)
+  ---@param wrap_to integer|nil Pane width to wrap the note to; nil leaves it unwrapped
+  ---@return table[]|nil
+  local function note_virt(key, wrap_to)
     local items = opts.notes and opts.notes[key]
     if not items or #items == 0 then
-      return
+      return nil
     end
     local virt = {}
     for _, item in ipairs(items) do
@@ -134,13 +261,26 @@ function M.build(files, opts)
       local icon = type_def and type_def.icon or "•"
       local group = type_def and type_def.hl or "CodeReviewNote"
       local prefix = ("   %s "):format(icon)
+      local stale = item.stale and "⚠ stale  " or nil
+
+      local body
+      if wrap_to then
+        -- The marker only prefixes the first line, but wrapping the whole note to the
+        -- narrower budget is what makes "nothing is clipped" true by construction rather
+        -- than true of every line except one.
+        local avail = wrap_to - vim.fn.strdisplaywidth(prefix) - (stale and vim.fn.strdisplaywidth(stale) or 0)
+        body = wrap(item.note, math.max(8, avail))
+      else
+        body = vim.split(item.note, "\n", { plain = true })
+      end
+
       -- A multi-line note becomes multiple virtual lines; the continuation lines are
       -- indented to the icon so the block reads as one comment.
-      for n, text in ipairs(vim.split(item.note, "\n", { plain = true })) do
+      for n, text in ipairs(body) do
         if n == 1 then
           local chunks = { { prefix, group } }
-          if item.stale then
-            chunks[#chunks + 1] = { "⚠ stale  ", "CodeReviewStale" }
+          if stale then
+            chunks[#chunks + 1] = { stale, "CodeReviewStale" }
           end
           chunks[#chunks + 1] = { text, "CodeReviewNote" }
           virt[#virt + 1] = chunks
@@ -149,7 +289,76 @@ function M.build(files, opts)
         end
       end
     end
-    mark(row, 0, { virt_lines = virt })
+    return virt
+  end
+
+  ---@param n integer
+  ---@return table[]
+  local function blank_virt(n)
+    local out = {}
+    for i = 1, n do
+      out[i] = { { "", "CodeReviewNote" } }
+    end
+    return out
+  end
+
+  ---Draw the notes on a row, and hold the opposite pane's place while they are drawn.
+  ---
+  ---A note costs the same vertical space in both panes because a virtual line occupies
+  ---exactly one display line whatever its width, so mirroring the *count* is enough to
+  ---keep the two panes' display heights identical.
+  ---@param row integer
+  ---@param before_key string|nil Pre-image key owning this row in the before pane
+  ---@param after_key string|nil Post-image (or whole-file) key owning it in the after pane
+  local function attach_notes(row, before_key, after_key)
+    if not split then
+      local virt = after_key and note_virt(after_key, nil)
+      if virt then
+        mark(after, row, 0, { virt_lines = virt })
+      end
+      return
+    end
+
+    local bvirt = before_key and note_virt(before_key, before_width) or nil
+    local avirt = after_key and note_virt(after_key, width) or nil
+    if not bvirt and not avirt then
+      return
+    end
+    -- The before pane's own notes come first in both panes, so the blocks line up row for
+    -- row and not merely in total height.
+    local bcount, acount = bvirt and #bvirt or 0, avirt and #avirt or 0
+    local bside = vim.list_extend(bvirt or {}, blank_virt(acount))
+    local aside = vim.list_extend(blank_virt(bcount), avirt or {})
+    mark(before, row, 0, { virt_lines = bside })
+    mark(after, row, 0, { virt_lines = aside })
+  end
+
+  ---The rendered text of one diff line in one pane, and where its code starts.
+  ---@param ln CRLine
+  ---@param number integer
+  ---@param sign string
+  ---@return string text, integer code_col, integer bar_len
+  local function line_text(ln, number, sign)
+    local bar = ln.side ~= "ctx" and icons.change_bar or " "
+    local prefix = bar .. rpad_num(number, digits) .. SEP .. sign
+    -- Byte offset, not display width: extmark columns are byte offsets, and both the
+    -- change bar and the separator are multibyte.
+    return prefix .. ln.text, #prefix, #bar
+  end
+
+  ---@param pane table
+  ---@param row integer
+  ---@param ln CRLine
+  ---@param bar_len integer
+  local function paint_line(pane, row, ln, bar_len)
+    if ln.side == "add" then
+      mark(pane, row, 0, { line_hl_group = "CodeReviewAdd" })
+      mark(pane, row, 0, { end_col = bar_len, hl_group = "CodeReviewAddBar" })
+    elseif ln.side == "del" then
+      mark(pane, row, 0, { line_hl_group = "CodeReviewDel" })
+      mark(pane, row, 0, { end_col = bar_len, hl_group = "CodeReviewDelBar" })
+    end
+    mark(pane, row, bar_len, { end_col = bar_len + digits + #SEP, hl_group = "CodeReviewLineNr" })
   end
 
   for fi, file in ipairs(files) do
@@ -173,7 +382,9 @@ function M.build(files, opts)
     --- File header -----------------------------------------------------------
     local icon = reviewed and icons.reviewed or (note_count > 0 and icons.annotated or icons.unreviewed)
     local chevron = expanded and icons.expanded or icons.collapsed
-    local name = file.old_path and ("%s → %s"):format(file.old_path, file.path) or file.path
+    -- A rename reads as a rename when each pane draws its own path; only the unified
+    -- layout, which has one header to say it in, spells the arrow out.
+    local name = (not split and file.old_path) and ("%s → %s"):format(file.old_path, file.path) or file.path
 
     local left = ("%s %s %s"):format(icon, chevron, name)
     local stat = file.binary and "binary" or ("+%d -%d"):format(file.added, file.removed)
@@ -183,79 +394,159 @@ function M.build(files, opts)
     local pad = math.max(1, width - vim.fn.strdisplaywidth(left) - vim.fn.strdisplaywidth(right))
     local header = left .. (" "):rep(pad) .. right
 
-    local row = push(header, { kind = "file", file = fi })
-    file_rows[fi] = row
-    mark(row, 0, { line_hl_group = reviewed and "CodeReviewFileReviewed" or "CodeReviewFileHeader" })
+    -- The before pane draws the half that concerns it: the path the pre-image had, indented
+    -- to sit under the after pane's name. A file that exists only on the after side has no
+    -- pre-image path at all, so its header row is filler like the rest of it.
+    local bheader = nil
+    if before and file.status ~= "A" and file.status ~= "U" then
+      local indent = (" "):rep(vim.fn.strdisplaywidth(icon) + vim.fn.strdisplaywidth(chevron) + 2)
+      bheader = truncate(indent .. (file.old_path or file.path), before_width)
+    end
+
+    -- The before pane's header row is chrome even when it is empty: it is where this file
+    -- begins on that side, and it is where `file_rows` points in both panes.
+    local row = row2(header, { kind = "file", file = fi }, bheader, { kind = "file", file = fi })
+    after.file_rows[fi] = row
+    if before then
+      before.file_rows[fi] = row
+    end
+    local header_hl = reviewed and "CodeReviewFileReviewed" or "CodeReviewFileHeader"
+    mark(after, row, 0, { line_hl_group = header_hl })
+    if before then
+      mark(before, row, 0, { line_hl_group = header_hl })
+    end
     -- Colour only the +N/-M inside the stat, not the note count that may follow it.
     local stat_col = #header - #right
     local plus_len = file.binary and 0 or #(("+%d"):format(file.added))
     if not file.binary then
-      mark(row, stat_col, { end_col = stat_col + plus_len, hl_group = "CodeReviewStatAdd" })
-      mark(row, stat_col + plus_len + 1, { end_col = stat_col + #stat, hl_group = "CodeReviewStatDel" })
+      mark(after, row, stat_col, { end_col = stat_col + plus_len, hl_group = "CodeReviewStatAdd" })
+      mark(after, row, stat_col + plus_len + 1, { end_col = stat_col + #stat, hl_group = "CodeReviewStatDel" })
     end
     if note_count > 0 then
-      mark(row, stat_col + #stat, { end_col = #header, hl_group = "CodeReviewNoteCount" })
+      mark(after, row, stat_col + #stat, { end_col = #header, hl_group = "CodeReviewNoteCount" })
     end
     -- Whole-file annotations hang off the header, so they stay visible even when the
-    -- file is collapsed -- which is exactly when a file-level note matters most.
-    attach_notes(row, M.file_key(file.path))
+    -- file is collapsed -- which is exactly when a file-level note matters most. Their key
+    -- carries no side, and the stat and the note count already sit here, so they belong to
+    -- the after pane.
+    attach_notes(row, nil, M.file_key(file.path))
 
     if not expanded then
-      push("", { kind = "pad", file = fi })
+      row2("", { kind = "pad", file = fi }, "", { kind = "pad", file = fi })
       goto next_file
     end
 
     if file.note then
-      local r = push("   " .. file.note, { kind = "pad", file = fi })
-      mark(r, 0, { line_hl_group = "CodeReviewNote" })
-      push("", { kind = "pad", file = fi })
+      -- Why there are no hunks -- binary, a rename with no content change, a mode-only
+      -- change. Drawn on the after pane, so the before pane holds its place with filler.
+      local r = row2("   " .. file.note, { kind = "pad", file = fi })
+      mark(after, r, 0, { line_hl_group = "CodeReviewNote" })
+      row2("", { kind = "pad", file = fi }, "", { kind = "pad", file = fi })
       goto next_file
     end
 
     --- Hunks -----------------------------------------------------------------
     for hi, hunk in ipairs(file.hunks) do
-      local head = hunk.heading ~= "" and ("%s %s"):format(hunk.header, hunk.heading) or hunk.header
-      local hrow = push(truncate(head, width), { kind = "hunk", file = fi, hunk = hi })
-      hunk_rows[#hunk_rows + 1] = hrow
-      mark(hrow, 0, { line_hl_group = "CodeReviewHunkHeader" })
-
-      for li, ln in ipairs(hunk.lines) do
-        local changed = ln.side ~= "ctx"
-        local bar = changed and icons.change_bar or " "
-        local sign = ln.side == "add" and "+" or (ln.side == "del" and "-" or " ")
-        local number = rpad_num(ln.new or ln.old, digits)
-        local prefix = bar .. number .. SEP .. sign
-        local text = prefix .. ln.text
-
-        -- Byte offset, not display width: extmark columns are byte offsets, and both the
-        -- change bar and the separator are multibyte.
-        local code_col = #prefix
-        local r = push(text, { kind = "line", file = fi, hunk = hi, line = li, col = code_col })
-
-        if ln.side == "add" then
-          mark(r, 0, { line_hl_group = "CodeReviewAdd" })
-          mark(r, 0, { end_col = #bar, hl_group = "CodeReviewAddBar" })
-        elseif ln.side == "del" then
-          mark(r, 0, { line_hl_group = "CodeReviewDel" })
-          mark(r, 0, { end_col = #bar, hl_group = "CodeReviewDelBar" })
-        end
-        mark(r, #bar, { end_col = #bar + digits + #SEP, hl_group = "CodeReviewLineNr" })
-
-        attach_notes(r, M.line_key(file.path, ln))
+      local hanchor = { kind = "hunk", file = fi, hunk = hi }
+      local hrow
+      if before then
+        -- Each pane says what its own image spans; git's section heading describes the
+        -- post-image, so it rides with the range that does.
+        local old_range, new_range = header_ranges(hunk.header, hunk)
+        local rhead = hunk.heading ~= "" and ("@@ %s @@ %s"):format(new_range, hunk.heading)
+          or ("@@ %s @@"):format(new_range)
+        hrow = row2(
+          truncate(rhead, width),
+          hanchor,
+          truncate(("@@ %s @@"):format(old_range), before_width),
+          { kind = "hunk", file = fi, hunk = hi }
+        )
+        mark(before, hrow, 0, { line_hl_group = "CodeReviewHunkHeader" })
+      else
+        local head = hunk.heading ~= "" and ("%s %s"):format(hunk.header, hunk.heading) or hunk.header
+        hrow = row2(truncate(head, width), hanchor)
       end
-      push("", { kind = "pad", file = fi, hunk = hi })
+      after.hunk_rows[#after.hunk_rows + 1] = hrow
+      if before then
+        before.hunk_rows[#before.hunk_rows + 1] = hrow
+      end
+      mark(after, hrow, 0, { line_hl_group = "CodeReviewHunkHeader" })
+
+      if not before then
+        for li, ln in ipairs(hunk.lines) do
+          local text, code_col, bar_len =
+            line_text(ln, ln.new or ln.old, ln.side == "add" and "+" or (ln.side == "del" and "-" or " "))
+          local r = push(after, text, { kind = "line", file = fi, hunk = hi, line = li, col = code_col })
+          paint_line(after, r, ln, bar_len)
+          attach_notes(r, nil, M.line_key(file.path, ln))
+        end
+      else
+        ---One logical row of the split body: a pre-image line beside a post-image line,
+        ---either of which may be absent and is then filler.
+        ---@param bi integer|nil Index into hunk.lines of the row's pre-image line
+        ---@param ai integer|nil Index into hunk.lines of the row's post-image line
+        local function pair(bi, ai)
+          local bln, aln = bi and hunk.lines[bi], ai and hunk.lines[ai]
+          local fill = { kind = "fill", file = fi, hunk = hi }
+
+          local atext, acol, abar
+          if aln then
+            atext, acol, abar = line_text(aln, aln.new, aln.side == "add" and "+" or " ")
+          end
+          local btext, bcol, bbar
+          if bln then
+            btext, bcol, bbar = line_text(bln, bln.old, bln.side == "del" and "-" or " ")
+          end
+
+          local r =
+            push(after, atext or "", aln and { kind = "line", file = fi, hunk = hi, line = ai, col = acol } or fill)
+          push(before, btext or "", bln and { kind = "line", file = fi, hunk = hi, line = bi, col = bcol } or fill)
+
+          if aln then
+            paint_line(after, r, aln, abar)
+          end
+          if bln then
+            paint_line(before, r, bln, bbar)
+          end
+          -- A deletion and its replacement share a row, so both keys are offered: each
+          -- pane draws the notes its own key owns and mirrors the other's height.
+          attach_notes(
+            r,
+            bln and bln.side == "del" and M.line_key(file.path, bln) or nil,
+            aln and M.line_key(file.path, aln) or nil
+          )
+        end
+
+        -- A deleted run and the run that replaced it occupy the same rows, longest first;
+        -- whichever runs out is filler for the rest. A context line ends both runs, because
+        -- it exists in both images and must sit on one row.
+        local dels, adds = {}, {}
+        local function flush()
+          for i = 1, math.max(#dels, #adds) do
+            pair(dels[i], adds[i])
+          end
+          dels, adds = {}, {}
+        end
+        for li, ln in ipairs(hunk.lines) do
+          if ln.side == "del" then
+            dels[#dels + 1] = li
+          elseif ln.side == "add" then
+            adds[#adds + 1] = li
+          else
+            flush()
+            pair(li, li)
+          end
+        end
+        flush()
+      end
+
+      row2("", { kind = "pad", file = fi, hunk = hi }, "", { kind = "pad", file = fi, hunk = hi })
     end
 
     ::next_file::
   end
 
-  return {
-    lines = lines,
-    anchors = anchors,
-    marks = marks,
-    file_rows = file_rows,
-    hunk_rows = hunk_rows,
-  }
+  return after, before
 end
 
 return M

--- a/lua/codereview/syntax.lua
+++ b/lua/codereview/syntax.lua
@@ -134,12 +134,13 @@ end
 
 ---@param view CRView
 ---@param ns integer
+---@param buf integer Buffer the rows in `map` are rows of
 ---@param file CRFile
 ---@param side "before"|"after"
 ---@param map table<integer, { row: integer, col: integer }>
 ---@param ref string|nil
 ---@param lang string
-local function apply_side(view, ns, file, side, map, ref, lang)
+local function apply_side(view, ns, buf, file, side, map, ref, lang)
   if vim.tbl_isempty(map) then
     return
   end
@@ -171,7 +172,7 @@ local function apply_side(view, ns, file, side, map, ref, lang)
   for _, c in ipairs(caps) do
     local slot = map[c.line]
     if slot then
-      pcall(vim.api.nvim_buf_set_extmark, view.buf, ns, slot.row - 1, slot.col + c.cs, {
+      pcall(vim.api.nvim_buf_set_extmark, buf, ns, slot.row - 1, slot.col + c.cs, {
         end_col = slot.col + c.ce,
         hl_group = c.hl,
         priority = render.PRIORITY.syntax,
@@ -222,31 +223,48 @@ function M.apply(view, ns)
   view.syntax_painted = view.syntax_painted or {}
 
   local lo, hi = viewport(view)
+  local split = view.before_render ~= nil
 
   -- Invert the anchor map: for each file, which source line is drawn on which row, and at
   -- what byte column the code text begins.
   local per_file = {}
-  for row, a in pairs(view.render.anchors) do
-    if a.kind == "line" then
-      local entry = per_file[a.file]
-      if not entry then
-        entry = { before = {}, after = {}, visible = false }
-        per_file[a.file] = entry
-      end
-      -- A file is parsed whole once any part of it is near the window: parsing only the
-      -- visible slice would cache a partial capture set that the next scroll invalidates.
-      if row >= lo and row <= hi then
-        entry.visible = true
-      end
-      local ln = view.files[a.file].hunks[a.hunk].lines[a.line]
-      -- Context lines exist on both sides; attributing them to the post-image keeps a
-      -- single parse authoritative for everything except pure deletions.
-      if ln.new then
-        entry.after[ln.new] = { row = row, col = a.col }
-      else
-        entry.before[ln.old] = { row = row, col = a.col }
+
+  ---@param anchors table<integer, CRAnchor>|nil
+  ---@param pane "unified"|"after"|"before"
+  local function collect(anchors, pane)
+    for row, a in pairs(anchors or {}) do
+      if a.kind == "line" then
+        local entry = per_file[a.file]
+        if not entry then
+          entry = { before = {}, after = {}, visible = false }
+          per_file[a.file] = entry
+        end
+        -- A file is parsed whole once any part of it is near the window: parsing only the
+        -- visible slice would cache a partial capture set that the next scroll invalidates.
+        -- The panes hold the same rows, so one pane's bounds answer for both.
+        if row >= lo and row <= hi then
+          entry.visible = true
+        end
+        local ln = view.files[a.file].hunks[a.hunk].lines[a.line]
+        if pane == "before" then
+          -- In the split layout the pane decides the image, not the line. A context line is
+          -- drawn in both, and the copy in the before pane is the pre-image's, at the
+          -- pre-image's line number.
+          entry.before[ln.old] = { row = row, col = a.col }
+        elseif ln.new then
+          -- Unified has one buffer, so context lines are attributed to the post-image,
+          -- which keeps a single parse authoritative for everything except pure deletions.
+          entry.after[ln.new] = { row = row, col = a.col }
+        else
+          entry.before[ln.old] = { row = row, col = a.col }
+        end
       end
     end
+  end
+
+  collect(view.render.anchors, split and "after" or "unified")
+  if split then
+    collect(view.before_render.anchors, "before")
   end
 
   for fi, maps in pairs(per_file) do
@@ -256,8 +274,11 @@ function M.apply(view, ns)
       if lang then
         -- An untracked file has no committed pre-image; its "after" is the working tree.
         local after_ref = file.status == "U" and nil or view.scope.after
-        apply_side(view, ns, file, "after", maps.after, after_ref, lang)
-        apply_side(view, ns, file, "before", maps.before, view.scope.before, lang)
+        apply_side(view, ns, view.buf, file, "after", maps.after, after_ref, lang)
+        -- Each image paints onto the pane that shows it. With one pane, that is the same
+        -- buffer twice, which is what the unified layout has always done.
+        local before_buf = split and view.before_buf or view.buf
+        apply_side(view, ns, before_buf, file, "before", maps.before, view.scope.before, lang)
       end
       view.syntax_painted[file.path] = true
     end

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -2,6 +2,12 @@
 ---
 ---One view exists at a time, in its own tab page. Everything it draws comes from
 ---`render.lua`; everything it knows about position comes from that render's anchor map.
+---
+---In the split layout the view keeps its existing buffer and window as the **after** pane
+---and gains a before pane beside it. The after-image is the primary one everywhere else --
+---context lines are attributed to it, line keys prefer it, an entry's line numbers prefer
+---it, and opening a file resolves through it -- so naming it primary here is consistent
+---rather than arbitrary, and it is what keeps the unified layout untouched.
 local config = require("codereview.config")
 local git = require("codereview.git")
 local render = require("codereview.render")
@@ -22,12 +28,16 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@field reviewed table<string, string>   Path -> blob at the time it was marked
 ---@field expanded table<string, boolean>
 ---@field notes table<string, table[]>     Line key -> annotations
----@field buf integer
----@field win integer
+---@field buf integer                     The after pane
+---@field win integer                     The after pane
+---@field before_buf integer|nil          nil in the unified layout
+---@field before_win integer|nil          nil in the unified layout
+---@field layout "unified"|"split"
 ---@field panel_buf integer|nil
 ---@field panel_win integer|nil
 ---@field tab integer
----@field render CRRender|nil
+---@field render CRRender|nil             The after pane's render
+---@field before_render CRRender|nil      nil in the unified layout
 ---@field panel_render CRPanelRender|nil
 
 ---@type CRView|nil
@@ -59,18 +69,114 @@ local function scope_key(scope)
   return scope.name .. ":" .. scope.before
 end
 
+--- Panes ----------------------------------------------------------------------
+
+---@return boolean
+local function has_before()
+  return V ~= nil and V.before_win ~= nil and vim.api.nvim_win_is_valid(V.before_win)
+end
+
+---Every review window there is, after pane first.
+---@return integer[]
+local function panes()
+  local out = { V.win }
+  if has_before() then
+    out[#out + 1] = V.before_win
+  end
+  return out
+end
+
+---Every review buffer there is, after pane first.
+---@return integer[]
+local function pane_bufs()
+  local out = { V.buf }
+  if V.before_buf and vim.api.nvim_buf_is_valid(V.before_buf) then
+    out[#out + 1] = V.before_buf
+  end
+  return out
+end
+
+---Which review window has focus, and the render drawn in it.
+---
+---Defaults to the after pane, which is the right answer for a caller that is in neither:
+---it is the primary pane everywhere else, and every other use of the view's window is
+---either a focus restore or a geometry read, for which the two panes are equivalent.
+---
+---Internal. Exported only because target resolution lives in another module, and is
+---exercised through that module's behaviour rather than directly.
+---@return integer win, CRRender|nil render
+function M.focused_pane()
+  if has_before() and vim.api.nvim_get_current_win() == V.before_win then
+    return V.before_win, V.before_render
+  end
+  return V.win, V.render
+end
+
+---Row the cursor is on, in whichever pane has focus. The two agree row for row, so this
+---is a question about the cursor rather than about the layout.
+---@return integer
+local function cursor_row()
+  local win = M.focused_pane()
+  return vim.api.nvim_win_get_cursor(win)[1]
+end
+
+---Put every pane on `row`, running the same view command in each.
+---
+---Explicitly rather than through `cursorbind`: the binding follows cursor *motions*, and
+---nothing here moves a cursor -- it sets one. Running the same command in both windows is
+---also what keeps their top lines identical, which the binding alone would not restore.
+---@param row integer
+---@param cmd string|nil A normal-mode view command: `zt` to put the row at the top, `zz`
+---       to centre it, nil to leave the window where it is
+local function place(row, cmd)
+  for _, win in ipairs(panes()) do
+    local last = vim.api.nvim_buf_line_count(vim.api.nvim_win_get_buf(win))
+    pcall(vim.api.nvim_win_set_cursor, win, { math.max(1, math.min(row, last)), 0 })
+    if cmd then
+      pcall(vim.api.nvim_win_call, win, function()
+        vim.cmd("normal! " .. cmd)
+      end)
+    end
+  end
+end
+
+---Put both panes back on the same row and the same top line.
+---
+---`scrollbind` and `cursorbind` track deltas rather than absolute positions, so a repaint
+---that changes the line count beneath them leaves the panes reading different code while
+---still believing they are in step. Four operations do that -- toggling expansion, toggling
+---reviewed, reloading the diff and changing scope -- and every one of them ends in a paint,
+---so the binding is re-asserted there rather than at four call sites.
+local function resync()
+  if not has_before() then
+    return
+  end
+  local from = M.focused_pane()
+  local last = vim.api.nvim_buf_line_count(V.buf)
+  local row = math.max(1, math.min(vim.api.nvim_win_get_cursor(from)[1], last))
+  local top = vim.api.nvim_win_call(from, function()
+    return vim.fn.line("w0")
+  end)
+  for _, win in ipairs(panes()) do
+    pcall(vim.api.nvim_win_call, win, function()
+      vim.fn.winrestview({ topline = math.max(1, math.min(top, last)), lnum = row, col = 0, leftcol = 0 })
+    end)
+  end
+end
+
 --- Painting --------------------------------------------------------------------
 
 ---Index of the file the diff cursor is currently inside, for the panel's highlight.
 ---@return integer|nil
 local function current_file_index()
-  if not (V.render and vim.api.nvim_win_is_valid(V.win)) then
+  local win, rendered = M.focused_pane()
+  if not (rendered and vim.api.nvim_win_is_valid(win)) then
     return nil
   end
-  local row = vim.api.nvim_win_get_cursor(V.win)[1]
+  local row = vim.api.nvim_win_get_cursor(win)[1]
   for r = row, 1, -1 do
-    if V.render.anchors[r] then
-      return V.render.anchors[r].file
+    if rendered.anchors[r] then
+      return rendered.anchors[r].file
     end
   end
   return nil
@@ -148,6 +254,36 @@ local function update_winbar()
   vim.wo[V.win].winbar = bar:gsub("%%", "%%%%")
 end
 
+---Name the revision the before pane is showing.
+---
+---The after pane's winbar already says what the review is; what it cannot say is which of
+---the two images is the base, and a reviewer should never have to infer that from the code.
+local function update_before_winbar()
+  if not has_before() then
+    return
+  end
+  local rev = V.scope.before
+  -- `:0` is git's name for the index, and a name nobody reads as one.
+  local bar = (" Before · %s"):format(rev == ":0" and "index" or rev)
+  vim.wo[V.before_win].winbar = bar:gsub("%%", "%%%%")
+end
+
+---Write one pane's render into its buffer.
+---@param buf integer
+---@param rendered CRRender
+local function write_pane(buf, rendered)
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, rendered.lines)
+  vim.bo[buf].modifiable = false
+
+  vim.api.nvim_buf_clear_namespace(buf, NS, 0, -1)
+  for _, m in ipairs(rendered.marks) do
+    -- An end_col past the end of a line is a hard error; a mis-measured header should
+    -- lose its colour, not abort the whole repaint.
+    pcall(vim.api.nvim_buf_set_extmark, buf, NS, m.row, m.col, m.opts)
+  end
+end
+
 ---Redraw from the files already in memory. Cheap; no git.
 ---@param keep_file integer|nil File index to park the cursor on afterwards
 function M.paint(keep_file)
@@ -158,8 +294,12 @@ function M.paint(keep_file)
   -- The queue is the source of truth for annotations; the view only ever displays a
   -- projection of it, so there is no second copy to keep in sync.
   V.notes = require("codereview.queue").by_key()
-  V.render = render.build(V.files, {
+  -- Both panes from one walk: their row counts and their anchors agree by construction
+  -- rather than because two calls happened to be handed the same arguments.
+  V.render, V.before_render = render.build(V.files, {
     width = vim.api.nvim_win_get_width(V.win),
+    before_width = has_before() and vim.api.nvim_win_get_width(V.before_win) or nil,
+    layout = has_before() and "split" or "unified",
     icons = cfg.icons,
     expanded = V.expanded,
     reviewed = V.reviewed,
@@ -167,22 +307,17 @@ function M.paint(keep_file)
     types = cfg.types,
   })
 
-  vim.bo[V.buf].modifiable = true
-  vim.api.nvim_buf_set_lines(V.buf, 0, -1, false, V.render.lines)
-  vim.bo[V.buf].modifiable = false
-
-  vim.api.nvim_buf_clear_namespace(V.buf, NS, 0, -1)
-  for _, m in ipairs(V.render.marks) do
-    -- An end_col past the end of a line is a hard error; a mis-measured header should
-    -- lose its colour, not abort the whole repaint.
-    pcall(vim.api.nvim_buf_set_extmark, V.buf, NS, m.row, m.col, m.opts)
+  write_pane(V.buf, V.render)
+  if V.before_render then
+    write_pane(V.before_buf, V.before_render)
   end
 
   paint_panel()
   update_winbar()
+  update_before_winbar()
 
   if keep_file and V.render.file_rows[keep_file] then
-    pcall(vim.api.nvim_win_set_cursor, V.win, { V.render.file_rows[keep_file], 0 })
+    place(V.render.file_rows[keep_file])
   end
 
   if config.get().syntax then
@@ -192,6 +327,8 @@ function M.paint(keep_file)
     syntax.reset_painted(V)
     syntax.apply(V, NS)
   end
+
+  resync()
 end
 
 ---Write progress to disk. Called from every mutation rather than from `paint`, which
@@ -228,15 +365,18 @@ end
 
 ---@return CRAnchor|nil
 local function anchor_at_cursor()
-  if not V.render then
+  local win, rendered = M.focused_pane()
+  if not rendered then
     return nil
   end
-  local row = vim.api.nvim_win_get_cursor(V.win)[1]
+  local row = vim.api.nvim_win_get_cursor(win)[1]
   -- Walk upward: a blank padding row still belongs to the file above it, so a cursor
-  -- resting in whitespace resolves to something sensible rather than nothing.
+  -- resting in whitespace resolves to something sensible rather than nothing. In the split
+  -- layout there is nothing to walk -- every row carries an anchor, and a filler row says
+  -- so rather than letting the cursor inherit an unrelated line above it.
   for r = row, 1, -1 do
-    if V.render.anchors[r] then
-      return V.render.anchors[r], r
+    if rendered.anchors[r] then
+      return rendered.anchors[r], r
     end
   end
   return nil
@@ -278,15 +418,12 @@ end
 
 ---Put a file header at the top of the window rather than leaving it wherever it lands:
 ---jumping to a file is a request to read it, and its first hunk should be on screen.
+---
+---Both panes, because a jump that moved only one would leave them reading different code.
 ---@param row integer
----@param top boolean
-local function goto_row(row, top)
-  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
-  if top then
-    vim.api.nvim_win_call(V.win, function()
-      vim.cmd("normal! zt")
-    end)
-  end
+---@param cmd string|nil `zt`, `zz`, or nil to leave the window where it is
+local function goto_row(row, cmd)
+  place(row, cmd)
   sync_panel()
 end
 
@@ -297,13 +434,12 @@ function M.jump(what, forward)
     return
   end
   local rows = what == "file" and V.render.file_rows or V.render.hunk_rows
-  local cur = vim.api.nvim_win_get_cursor(V.win)[1]
-  local row = nearest(rows, cur, forward)
+  local row = nearest(rows, cursor_row(), forward)
   if not row then
     info(("No %s %s here"):format(forward and "next" or "previous", what))
     return
   end
-  goto_row(row, what == "file")
+  goto_row(row, what == "file" and "zt" or nil)
 end
 
 ---Jump to the next or previous file that is still unreviewed.
@@ -327,15 +463,14 @@ function M.jump_unreviewed(forward)
     return
   end
 
-  local cur = vim.api.nvim_win_get_cursor(V.win)[1]
-  local row = nearest(rows, cur, forward)
+  local row = nearest(rows, cursor_row(), forward)
   if not row then
     -- Wrap: with the reviewed files skipped there are few targets left, and stopping dead
     -- at the last one means scrolling back by hand.
     row = forward and rows[1] or rows[#rows]
     info(forward and "Wrapped to the first unreviewed file" or "Wrapped to the last unreviewed file")
   end
-  goto_row(row, true)
+  goto_row(row, "zt")
 end
 
 ---Jump to the next or previous annotated line.
@@ -344,32 +479,46 @@ function M.jump_annotation(forward)
   if not M.current() or not V.render then
     return
   end
-  local render = require("codereview.render")
-  local rows = {}
-  for row, a in pairs(V.render.anchors) do
-    local file = V.files[a.file]
-    local key
-    if a.kind == "line" then
-      key = render.line_key(file.path, file.hunks[a.hunk].lines[a.line])
-    elseif a.kind == "file" then
-      key = render.file_key(file.path)
-    end
-    if key and V.notes[key] then
-      rows[#rows + 1] = row
+  ---Rows carrying a note, and whether the before pane is the one carrying it there. Both
+  ---anchor maps are read: a note on a deleted line exists only in the before pane's, and
+  ---skipping it would make half a reviewer's remarks unreachable by `]a`.
+  local owner = {}
+  ---@param rendered CRRender|nil
+  ---@param is_before boolean
+  local function collect(rendered, is_before)
+    for row, a in pairs(rendered and rendered.anchors or {}) do
+      local file = V.files[a.file]
+      local key
+      if a.kind == "line" then
+        key = render.line_key(file.path, file.hunks[a.hunk].lines[a.line])
+      elseif a.kind == "file" and not is_before then
+        -- A whole-file note carries no side, and it hangs off the after pane's header.
+        key = render.file_key(file.path)
+      end
+      -- The after pane is collected first, so a row annotated on both sides is recorded as
+      -- its own rather than being claimed by the before pane.
+      if key and V.notes[key] and owner[row] == nil then
+        owner[row] = is_before
+      end
     end
   end
+  collect(V.render, false)
+  collect(V.before_render, true)
+
+  local rows = vim.tbl_keys(owner)
   if #rows == 0 then
     info("No annotations yet")
     return
   end
   table.sort(rows)
 
-  local cur = vim.api.nvim_win_get_cursor(V.win)[1]
-  local row = nearest(rows, cur, forward) or (forward and rows[1] or rows[#rows])
-  goto_row(row, false)
-  vim.api.nvim_win_call(V.win, function()
-    vim.cmd("normal! zz")
-  end)
+  local row = nearest(rows, cursor_row(), forward) or (forward and rows[1] or rows[#rows])
+  -- Land in the pane the note is drawn in, so the jump arrives at the code and not beside
+  -- it. A row annotated on both sides keeps whichever pane the reviewer is already in.
+  if has_before() and owner[row] and vim.api.nvim_get_current_win() ~= V.before_win then
+    vim.api.nvim_set_current_win(V.before_win)
+  end
+  goto_row(row, "zz")
 end
 
 ---Jump straight to a file, chosen from a list.
@@ -411,7 +560,7 @@ function M.pick_file()
       M.paint()
     end
     if V.render.file_rows[index] then
-      goto_row(V.render.file_rows[index], true)
+      goto_row(V.render.file_rows[index], "zt")
     end
   end)
 end
@@ -553,7 +702,7 @@ function M.set_scope(spec)
     info(("No changes in scope '%s'"):format(scope.label))
   end
   M.paint()
-  pcall(vim.api.nvim_win_set_cursor, V.win, { 1, 0 })
+  place(1)
 end
 
 ---Line in the current file that this row corresponds to.
@@ -638,11 +787,7 @@ function M.panel_select()
     M.paint()
   end
   vim.api.nvim_set_current_win(V.win)
-  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[fi], 0 })
-  vim.api.nvim_win_call(V.win, function()
-    vim.cmd("normal! zt")
-  end)
-  sync_panel()
+  goto_row(V.render.file_rows[fi], "zt")
 end
 
 ---@param shut boolean|nil nil toggles
@@ -878,13 +1023,19 @@ function M.jump_to_entry(entry)
     M.paint()
   end
 
+  -- The entry's key is already sided, so it also says which pane the annotation belongs to,
+  -- and that pane's anchor map is the only one carrying it. No new rule: the same key that
+  -- decides where the note is drawn decides where the jump lands.
+  local to_before = has_before() and render.is_before_key(entry.key)
+  local rendered = to_before and V.before_render or V.render
+
   -- The scan `]a` already makes: the anchor map is the only thing that knows which row a
   -- key is on now, which is what lets a stale annotation still land wherever its anchor
   -- points. A whole-file entry's key matches no line, and neither does a line that this
   -- diff no longer renders; both mean the file, so both land on its header.
-  local row = V.render.file_rows[index]
+  local row = rendered.file_rows[index]
   local file = V.files[index]
-  for r, a in pairs(V.render.anchors) do
+  for r, a in pairs(rendered.anchors) do
     if
       a.file == index
       and a.kind == "line"
@@ -895,11 +1046,8 @@ function M.jump_to_entry(entry)
     end
   end
 
-  vim.api.nvim_set_current_win(V.win)
-  goto_row(row, false)
-  vim.api.nvim_win_call(V.win, function()
-    vim.cmd("normal! zz")
-  end)
+  vim.api.nvim_set_current_win(to_before and V.before_win or V.win)
+  goto_row(row, "zz")
   return true
 end
 
@@ -1089,7 +1237,10 @@ local function bind(buf, maps)
   end
 end
 
-local function setup_main_keymaps()
+---Bind the diff's keys. Every pane gets the same set: which pane a reviewer happens to be
+---in decides what a key acts on, never whether it works.
+---@param buf integer
+local function setup_main_keymaps(buf)
   -- Annotation keys are prefixed with `a` rather than bound bare. Bare `b`/`f`/`s`/`n`
   -- would shadow back-word, find-char and next-search inside the buffer; `a` (append) is
   -- dead in a nomodifiable buffer, so it costs a keystroke and no motion.
@@ -1097,16 +1248,16 @@ local function setup_main_keymaps()
   for _, t in ipairs(config.get().types) do
     vim.keymap.set({ "n", "x" }, "a" .. t.key, function()
       annotate.annotate(t.name)
-    end, { buffer = V.buf, nowait = true, silent = true, desc = "Annotate: " .. t.name })
+    end, { buffer = buf, nowait = true, silent = true, desc = "Annotate: " .. t.name })
   end
   vim.keymap.set({ "n", "x" }, "aa", annotate.annotate_pick, {
-    buffer = V.buf,
+    buffer = buf,
     nowait = true,
     silent = true,
     desc = "Annotate: pick type",
   })
 
-  bind(V.buf, {
+  bind(buf, {
     ["x"] = { annotate.drop, "Drop the annotation here" },
     ["]f"] = {
       function()
@@ -1265,6 +1416,49 @@ local function window_opts(win)
   vim.wo[win].spell = false
 end
 
+--- The before pane -------------------------------------------------------------
+
+---Add the before pane, to the left of the after pane.
+---
+---A window and a buffer of its own rather than a second rendering of the existing one: the
+---two panes hold different text, and Neovim binds scrolling and the cursor between windows,
+---not between renderings.
+local function show_before_pane()
+  vim.api.nvim_set_current_win(V.win)
+  vim.cmd("leftabove vsplit")
+  local win = vim.api.nvim_get_current_win()
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_win_set_buf(win, buf)
+  scratch(buf, "codereview")
+  window_opts(win)
+  V.before_buf, V.before_win = buf, win
+
+  -- Both window-local. `scrollopt`, which decides what a bound window keeps in step, is
+  -- global -- a plugin that set it would reach outside its own windows -- so it is left
+  -- alone. Its default gives vertical synchronisation only, and horizontal scrolling
+  -- staying independent per pane is accepted.
+  for _, w in ipairs({ V.win, win }) do
+    vim.wo[w].scrollbind = true
+    vim.wo[w].cursorbind = true
+  end
+
+  vim.api.nvim_set_current_win(V.win)
+end
+
+---Give the two panes equal width.
+---
+---Called when the windows themselves change rather than on every paint: a reviewer who has
+---dragged the border between the panes has said what they want, and a repaint is not the
+---moment to overrule them. What does change the split without being asked is the panel
+---appearing or disappearing beside it, which is what this covers.
+local function balance_panes()
+  if not has_before() then
+    return
+  end
+  local total = vim.api.nvim_win_get_width(V.before_win) + vim.api.nvim_win_get_width(V.win)
+  pcall(vim.api.nvim_win_set_width, V.before_win, math.floor(total / 2))
+end
+
 --- The panel window ------------------------------------------------------------
 
 ---Build the panel: its window, its buffer and its keymaps.
@@ -1316,6 +1510,10 @@ function M.toggle_panel()
   else
     show_panel()
   end
+  -- With three windows competing for the terminal's columns, the panel's arrival or
+  -- departure is taken out of, or given back to, whichever pane Neovim picked. Split the
+  -- difference so the two panes stay comparable, which is the whole point of the layout.
+  balance_panes()
   -- The diff just changed width and its file headers are padded to that width, so this has
   -- to repaint. The resize autocmd does not cover it: WinResized is fired from the main
   -- loop, so it lands after the toggle has returned -- and never at all if nothing else
@@ -1377,6 +1575,7 @@ function M.open(spec)
     collapsed = {},
     buf = buf,
     win = main_win,
+    layout = cfg.layout,
     tab = tab,
   }
   V.reviewed = V.per_scope[key].reviewed
@@ -1385,11 +1584,19 @@ function M.open(spec)
   queue_restored = true
   M.reconcile()
 
+  -- Before the panel, so the panel's `topleft`/`botright` split lands outside both panes
+  -- rather than between them.
+  if cfg.layout == "split" then
+    show_before_pane()
+  end
   if cfg.panel.enabled then
     show_panel()
   end
+  balance_panes()
 
-  setup_main_keymaps()
+  for _, b in ipairs(pane_bufs()) do
+    setup_main_keymaps(b)
+  end
 
   local augroup = vim.api.nvim_create_augroup("CodeReviewView", { clear = true })
 
@@ -1408,41 +1615,45 @@ function M.open(spec)
   -- submitted from an insert-mode mapping closes its window without ending insert, and
   -- focus lands here mid-insert -- no InsertEnter fires, because insert never ended.
   -- Every navigation key is then a failed edit rather than a motion.
-  vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "InsertEnter" }, {
-    group = augroup,
-    buffer = buf,
-    callback = function()
-      if vim.fn.mode():sub(1, 1) == "i" then
-        vim.schedule(function()
-          if vim.fn.mode():sub(1, 1) == "i" then
-            vim.cmd("stopinsert")
-          end
-        end)
-      end
-    end,
-  })
+  for _, b in ipairs(pane_bufs()) do
+    vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "InsertEnter" }, {
+      group = augroup,
+      buffer = b,
+      callback = function()
+        if vim.fn.mode():sub(1, 1) == "i" then
+          vim.schedule(function()
+            if vim.fn.mode():sub(1, 1) == "i" then
+              vim.cmd("stopinsert")
+            end
+          end)
+        end
+      end,
+    })
+  end
 
   -- Highlighting is bounded by the viewport, so scrolling into an un-parsed file is what
   -- triggers its parse. Cheap on every other scroll: already-painted files are skipped
   -- and already-parsed ones repaint from cache.
-  vim.api.nvim_create_autocmd({ "WinScrolled", "CursorMoved" }, {
-    group = augroup,
-    buffer = buf,
-    callback = function()
-      if not M.current() then
-        return
-      end
-      if config.get().syntax then
-        require("codereview.syntax").apply(V, NS)
-      end
-      -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
-      -- immediately unless the cursor crossed into a different file.
-      sync_panel()
-    end,
-  })
+  for _, b in ipairs(pane_bufs()) do
+    vim.api.nvim_create_autocmd({ "WinScrolled", "CursorMoved" }, {
+      group = augroup,
+      buffer = b,
+      callback = function()
+        if not M.current() then
+          return
+        end
+        if config.get().syntax then
+          require("codereview.syntax").apply(V, NS)
+        end
+        -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
+        -- immediately unless the cursor crossed into a different file.
+        sync_panel()
+      end,
+    })
+  end
 
   M.paint()
-  vim.api.nvim_win_set_cursor(main_win, { 1, 0 })
+  place(1)
 end
 
 return M

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
 | `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling |
+| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring with no windows; then the binding, annotation parity against the unified layout, and the two intersections nobody else owns |
 | `syntax_spec` | Treesitter harvest/replay, caching, guardrails |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
@@ -60,8 +61,10 @@ interchangeable, and the assertions know which one they are looking at.
   modified, deleted, added, renamed-and-edited, staged, unstaged, untracked, untracked
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
-  `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec` and
-  `interactive_spec`.
+  `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `split_spec` and
+  `interactive_spec`. It already covers everything the split layout has to render,
+  including the files that exist on only one side and the additions between context lines
+  that produce filler — so that slice needed no fixture of its own.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec`, `focus_spec` and `queue_jump_panel_spec`.
@@ -153,6 +156,22 @@ so the out-of-core language path is still checked locally without ever failing C
   answers a tick later, which is the shape a real picker has and the only one that
   reproduces the defect. `composer_spec`'s file picker still answers inline on purpose: it
   is asserting text and cursor, not mode.
+- **`scrollbind` and `cursorbind` follow motions, not the API.** They *do* work in a
+  headless Neovim, which was measured rather than assumed: a `normal!` motion, a `<C-e>`
+  and fed keys all propagate to the bound window, and `nvim_win_set_cursor` does not.
+  Driving a binding assertion through the API therefore passes whether or not the binding
+  exists — the failure mode `interactive_spec` exists to avoid — so `split_spec` drives
+  `normal!` and asserts the *other* pane followed. Removing the two `vim.wo` lines in
+  `view.lua`'s `show_before_pane` must fail three cases. The same asymmetry is why the view
+  sets both panes' cursors explicitly instead of trusting the binding to carry one across.
+- **Two panes that were never moved apart cannot be seen coming back together.** The first
+  version of "both panes hold their alignment across every repaint" passed with `resync()`
+  deleted, because nothing had knocked them out of step: both sat at line 1 throughout. It
+  now lifts the binding, moves one pane, puts the binding back — which is the state a
+  repaint that changed the line count leaves behind — and only then repaints. A guard case
+  asserts the panes really did diverge, so the assertion cannot quietly stop measuring.
+  Note that `zt` in one pane propagates through `scrollbind`, so it is no use for pulling
+  them apart; that was the first attempt and the guard caught it.
 - **`interactive_spec` must keep its teeth.** To confirm it still reproduces the bug,
   remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless
@@ -170,6 +189,10 @@ so the out-of-core language path is still checked locally without ever failing C
 - **Real adapters.** `send`, `pick_target` and `compose` are injected stubs throughout.
   That is the point of the seam — the plugin carries no opinion about the transport — but
   it means no test exercises a real agent handoff.
+- **Horizontal scroll synchronisation between panes.** There is nothing to cover: it is
+  `scrollopt` that decides whether a bound window keeps its horizontal position in step,
+  `scrollopt` is global, and the plugin deliberately does not set it. What *is* covered is
+  that it stays untouched.
 - **Timing and wall clock.** `perf.lua` reports numbers and fails only past a deliberately
   loose ceiling. It is a report you read, not a gate; it is not in CI, where a shared
   runner would make it noise.

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -525,6 +525,20 @@ do
   h.feed("Vjab")
   reference.range = shape(queue.all()[1])
 
+  -- A range covering a context line and the deletion under it. Both rows exist in the
+  -- before pane too, and in the same order, so this one crosses the layouts unchanged --
+  -- unlike a range spanning a deletion *and its replacement*, which is the documented
+  -- exception because the two runs live in different windows.
+  queue.clear()
+  vim.api.nvim_win_set_cursor(V.win, {
+    line_row(V, V.render, "src/main.lua", function(ln)
+      return ln.side == "ctx" and ln.old == 1
+    end),
+    0,
+  })
+  h.feed("Vjab")
+  reference.del_range = shape(queue.all()[1])
+
   queue.clear()
   view.close()
 end
@@ -788,6 +802,37 @@ describe("annotating from either pane", function()
     vim.api.nvim_win_set_cursor(V.win, { line_row(V, V.render, "src/untracked.lua", ADDED), 0 })
     h.feed("Vjab")
     assert.same(reference.range, shape(queue.all()[1]))
+  end)
+
+  -- Fed through the mapping rather than called directly: `capture` reads `mode()` and
+  -- `line("v")` while the selection is still live, and the mapping is only reachable if the
+  -- before pane's buffer really carries the diff's keys.
+  it("captures a range containing a deletion from the before pane, as unified does", function()
+    queue.clear()
+    focus(V.before_win)
+    vim.api.nvim_win_set_cursor(V.before_win, {
+      line_row(V, V.before_render, "src/main.lua", function(ln)
+        return ln.side == "ctx" and ln.old == 1
+      end),
+      0,
+    })
+    h.feed("Vjab")
+    assert.same(1, queue.count())
+    assert.same(reference.del_range, shape(queue.all()[1]))
+    assert.is_true(queue.all()[1].inline)
+  end)
+
+  it("binds the diff's keys in the before pane too", function()
+    -- Both sides through `vim.keycode`: the API reports a control key in its own notation
+    -- (`<C-P>`, capitalised) rather than the one it was bound with, so comparing the
+    -- strings as written silently never matches.
+    local lhs = {}
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(V.before_buf, "n")) do
+      lhs[vim.keycode(m.lhs)] = true
+    end
+    for _, key in ipairs({ "ab", "aa", "x", "]f", "]a", "R", "za", "gp", "<C-p>", "Q" }) do
+      assert.is_true(lhs[vim.keycode(key)] == true, ("%s is not bound in the before pane"):format(key))
+    end
   end)
 
   -- The cursor is on nothing, so this means the file -- never the unrelated line above it,

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -1,0 +1,1078 @@
+-- The split layout: two panes out of one walk.
+--
+-- Most of this needs no window at all. `render.build` returns both panes together, so pane
+-- parity, anchor totality, note mirroring and per-pane chrome are properties of returned
+-- data and are asserted against that data directly -- which is the whole point of returning
+-- them from one call rather than making two.
+--
+-- What does need a view is annotation parity, because target resolution reads the focused
+-- window and a visual selection has to be live while it is read; and the pane binding,
+-- because `scrollbind` and `cursorbind` are Neovim's, not ours.
+local h = require("tests.helpers")
+
+h.ui(120, 45)
+local root = h.cd_fixture("mkfixture")
+
+local last_ctx
+local function setup(layout)
+  require("codereview").setup({
+    layout = layout,
+    syntax = false,
+    compose = function(ctx, on_accept, _)
+      last_ctx = ctx
+      on_accept(nil, "note about " .. ctx.label)
+    end,
+  })
+end
+setup("unified")
+
+local config = require("codereview.config")
+local git = require("codereview.git")
+local render = require("codereview.render")
+local queue = require("codereview.queue")
+local annotate = require("codereview.annotate")
+local view = require("codereview.view")
+
+--- Pure: no windows ------------------------------------------------------------
+
+local scope = assert(git.resolve_scope("branch", root))
+local files = assert(git.collect(scope, root, { context = 3, untracked = true }))
+
+---@param opts table|nil Overrides on top of a plain 60-column split
+---@return CRRender after, CRRender|nil before
+local function build(opts)
+  local cfg = config.get()
+  return render.build(
+    files,
+    vim.tbl_extend("force", {
+      width = 60,
+      before_width = 60,
+      layout = "split",
+      icons = cfg.icons,
+      expanded = {},
+      reviewed = {},
+      notes = {},
+      types = cfg.types,
+    }, opts or {})
+  )
+end
+
+---@param path string
+---@return integer
+local function index_of(path)
+  for i, f in ipairs(files) do
+    if f.path == path then
+      return i
+    end
+  end
+  error("no such file in the fixture: " .. path)
+end
+
+---Rows a file occupies in a render, from its header to the row before the next file's.
+---@param rendered CRRender
+---@param fi integer
+---@return integer[]
+local function rows_of(rendered, fi)
+  local out = {}
+  for row = 1, #rendered.lines do
+    if rendered.anchors[row].file == fi then
+      out[#out + 1] = row
+    end
+  end
+  return out
+end
+
+---The virtual lines an extmark on `row` carries in a pane, or nil.
+---@param rendered CRRender
+---@param row integer
+---@return table[]|nil
+local function virt_at(rendered, row)
+  for _, m in ipairs(rendered.marks) do
+    if m.row == row - 1 and m.opts.virt_lines then
+      return m.opts.virt_lines
+    end
+  end
+end
+
+describe("one walk, two renders", function()
+  it("returns nothing for a second pane in the unified layout", function()
+    local after, before = build({ layout = "unified" })
+    assert.is_table(after)
+    assert.is_nil(before)
+  end)
+
+  it("returns a second pane in the split layout", function()
+    local after, before = build()
+    assert.is_table(after)
+    assert.is_table(before)
+  end)
+end)
+
+describe("pane parity", function()
+  local after, before = build()
+
+  it("holds the same number of rows in both panes", function()
+    assert.same(#after.lines, #before.lines)
+  end)
+
+  -- The invariant the whole layout rests on. Row for row, the two panes must agree about
+  -- which file and which hunk they are inside, or a cursor in one pane means something
+  -- different from the same cursor in the other.
+  it("agrees row for row on the file and the hunk", function()
+    for row = 1, #after.lines do
+      local a, b = after.anchors[row], before.anchors[row]
+      assert.is_table(a, ("after pane has no anchor on row %d"):format(row))
+      assert.is_table(b, ("before pane has no anchor on row %d"):format(row))
+      assert.same({ a.file, a.hunk }, { b.file, b.hunk }, ("row %d disagrees"):format(row))
+    end
+  end)
+
+  it("puts every file's header on the same row in both panes", function()
+    assert.same(after.file_rows, before.file_rows)
+  end)
+
+  it("puts every hunk header on the same row in both panes", function()
+    assert.same(after.hunk_rows, before.hunk_rows)
+  end)
+end)
+
+describe("anchor totality", function()
+  local after, before = build()
+
+  it("anchors every row of both panes", function()
+    for row = 1, #after.lines do
+      assert.is_table(after.anchors[row], ("after row %d"):format(row))
+      assert.is_table(before.anchors[row], ("before row %d"):format(row))
+    end
+  end)
+
+  -- `pad` is the blank row after a hunk, which both panes draw. `fill` is a row one image
+  -- has no counterpart for. They dispatch identically -- both fall through to a whole-file
+  -- target -- but they mean different things, and the kind is documentation as much as it
+  -- is dispatch.
+  it("gives filler its own kind, distinct from pad", function()
+    local kinds = {}
+    for row = 1, #after.lines do
+      kinds[after.anchors[row].kind] = true
+      kinds[before.anchors[row].kind] = true
+    end
+    assert.is_true(kinds.fill)
+    assert.is_true(kinds.pad)
+  end)
+
+  it("never emits filler in the unified layout", function()
+    local unified = build({ layout = "unified" })
+    for row = 1, #unified.lines do
+      assert.is_true(unified.anchors[row] == nil or unified.anchors[row].kind ~= "fill")
+    end
+  end)
+end)
+
+describe("a file that exists on only one side", function()
+  local after, before = build()
+
+  it("renders an added file as filler for its whole length on the before pane", function()
+    local fi = index_of("src/fresh.lua")
+    local seen = 0
+    for _, row in ipairs(rows_of(after, fi)) do
+      if after.anchors[row].kind == "line" then
+        seen = seen + 1
+        assert.same("fill", before.anchors[row].kind, ("row %d"):format(row))
+      end
+    end
+    assert.is_true(seen > 0)
+  end)
+
+  it("renders a deleted file as filler for its whole length on the after pane", function()
+    local fi = index_of("src/gone.lua")
+    local seen = 0
+    for _, row in ipairs(rows_of(before, fi)) do
+      if before.anchors[row].kind == "line" then
+        seen = seen + 1
+        assert.same("fill", after.anchors[row].kind, ("row %d"):format(row))
+      end
+    end
+    assert.is_true(seen > 0)
+  end)
+
+  it("leaves an added file's before-pane header empty rather than naming a path it never had", function()
+    local row = after.file_rows[index_of("src/fresh.lua")]
+    assert.same("", before.lines[row])
+    assert.same("file", before.anchors[row].kind)
+  end)
+end)
+
+describe("per-pane chrome", function()
+  local after, before = build()
+
+  it("splits a hunk header into its pre-image range on the left and its post-image on the right", function()
+    local fi = index_of("src/main.lua")
+    local hrow
+    for _, row in ipairs(rows_of(after, fi)) do
+      if after.anchors[row].kind == "hunk" then
+        hrow = row
+        break
+      end
+    end
+    assert.is_truthy(hrow)
+    assert.same("@@ -1,3 @@", before.lines[hrow])
+    assert.same("@@ +1,3 @@", after.lines[hrow])
+  end)
+
+  it("keeps git's section heading with the post-image range", function()
+    -- Whichever hunk in this fixture carries one; git only emits a heading when it finds a
+    -- containing declaration, so the assertion is conditional on there being one at all.
+    for fi, file in ipairs(files) do
+      for hi, hunk in ipairs(file.hunks) do
+        if hunk.heading ~= "" then
+          local row
+          for _, r in ipairs(rows_of(after, fi)) do
+            local a = after.anchors[r]
+            if a.kind == "hunk" and a.hunk == hi then
+              row = r
+            end
+          end
+          assert.is_truthy(after.lines[row]:find(hunk.heading, 1, true))
+          assert.is_falsy(before.lines[row]:find(hunk.heading, 1, true))
+          return
+        end
+      end
+    end
+  end)
+
+  it("shows a renamed file's old path on the left and its new path on the right", function()
+    local row = after.file_rows[index_of("src/newname.lua")]
+    assert.is_truthy(before.lines[row]:find("src/oldname.lua", 1, true))
+    assert.is_falsy(before.lines[row]:find("src/newname.lua", 1, true))
+    assert.is_truthy(after.lines[row]:find("src/newname.lua", 1, true))
+    assert.is_falsy(after.lines[row]:find("src/oldname.lua", 1, true))
+  end)
+
+  -- The unified layout has one header to say it in, so it keeps spelling the arrow out.
+  it("still writes the rename as one header in the unified layout", function()
+    local unified = build({ layout = "unified" })
+    local row = unified.file_rows[index_of("src/newname.lua")]
+    assert.is_truthy(unified.lines[row]:find("src/oldname.lua → src/newname.lua", 1, true))
+  end)
+
+  it("draws the explanatory note of a file with no hunks", function()
+    local fi = index_of("src/untracked.bin")
+    local drawn
+    for _, row in ipairs(rows_of(after, fi)) do
+      if after.lines[row]:find("binary", 1, true) and after.anchors[row].kind ~= "file" then
+        drawn = row
+      end
+    end
+    assert.is_truthy(drawn, "the binary file's note never rendered")
+    assert.same("fill", before.anchors[drawn].kind)
+  end)
+
+  it("gives both panes the same file-header text width to pad against", function()
+    local narrow = select(2, build({ before_width = 40 }))
+    local row = narrow.file_rows[index_of("src/main.lua")]
+    assert.is_true(vim.fn.strdisplaywidth(narrow.lines[row]) <= 40)
+  end)
+end)
+
+describe("where a note is drawn", function()
+  local path = "src/main.lua"
+  local del_key = render.line_key(path, { side = "del", old = 2 })
+  local add_key = render.line_key(path, { side = "add", new = 2 })
+
+  it("keys a deletion to the pre-image and its replacement to the post-image", function()
+    assert.same({ "src/main.lua:o:2", "src/main.lua:n:2" }, { del_key, add_key })
+    assert.is_true(render.is_before_key(del_key))
+    assert.is_false(render.is_before_key(add_key))
+  end)
+
+  -- No new rule: the key is already sided, and that side is the pane.
+  it("draws a note on a deleted line in the before pane", function()
+    local after, before = build({ notes = { [del_key] = { { note = "gone", type = "bug" } } } })
+    local row
+    for r = 1, #before.lines do
+      local a = before.anchors[r]
+      if a.kind == "line" and files[a.file].path == path and files[a.file].hunks[a.hunk].lines[a.line].old == 2 then
+        row = r
+      end
+    end
+    assert.is_truthy(row)
+    local bvirt, avirt = virt_at(before, row), virt_at(after, row)
+    assert.is_truthy(bvirt[1][#bvirt[1]][1]:find("gone", 1, true))
+    -- The after pane holds its place with a blank of the same height.
+    assert.same(#bvirt, #avirt)
+    assert.same("", avirt[1][1][1])
+  end)
+
+  it("draws a note on an added line in the after pane", function()
+    local after, before = build({ notes = { [add_key] = { { note = "here", type = "bug" } } } })
+    local row = after.file_rows[index_of(path)]
+    for r = 1, #after.lines do
+      local a = after.anchors[r]
+      if a.kind == "line" and files[a.file].path == path and files[a.file].hunks[a.hunk].lines[a.line].new == 2 then
+        row = r
+      end
+    end
+    local avirt, bvirt = virt_at(after, row), virt_at(before, row)
+    assert.is_truthy(avirt[1][#avirt[1]][1]:find("here", 1, true))
+    assert.same(#avirt, #bvirt)
+    assert.same("", bvirt[1][1][1])
+  end)
+
+  -- A context line exists in both images, and its key prefers the post-image -- so it reads
+  -- in the after pane, exactly as it does everywhere else in the plugin.
+  it("draws a note on a context line in the after pane", function()
+    local ctx_key = render.line_key(path, { side = "ctx", old = 1, new = 1 })
+    local after, before = build({ notes = { [ctx_key] = { { note = "context", type = "bug" } } } })
+    local row
+    for r = 1, #after.lines do
+      local a = after.anchors[r]
+      if a.kind == "line" and files[a.file].path == path and files[a.file].hunks[a.hunk].lines[a.line].new == 1 then
+        row = r
+      end
+    end
+    assert.is_truthy(virt_at(after, row)[1][#virt_at(after, row)[1]][1]:find("context", 1, true))
+    assert.same("", virt_at(before, row)[1][1][1])
+  end)
+
+  it("hangs a whole-file note off the after pane's header, and holds the before pane's place", function()
+    local key = render.file_key(path)
+    local after, before = build({ notes = { [key] = { { note = "all of it", type = "bug" } } } })
+    local row = after.file_rows[index_of(path)]
+    assert.is_truthy(virt_at(after, row)[1][#virt_at(after, row)[1]][1]:find("all of it", 1, true))
+    assert.same(#virt_at(after, row), #virt_at(before, row))
+  end)
+
+  it("keeps a whole-file note on the header of a collapsed file", function()
+    local key = render.file_key(path)
+    local after, before = build({
+      notes = { [key] = { { note = "all of it", type = "bug" } } },
+      expanded = { [path] = false },
+    })
+    local row = after.file_rows[index_of(path)]
+    assert.is_truthy(virt_at(after, row))
+    assert.same(#virt_at(after, row), #virt_at(before, row))
+  end)
+
+  it("marks a stale annotation in the split layout", function()
+    local after = build({ notes = { [add_key] = { { note = "old", type = "bug", stale = true } } } })
+    local found = false
+    for _, m in ipairs(after.marks) do
+      for _, line in ipairs(m.opts.virt_lines or {}) do
+        for _, chunk in ipairs(line) do
+          found = found or chunk[2] == "CodeReviewStale"
+        end
+      end
+    end
+    assert.is_true(found)
+  end)
+end)
+
+describe("note text in a narrow pane", function()
+  local long = "a remark long enough that it cannot possibly fit inside a single narrow "
+    .. "column, which is exactly the case a virtual line silently truncates because it "
+    .. "clips at the window edge instead of wrapping"
+  local key = render.line_key("src/main.lua", { side = "add", new = 2 })
+
+  it("wraps to the pane width rather than being clipped", function()
+    local after = build({ width = 46, notes = { [key] = { { note = long, type = "bug" } } } })
+    local emitted, total = 0, 0
+    for _, m in ipairs(after.marks) do
+      for _, line in ipairs(m.opts.virt_lines or {}) do
+        local text = ""
+        for _, chunk in ipairs(line) do
+          text = text .. chunk[1]
+        end
+        if text ~= "" then
+          emitted = emitted + 1
+          total = total + #text
+          assert.is_true(
+            vim.fn.strdisplaywidth(text) <= 46,
+            ("virtual line %q is %d columns wide"):format(text, vim.fn.strdisplaywidth(text))
+          )
+        end
+      end
+    end
+    -- More than one line, and every word still present: wrapped, not truncated.
+    assert.is_true(emitted > 1)
+    for word in long:gmatch("%S+") do
+      assert.is_true(total >= #word)
+    end
+  end)
+
+  it("keeps every word of the note", function()
+    local after = build({ width = 46, notes = { [key] = { { note = long, type = "bug" } } } })
+    local joined = {}
+    for _, m in ipairs(after.marks) do
+      for _, line in ipairs(m.opts.virt_lines or {}) do
+        for _, chunk in ipairs(line) do
+          joined[#joined + 1] = chunk[1]
+        end
+      end
+    end
+    local text = table.concat(joined, " ")
+    for word in long:gmatch("%S+") do
+      assert.is_truthy(text:find(word, 1, true), ("%q was clipped"):format(word))
+    end
+  end)
+
+  -- Unwrapped is what the unified layout has always emitted, and it is a full-width window.
+  it("leaves the unified layout's notes exactly as they were", function()
+    local unified = build({ layout = "unified", width = 46, notes = { [key] = { { note = long, type = "bug" } } } })
+    local lines = 0
+    for _, m in ipairs(unified.marks) do
+      lines = lines + #(m.opts.virt_lines or {})
+    end
+    assert.same(1, lines)
+  end)
+end)
+
+--- Configuration ---------------------------------------------------------------
+
+describe("selecting the layout", function()
+  it("defaults to unified", function()
+    setup(nil)
+    assert.same("unified", config.get().layout)
+  end)
+
+  it("takes split when asked for", function()
+    setup("split")
+    assert.same("split", config.get().layout)
+  end)
+
+  -- Silently falling back to unified would leave a reviewer wondering why their
+  -- configuration did nothing, with the answer nowhere on screen.
+  it("rejects an unknown value at setup, naming it", function()
+    local ok, err = pcall(setup, "side-by-side")
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("side-by-side", 1, true))
+    assert.is_truthy(tostring(err):find("layout", 1, true))
+  end)
+end)
+
+--- With a view -----------------------------------------------------------------
+
+---The entry a fresh annotation produces, reduced to what ADR-0002 says must not depend on
+---how it was captured.
+---@param e CRAnnotation
+---@return table
+local function shape(e)
+  return { key = e.key, kind = e.kind, tag = e.tag, inline = e.inline, first = e.first, last = e.last, lines = e.lines }
+end
+
+---Row in a pane whose line anchor points at the CRLine `pred` accepts.
+---@param V CRView
+---@param rendered CRRender
+---@param path string
+---@param pred fun(ln: CRLine): boolean
+---@return integer
+local function line_row(V, rendered, path, pred)
+  for row, a in pairs(rendered.anchors) do
+    if a.kind == "line" and V.files[a.file].path == path then
+      if pred(V.files[a.file].hunks[a.hunk].lines[a.line]) then
+        return row
+      end
+    end
+  end
+  error(("no row for %s"):format(path))
+end
+
+local DELETED = function(ln)
+  return ln.side == "del"
+end
+local ADDED = function(ln)
+  return ln.side == "add"
+end
+
+--- Reference entries, captured in the layout that has always existed -------------
+
+local reference = {}
+do
+  setup("unified")
+  view.open("branch")
+  local V = view.current()
+  queue.clear()
+
+  ---@param path string
+  ---@param pred fun(ln: CRLine): boolean
+  ---@param what string
+  local function capture(what, path, pred)
+    queue.clear()
+    vim.api.nvim_win_set_cursor(V.win, { line_row(V, V.render, path, pred), 0 })
+    annotate.annotate("bug")
+    reference[what] = shape(queue.all()[1])
+  end
+
+  capture("deleted", "src/main.lua", DELETED)
+  capture("added", "src/main.lua", ADDED)
+  capture("context", "src/main.lua", function(ln)
+    return ln.side == "ctx"
+  end)
+
+  queue.clear()
+  vim.api.nvim_win_set_cursor(V.win, { assert(V.render.hunk_rows[1]), 0 })
+  annotate.annotate("bug")
+  reference.hunk = shape(queue.all()[1])
+
+  queue.clear()
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[1], 0 })
+  annotate.annotate("bug")
+  reference.file = shape(queue.all()[1])
+
+  -- A pure-addition range: the one range shape the split layout keeps, since it never
+  -- has to span two windows.
+  queue.clear()
+  vim.api.nvim_win_set_cursor(V.win, { line_row(V, V.render, "src/untracked.lua", ADDED), 0 })
+  h.feed("Vjab")
+  reference.range = shape(queue.all()[1])
+
+  queue.clear()
+  view.close()
+end
+
+--- The split layout, on screen --------------------------------------------------
+
+local scrollopt_before = vim.go.scrollopt
+
+setup("split")
+view.open("branch")
+local V = view.current()
+queue.clear()
+
+---@param win integer
+local function focus(win)
+  vim.api.nvim_set_current_win(win)
+end
+
+---@param win integer
+---@return integer
+local function row_in(win)
+  return vim.api.nvim_win_get_cursor(win)[1]
+end
+
+---@param win integer
+---@return integer
+local function topline(win)
+  return vim.api.nvim_win_call(win, function()
+    return vim.fn.line("w0")
+  end)
+end
+
+describe("opening in the split layout", function()
+  it("opens a second pane", function()
+    assert.is_truthy(V.before_win)
+    assert.is_true(vim.api.nvim_win_is_valid(V.before_win))
+    assert.is_true(V.before_buf ~= V.buf)
+  end)
+
+  it("puts the before-image on the left and the after-image on the right", function()
+    local left = vim.api.nvim_win_get_position(V.before_win)[2]
+    local right = vim.api.nvim_win_get_position(V.win)[2]
+    assert.is_true(left < right, ("before at col %d, after at col %d"):format(left, right))
+  end)
+
+  it("holds the same number of rows in both buffers", function()
+    assert.same(vim.api.nvim_buf_line_count(V.buf), vim.api.nvim_buf_line_count(V.before_buf))
+  end)
+
+  it("keeps the tree beside both of them", function()
+    assert.is_truthy(V.panel_win and vim.api.nvim_win_is_valid(V.panel_win))
+  end)
+
+  it("carries the review status on the after pane's winbar", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("reviewed", 1, true))
+  end)
+
+  it("names the revision the before pane is showing", function()
+    assert.is_truthy(vim.wo[V.before_win].winbar:find(V.scope.before, 1, true))
+  end)
+end)
+
+describe("holding the panes together", function()
+  -- `scrollopt` is global. A plugin that set it would reach outside its own windows, so
+  -- what is accepted instead is its default: vertical synchronisation only.
+  it("does not modify the global scroll-options setting", function()
+    assert.same(scrollopt_before, vim.go.scrollopt)
+  end)
+
+  it("binds scrolling and the cursor in both panes", function()
+    for _, win in ipairs({ V.win, V.before_win }) do
+      assert.is_true(vim.wo[win].scrollbind)
+      assert.is_true(vim.wo[win].cursorbind)
+    end
+  end)
+
+  -- Driven with `normal!` rather than `nvim_win_set_cursor`: the binding follows cursor
+  -- *motions*, and the API sets a cursor without moving one. With `cursorbind` off the
+  -- before pane stays where it was, which is what gives this case its teeth.
+  it("moves the cursor in one pane by moving it in the other", function()
+    focus(V.win)
+    vim.fn.winrestview({ topline = 1, lnum = 1, col = 0 })
+    vim.api.nvim_win_call(V.before_win, function()
+      vim.fn.winrestview({ topline = 1, lnum = 1, col = 0 })
+    end)
+    assert.same({ 1, 1 }, { row_in(V.win), row_in(V.before_win) })
+
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! 20j")
+    end)
+    assert.same(21, row_in(V.win))
+    assert.same(21, row_in(V.before_win))
+  end)
+
+  it("scrolls one pane by scrolling the other", function()
+    focus(V.win)
+    for _, win in ipairs({ V.win, V.before_win }) do
+      vim.api.nvim_win_call(win, function()
+        vim.fn.winrestview({ topline = 1, lnum = 1, col = 0 })
+      end)
+    end
+    assert.same({ 1, 1 }, { topline(V.win), topline(V.before_win) })
+
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! 10\5") -- 10 <C-e>
+    end)
+    assert.is_true(topline(V.win) > 1)
+    assert.same(topline(V.win), topline(V.before_win))
+  end)
+
+  ---Leave the panes bound but not where each other is -- exactly the state a binding is in
+  ---once a repaint has changed the line count beneath it. Reached by moving one pane with
+  ---the binding lifted, because with it on there is no motion the other does not follow:
+  ---that is the whole point of it, and it is also why the binding cannot repair itself.
+  local function diverge()
+    vim.wo[V.before_win].scrollbind = false
+    vim.wo[V.before_win].cursorbind = false
+    vim.api.nvim_win_call(V.before_win, function()
+      vim.fn.winrestview({ topline = 1, lnum = 1, col = 0 })
+    end)
+    vim.wo[V.before_win].scrollbind = true
+    vim.wo[V.before_win].cursorbind = true
+  end
+
+  ---@param what string
+  local function aligned(what)
+    assert.same(
+      vim.api.nvim_buf_line_count(V.buf),
+      vim.api.nvim_buf_line_count(V.before_buf),
+      ("row counts diverged after %s"):format(what)
+    )
+    assert.same(row_in(V.win), row_in(V.before_win), ("cursors diverged after %s"):format(what))
+    assert.same(topline(V.win), topline(V.before_win), ("toplines diverged after %s"):format(what))
+  end
+
+  -- Guards the four cases below: if this passes, the panes really can be knocked apart, and
+  -- an assertion that they came back together is measuring something.
+  it("really can be knocked out of step", function()
+    focus(V.win)
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! 20j")
+    end)
+    diverge()
+    assert.is_true(row_in(V.win) ~= row_in(V.before_win))
+    assert.is_true(topline(V.win) ~= topline(V.before_win))
+  end)
+
+  -- The binding tracks deltas, so it loses its place whenever a repaint changes the line
+  -- count beneath it. Every operation that does ends in a paint, and a paint is where both
+  -- panes' views are re-asserted.
+  it("puts both panes back at the end of a bare repaint", function()
+    focus(V.win)
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! 20j")
+    end)
+    diverge()
+    view.paint()
+    aligned("a repaint")
+  end)
+
+  it("holds its alignment across toggling expansion and reviewed", function()
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[2], 0 })
+    diverge()
+    view.toggle_expand()
+    aligned("toggling expansion")
+    diverge()
+    view.toggle_expand()
+    aligned("toggling expansion back")
+
+    diverge()
+    view.toggle_reviewed()
+    aligned("toggling reviewed")
+    diverge()
+    view.toggle_reviewed()
+    aligned("toggling reviewed back")
+  end)
+
+  it("holds its alignment across reloading the diff", function()
+    focus(V.win)
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! 15j")
+    end)
+    diverge()
+    view.refresh()
+    aligned("reloading the diff")
+  end)
+
+  it("holds its alignment across changing scope", function()
+    focus(V.win)
+    diverge()
+    view.set_scope("staged")
+    aligned("changing scope")
+    diverge()
+    view.set_scope("branch")
+    aligned("changing scope back")
+  end)
+end)
+
+describe("annotating from either pane", function()
+  ---@param win integer
+  ---@param rendered CRRender
+  ---@param path string
+  ---@param pred fun(ln: CRLine): boolean
+  ---@return table
+  local function annotate_at(win, rendered, path, pred)
+    queue.clear()
+    focus(win)
+    vim.api.nvim_win_set_cursor(win, { line_row(V, rendered, path, pred), 0 })
+    annotate.annotate("bug")
+    return shape(queue.all()[1])
+  end
+
+  -- The case that pins ADR-0002 on the surface: a rendering choice must not reach the
+  -- receiving agent, so the same logical line has to produce the same entry either way.
+  it("captures a deleted line from the before pane exactly as the unified layout does", function()
+    assert.same(reference.deleted, annotate_at(V.before_win, V.before_render, "src/main.lua", DELETED))
+  end)
+
+  it("captures an added line from the after pane exactly as the unified layout does", function()
+    assert.same(reference.added, annotate_at(V.win, V.render, "src/main.lua", ADDED))
+  end)
+
+  it("captures a context line the same from either pane, and the same as unified", function()
+    local from_after = annotate_at(V.win, V.render, "src/main.lua", function(ln)
+      return ln.side == "ctx"
+    end)
+    local from_before = annotate_at(V.before_win, V.before_render, "src/main.lua", function(ln)
+      return ln.side == "ctx"
+    end)
+    assert.same(reference.context, from_after)
+    assert.same(reference.context, from_before)
+  end)
+
+  it("captures both images inlined from a hunk header in either pane", function()
+    for _, win in ipairs({ V.win, V.before_win }) do
+      queue.clear()
+      focus(win)
+      vim.api.nvim_win_set_cursor(win, { V.render.hunk_rows[1], 0 })
+      annotate.annotate("bug")
+      assert.same(reference.hunk, shape(queue.all()[1]))
+      assert.is_true(queue.all()[1].inline)
+    end
+  end)
+
+  it("captures the whole file from a file header in either pane", function()
+    for _, win in ipairs({ V.win, V.before_win }) do
+      queue.clear()
+      focus(win)
+      vim.api.nvim_win_set_cursor(win, { V.render.file_rows[1], 0 })
+      annotate.annotate("bug")
+      assert.same(reference.file, shape(queue.all()[1]))
+    end
+  end)
+
+  -- Pure-addition and pure-deletion ranges still work; only a sub-hunk range spanning both
+  -- images is lost, and that is the one documented difference between the layouts.
+  it("captures a pure-addition range from the after pane exactly as unified does", function()
+    queue.clear()
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { line_row(V, V.render, "src/untracked.lua", ADDED), 0 })
+    h.feed("Vjab")
+    assert.same(reference.range, shape(queue.all()[1]))
+  end)
+
+  -- The cursor is on nothing, so this means the file -- never the unrelated line above it,
+  -- which in the split layout is code the reviewer was not looking at.
+  it("resolves a cursor on a filler row to the whole file", function()
+    queue.clear()
+    -- A file whose additions sit *between* context lines, so the filler beside them has
+    -- real code above it in the same pane -- which is what a walk upward would have found
+    -- instead, and is the whole reason filler carries an anchor of its own.
+    local path = "src/routes.lua"
+    local fi = assert(h.file_index(V, path))
+    local row, above
+    for r = 1, vim.api.nvim_buf_line_count(V.buf) do
+      local a = V.before_render.anchors[r]
+      if a.file == fi and a.kind == "line" then
+        above = r
+      elseif a.file == fi and a.kind == "fill" and above then
+        row = r
+        break
+      end
+    end
+    assert.is_truthy(row, "no filler with code above it in " .. path)
+
+    focus(V.before_win)
+    vim.api.nvim_win_set_cursor(V.before_win, { row, 0 })
+    annotate.annotate("bug")
+    local e = queue.all()[1]
+    assert.same({ "file", path }, { e.kind, e.path })
+    -- Not the line above it, which is what would have been captured without the anchor.
+    assert.is_falsy(e.first)
+  end)
+
+  it("returns focus to the pane the annotation was started from", function()
+    queue.clear()
+    focus(V.before_win)
+    vim.api.nvim_win_set_cursor(V.before_win, { line_row(V, V.before_render, "src/main.lua", DELETED), 0 })
+    annotate.annotate("bug")
+    assert.same(V.before_win, last_ctx.origin_win)
+  end)
+
+  it("drops an annotation from the pane it was made in", function()
+    queue.clear()
+    focus(V.before_win)
+    local row = line_row(V, V.before_render, "src/main.lua", DELETED)
+    vim.api.nvim_win_set_cursor(V.before_win, { row, 0 })
+    annotate.annotate("bug")
+    assert.same(1, queue.count())
+
+    vim.api.nvim_win_set_cursor(V.before_win, { row, 0 })
+    annotate.drop()
+    assert.same(0, queue.count())
+  end)
+
+  it("drops an annotation on an added line from the after pane", function()
+    queue.clear()
+    focus(V.win)
+    local row = line_row(V, V.render, "src/main.lua", ADDED)
+    vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+    annotate.annotate("bug")
+    vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+    annotate.drop()
+    assert.same(0, queue.count())
+  end)
+end)
+
+describe("notes on screen", function()
+  queue.clear()
+  focus(V.before_win)
+  local del_row = line_row(V, V.before_render, "src/main.lua", DELETED)
+  vim.api.nvim_win_set_cursor(V.before_win, { del_row, 0 })
+  annotate.annotate("bug")
+  view.paint()
+
+  ---@param buf integer
+  ---@return table[]
+  local function virt(buf)
+    return vim.tbl_filter(function(m)
+      return m[4].virt_lines ~= nil
+    end, vim.api.nvim_buf_get_extmarks(buf, h.NS, 0, -1, { details = true }))
+  end
+
+  it("draws the note in the pane the line belongs to", function()
+    local before_marks = virt(V.before_buf)
+    assert.same(1, #before_marks)
+    local first = before_marks[1][4].virt_lines[1]
+    assert.is_truthy(first[#first][1]:find("note about", 1, true))
+  end)
+
+  it("holds the opposite pane's place at the same row, to the same height", function()
+    local b, a = virt(V.before_buf)[1], virt(V.buf)[1]
+    assert.is_truthy(a, "the after pane drew nothing to hold its place")
+    assert.same(b[2], a[2])
+    assert.same(#b[4].virt_lines, #a[4].virt_lines)
+    assert.same("", a[4].virt_lines[1][1][1])
+  end)
+
+  queue.clear()
+  view.paint()
+end)
+
+describe("getting around in the split layout", function()
+  it("moves both panes together when jumping by file", function()
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    view.jump("file", true)
+    assert.same(V.render.file_rows[2], row_in(V.win))
+    assert.same(row_in(V.win), row_in(V.before_win))
+  end)
+
+  it("moves both panes together when jumping by hunk", function()
+    view.jump("hunk", false)
+    assert.same("hunk", V.render.anchors[row_in(V.win)].kind)
+    assert.same(row_in(V.win), row_in(V.before_win))
+  end)
+
+  it("jumps to the next unreviewed file in both panes", function()
+    view.jump_unreviewed(true)
+    assert.same("file", V.render.anchors[row_in(V.win)].kind)
+    assert.same(row_in(V.win), row_in(V.before_win))
+  end)
+
+  it("jumps to an annotation on a deleted line, landing in the before pane", function()
+    queue.clear()
+    focus(V.before_win)
+    local row = line_row(V, V.before_render, "src/main.lua", DELETED)
+    vim.api.nvim_win_set_cursor(V.before_win, { row, 0 })
+    annotate.annotate("bug")
+
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    view.jump_annotation(true)
+    assert.same(V.before_win, vim.api.nvim_get_current_win())
+    assert.same(row, row_in(V.before_win))
+    assert.same(row, row_in(V.win))
+    queue.clear()
+    view.paint()
+  end)
+
+  it("jumps straight to a file through the picker", function()
+    local index = assert(h.file_index(V, "src/routes.lua"))
+    local orig = vim.ui.select
+    vim.ui.select = function(_, _, cb)
+      cb(nil, index)
+    end
+    focus(V.win)
+    view.pick_file()
+    vim.ui.select = orig
+    assert.same(V.render.file_rows[index], row_in(V.win))
+    assert.same(row_in(V.win), row_in(V.before_win))
+  end)
+end)
+
+-- Nobody else could cover this: the queue float's jump landed before the split layout
+-- existed, and it resolves an entry's key back to a row -- which in two panes is also a
+-- question about which pane that row is in.
+describe("jumping from the queue float in the split layout", function()
+  ---@param entry_key_side "del"|"add"
+  ---@return CRAnnotation
+  local function queued(entry_key_side)
+    queue.clear()
+    local pane = entry_key_side == "del" and V.before_win or V.win
+    local rendered = entry_key_side == "del" and V.before_render or V.render
+    focus(pane)
+    vim.api.nvim_win_set_cursor(pane, {
+      line_row(V, rendered, "src/main.lua", entry_key_side == "del" and DELETED or ADDED),
+      0,
+    })
+    annotate.annotate("bug")
+    return queue.all()[1]
+  end
+
+  it("lands in the before pane for a note on a deleted line", function()
+    local entry = queued("del")
+    local row = line_row(V, V.before_render, "src/main.lua", DELETED)
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    assert.is_true(view.jump_to_entry(entry))
+    assert.same(V.before_win, vim.api.nvim_get_current_win())
+    assert.same(row, row_in(V.before_win))
+  end)
+
+  it("lands in the after pane for a note on an added line", function()
+    local entry = queued("add")
+    local row = line_row(V, V.render, "src/main.lua", ADDED)
+    focus(V.before_win)
+    vim.api.nvim_win_set_cursor(V.before_win, { 1, 0 })
+    assert.is_true(view.jump_to_entry(entry))
+    assert.same(V.win, vim.api.nvim_get_current_win())
+    assert.same(row, row_in(V.win))
+  end)
+
+  it("expands a collapsed file and still lands in the right pane", function()
+    local entry = queued("del")
+    local index = assert(h.file_index(V, "src/main.lua"))
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index], 0 })
+    view.toggle_reviewed()
+    assert.is_false(V.expanded["src/main.lua"])
+
+    assert.is_true(view.jump_to_entry(entry))
+    assert.is_true(V.expanded["src/main.lua"])
+    assert.same(V.before_win, vim.api.nvim_get_current_win())
+    assert.same("line", V.before_render.anchors[row_in(V.before_win)].kind)
+    assert.same(row_in(V.before_win), row_in(V.win))
+
+    view.toggle_reviewed()
+    queue.clear()
+    view.paint()
+  end)
+end)
+
+-- The other intersection nobody else owns: three windows competing for the terminal's
+-- columns, and the panel's presence transitioning at runtime underneath two bound panes.
+describe("toggling the tree in the split layout", function()
+  ---@return integer before, integer after
+  local function widths()
+    return vim.api.nvim_win_get_width(V.before_win), vim.api.nvim_win_get_width(V.win)
+  end
+
+  local shown_b, shown_a = widths()
+  view.toggle_panel()
+  local hidden_b, hidden_a = widths()
+  view.toggle_panel()
+  local back_b, back_a = widths()
+
+  it("really dismissed and summoned the tree", function()
+    assert.is_truthy(V.panel_win and vim.api.nvim_win_is_valid(V.panel_win))
+    assert.is_true(hidden_b > shown_b, ("%d columns did not grow to %d"):format(shown_b, hidden_b))
+  end)
+
+  it("gives the reclaimed columns to both panes, not to one", function()
+    assert.is_true(math.abs(hidden_b - hidden_a) <= 1, ("%d vs %d"):format(hidden_b, hidden_a))
+    assert.is_true(math.abs(back_b - back_a) <= 1, ("%d vs %d"):format(back_b, back_a))
+  end)
+
+  it("comes back to the widths it started at", function()
+    assert.same({ shown_b, shown_a }, { back_b, back_a })
+  end)
+
+  it("keeps the panes aligned across the toggle", function()
+    assert.same(vim.api.nvim_buf_line_count(V.buf), vim.api.nvim_buf_line_count(V.before_buf))
+    assert.same(row_in(V.win), row_in(V.before_win))
+  end)
+
+  it("repaints both panes to the new width", function()
+    view.toggle_panel()
+    local wide = vim.api.nvim_win_get_width(V.before_win)
+    local row = V.before_render.file_rows[assert(h.file_index(V, "src/newname.lua"))]
+    assert.is_true(vim.fn.strdisplaywidth(V.before_render.lines[row]) <= math.max(40, wide))
+    view.toggle_panel()
+  end)
+end)
+
+describe("syntax highlighting in the split layout", function()
+  -- Re-opened with syntax on: the rest of this file turns it off so that repaints are
+  -- about the render and nothing else.
+  view.close()
+  require("codereview").setup({ layout = "split", syntax = true })
+  view.open("branch")
+  V = view.current()
+
+  ---@param buf integer
+  ---@return table[]
+  local function painted(buf)
+    local priority = render.PRIORITY.syntax
+    return vim.tbl_filter(function(m)
+      return m[4].priority == priority
+    end, vim.api.nvim_buf_get_extmarks(buf, h.NS, 0, -1, { details = true }))
+  end
+
+  it("paints the after pane from the post-image", function()
+    assert.is_true(#painted(V.buf) > 0)
+  end)
+
+  it("paints the before pane from the pre-image", function()
+    assert.is_true(#painted(V.before_buf) > 0)
+  end)
+
+  -- The before pane's captures come from a different parse of a different blob, so they
+  -- cannot simply be the after pane's marks copied across.
+  it("paints a deleted line, which exists in no post-image at all", function()
+    local row = line_row(V, V.before_render, "src/main.lua", DELETED)
+    local on_row = vim.tbl_filter(function(m)
+      return m[2] == row - 1
+    end, painted(V.before_buf))
+    assert.is_true(#on_row > 0, ("nothing highlighted on before-pane row %d"):format(row))
+  end)
+end)


### PR DESCRIPTION
The **review view** gains a second **layout**. The **unified layout** is what exists today
and stays the default. The **split layout** renders the same diff as two **panes** — the
before-image on the left, the after-image on the right — kept in step so corresponding code
sits on the same screen row. Selected through configuration only; the runtime toggle is #55.

Closes #54.

## How alignment is achieved

`render.build` now returns **two renders from one walk** — `after, before|nil`. That is the
central decision: row alignment becomes a property of the returned data, guaranteed by
construction, rather than an emergent property of two independent calls agreeing. It is
also what lets pane parity, anchor totality, note mirroring and per-pane chrome be asserted
**with no window on screen**. The unified layout returns nil as the second value, and every
existing caller ignores it unchanged.

Filler takes an anchor kind of its own, `fill`, rather than reusing `pad`. They dispatch
identically — both fall through to a whole-file target — but a pad is the blank row after a
hunk and a filler is an image with no counterpart, and the kind is documentation as much as
dispatch.

The view keeps its existing buffer and window as the after pane and adds the before pane
beside it. A note's owning pane is derived from its **anchor** key, which is already sided;
no new rule. `scrollbind` and `cursorbind` are set per window and `scrollopt` is deliberately
untouched — it is global, and a plugin that set it would reach outside its own windows.
Because the bindings track deltas, both panes' views are re-asserted at the end of every
paint.

## Red first

The spec was written against the base implementation before any of it existed:

| | Success | Failed | Errors |
| --- | --- | --- | --- |
| `split_spec` on `9547e29` (base) | 17 | 46 | 2 |
| `split_spec` on this branch | 76 | 0 | 0 |
| whole suite before | 682 | 0 | 0 |
| whole suite after | 739 | 0 | 0 |

Three teeth checks, each reverting one decision and re-running:

| Reverted | Fails |
| --- | --- |
| `scrollbind`/`cursorbind` never set | 3 — the two binding cases and the option assertion |
| `resync()` dropped from `paint` | 3 — bare repaint, expansion/reviewed, reloading the diff |
| `fill` collapsed back into `pad` | 3 — both one-sided-file cases and filler resolution |

The unified layout's render output was diffed against the base across three widths, with and
without a collapsed file, with reviewed marks and with multi-line, stale and whole-file
notes: **byte-identical, 77 377 bytes**.

## Scroll and cursor binding are covered, not deferred

The acceptance criterion allowed recording these under "Deliberately not covered". They are
covered instead, because measurement said they could be covered honestly:

```
                  without bind      with bind
normal! 30j       left=1  right=31  left=31 right=31
normal! 10<C-e>   top=1   top=11    top=11  top=11
feedkeys 40j      left=1  right=41  left=41 right=41
nvim_win_set_cursor  does not propagate — in either case
```

So a headless assertion driven through `normal!` and fed keys can fail, and does: removing
the two options fails three cases. Driven through `nvim_win_set_cursor` it could not, which
is the failure mode `interactive_spec` exists to document — and it is also why the view sets
both panes' cursors explicitly rather than trusting the binding to carry one across.

Two related traps are recorded in `tests/README.md`. The first alignment assertion passed
with `resync()` deleted, because both panes sat at line 1 and had never been knocked apart;
it now lifts the binding, moves one pane, restores it, and a guard case asserts they really
diverged. `zt` was the first attempt at pulling them apart and is no use — it propagates
through `scrollbind`, which the guard caught.

Horizontal scroll synchronisation is listed under "Deliberately not covered": there is
nothing to cover, since `scrollopt` decides it, `scrollopt` is global, and the plugin does
not set it. That it stays untouched **is** asserted.

## ADR-0002

Annotation parity is asserted at the existing target-resolution seam by capturing reference
entries in the unified layout first, then comparing key, kind, tag, inlining and line
numbers field by field for the same logical line captured from either pane — deleted, added,
context, whole hunk, whole file, a pure-addition range, and a range crossing a context line
and the deletion under it. The single documented exception is a sub-hunk range spanning both
images, which cannot be selected across two windows.

## Two intersections nobody else could cover

Both land here because this slice lands last: jumping from the queue float **in the split
layout**, where the entry's sided key selects the pane (and still does when the file is
collapsed and has to be expanded first); and toggling the panel **in the split layout**,
where three windows compete for width and the reclaimed columns have to reach both panes
rather than whichever one Neovim picked.

## Also

- The `layout` key is validated at `setup()`, so a mistyped value fails there instead of
  silently rendering unified.
- Notes are wrapped to the pane width before they are emitted, since virtual lines clip
  rather than wrap; every word is asserted to survive.
- Syntax paints each image onto its own pane — pre-image left, post-image right — including
  deleted lines, which exist in no post-image at all.
- `CONTEXT.md` gains Layout, Pane and Filler; `README.md` and `doc/codereview.txt` gain a
  Layouts section.

The queue, the batch, the payload, staleness, drafts, delivery, the composer and every
injected adapter are untouched.