### PR TITLE
feat(view): switch layout without losing your place

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,36 @@ because the two runs live in different windows and cannot be in one selection.
 Pure-addition and pure-deletion ranges work, and annotating the hunk header captures both
 images inlined — so what a split range cannot express is still one keystroke away.
 
+### Switching layouts
+
+`gl` switches between the two, from either pane and from the file tree — so you can reach
+for side-by-side on the one reformatted file without editing your configuration.
+
+It keeps you where you were, but **not on the same row**. Buffer rows mean nothing across
+layouts: the same line of the same hunk sits at a different row in each. What is carried
+across is the **anchor** — the same line of the same hunk of the same file — and the row
+carrying it is found again afterwards. Three things follow, none of them a new rule:
+
+- which pane the cursor lands in follows the line's side, so a deleted line lands on the
+  left and an added or context line on the right;
+- switching back is unambiguous, since one anchor has one row;
+- a cursor on **filler** has no counterpart in the unified layout at all, so it falls back
+  to that file's header.
+
+The landing line is centred, because the row moved structurally and preserving an exact
+scroll offset across that would be preserving something meaningless.
+
+Nothing else changes across a toggle: reviewed marks, expanded state, the queue, the
+current **scope**, the delivery **target** and the tree's collapsed directories are all
+layout-independent, and your queued annotations are re-drawn on the pane their line belongs
+to.
+
+The choice lasts **for the rest of the session** — closing a review and opening another
+does not quietly put you back — and resets when Neovim exits, so `layout` is what decides
+at the start of every session. It is deliberately not written to the state file: that file
+is per repository and a layout preference is not, and a stored preference would silently
+override a `layout` you had since changed.
+
 ### Inside the view
 
 | Key | Action |
@@ -213,6 +243,7 @@ images inlined — so what a split range cannot express is still one keystroke a
 | `gs` | Cycle scope, re-rendering in place |
 | `gr` | Re-read the diff from git |
 | `gp` | Show or hide the file tree |
+| `gl` | Switch between the unified and split layouts |
 | `<CR>` | Open the real file here, in a new tab |
 | `Q` | Review the queue |
 | `<C-t>` | Choose the delivery target |
@@ -252,6 +283,7 @@ cursor last was.
 | `<C-p>` | Jump to a file by name |
 | `<Tab>` | Back to the diff |
 | `gp` | Dismiss the tree, landing back in the diff |
+| `gl` | Switch between the unified and split layouts |
 | `q` | Close |
 
 Jumping to a file that was collapsed because it is reviewed expands it: you asked to look
@@ -490,6 +522,11 @@ has no scope behind it and is judged against the file on disk, at any scope and 
 review open. That distinction matters in a `staged` review, where the diff shows the index
 and a buffer capture holds the working tree: judging one by the other would flag a note
 about a file nobody has touched.
+
+Two things deliberately do **not** go there: the delivery target, which names a live
+destination a restart would make dead, and the layout `gl` last chose, which is a
+preference rather than review progress. The store is per repository and neither of those
+is; both last for the session and no longer.
 
 ## Development
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -65,6 +65,7 @@ Buffer-local, inside the review view:
     gs               Cycle scope, re-rendering in place
     gr               Re-read the diff from git
     gp               Show or hide the file tree
+    gl               Switch between the unified and split layouts
     <CR>             Open the real file here, in a new tab
     Q                Review the queue
     <C-t>            Choose the delivery target
@@ -100,6 +101,7 @@ In the file tree:                                         *codereview-tree*
     <C-p>            Jump to a file by name
     <Tab>            Back to the diff
     gp               Dismiss the tree, landing back in the diff
+    gl               Switch between the unified and split layouts
     q                Close the review
 
 The tree collapses single-child directory chains, so a monorepo shows
@@ -206,6 +208,33 @@ images, because the two runs live in different windows and cannot be in one
 selection. Pure-addition and pure-deletion ranges work, and annotating the
 hunk header captures both images inlined -- so what a split range cannot
 express is still one keystroke away.
+
+Switching layouts                                  *codereview-layout-toggle*
+
+`gl` switches between the two, from either pane and from the file tree. It
+keeps you where you were, but not on the same row: buffer rows mean nothing
+across layouts, since the same line of the same hunk sits at a different row
+in each. What is carried across is the anchor -- the same line of the same
+hunk of the same file -- and the row carrying it is found again afterwards.
+
+Which pane the cursor lands in follows the line's side: a deleted line lands
+in the left pane, an added or context line in the right. Switching back is
+unambiguous, since one anchor has one row. A cursor on filler has no
+counterpart in the unified layout at all, so it falls back to that file's
+header. The landing line is centred, because the row moved structurally and
+an exact scroll offset carried across would mean nothing.
+
+Nothing else changes. Reviewed marks, expanded state, the queue, the current
+scope, the delivery target and the tree's collapsed directories are all
+layout-independent, and annotations are re-drawn on the pane their line
+belongs to.
+
+The choice lasts for the rest of the session: closing a review and opening
+another does not quietly put you back. It resets when Neovim exits, so `layout`
+is what decides at the start of every session. It is deliberately not written
+to the state file -- that file is per repository and a layout preference is
+not, and a stored preference would silently override a `layout` you had since
+changed.
 
 ==============================================================================
 6. ANNOTATIONS                                      *codereview-annotations*
@@ -585,6 +614,12 @@ A corrupt or older state file is discarded rather than migrated.
 The queue is restored once per session, on first use, whether or not a review
 view is ever opened. Reviewed marks are kept for every scope the store knows
 about, not only the one on screen.
+
+What is deliberately NOT written there: the delivery target, which names a
+live destination a restart would make dead; and the layout `gl` last chose,
+which is a preference rather than review progress. That file is per
+repository and neither of those is; both last for the session and no longer.
+See |codereview-layout-toggle|.
 
 Judging staleness                          *codereview-persistence-staleness*
 

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -125,10 +125,28 @@ end
 ---Explicitly rather than through `cursorbind`: the binding follows cursor *motions*, and
 ---nothing here moves a cursor -- it sets one. Running the same command in both windows is
 ---also what keeps their top lines identical, which the binding alone would not restore.
+---
+---And with the binding *lifted* while it does, because the binding tracks scroll deltas: the
+---first pane's `zz` propagates into the second pane before the second pane has been placed,
+---and the second pane's own `zz` then propagates back -- landing the two somewhere neither
+---was asked for, and nine rows apart. Both panes are set from the same row and the same
+---command instead, which is what makes the result the command that was asked for.
 ---@param row integer
 ---@param cmd string|nil A normal-mode view command: `zt` to put the row at the top, `zz`
 ---       to centre it, nil to leave the window where it is
 local function place(row, cmd)
+  local bound = has_before()
+  ---@param on boolean
+  local function bind_panes(on)
+    for _, win in ipairs(panes()) do
+      vim.wo[win].scrollbind = on
+      vim.wo[win].cursorbind = on
+    end
+  end
+
+  if bound then
+    bind_panes(false)
+  end
   for _, win in ipairs(panes()) do
     local last = vim.api.nvim_buf_line_count(vim.api.nvim_win_get_buf(win))
     pcall(vim.api.nvim_win_set_cursor, win, { math.max(1, math.min(row, last)), 0 })
@@ -137,6 +155,11 @@ local function place(row, cmd)
         vim.cmd("normal! " .. cmd)
       end)
     end
+  end
+  if bound then
+    -- Turning the binding back on records the offset the panes are at now; it does not
+    -- scroll either of them, which is what makes lifting it safe.
+    bind_panes(true)
   end
 end
 

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -36,12 +36,32 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@field panel_buf integer|nil
 ---@field panel_win integer|nil
 ---@field tab integer
+---@field augroup integer                 Autocommands belonging to this review
 ---@field render CRRender|nil             The after pane's render
 ---@field before_render CRRender|nil      nil in the unified layout
 ---@field panel_render CRPanelRender|nil
 
 ---@type CRView|nil
 local V = nil
+
+---The layout a reviewer has chosen, for the rest of this editing session.
+---
+---Module-level rather than on the view, because the view is torn down when a review closes
+---and the choice has to outlive that: a reviewer who switched once is not quietly put back
+---by opening the next review.
+---
+---Deliberately not written to the state store either. That store is per repository and a
+---layout preference is not; and a persisted preference would silently override a later
+---configuration change, which is the bug where someone edits their config and nothing
+---happens. A module local lasts exactly as long as it should -- until Neovim exits, after
+---which configuration decides again.
+---@type "unified"|"split"|nil nil until a reviewer has chosen, when configuration decides
+local session_layout = nil
+
+---@return "unified"|"split"
+local function opening_layout()
+  return session_layout or config.get().layout
+end
 
 ---@param msg string
 local function warn(msg)
@@ -82,16 +102,6 @@ local function panes()
   local out = { V.win }
   if has_before() then
     out[#out + 1] = V.before_win
-  end
-  return out
-end
-
----Every review buffer there is, after pane first.
----@return integer[]
-local function pane_bufs()
-  local out = { V.buf }
-  if V.before_buf and vim.api.nvim_buf_is_valid(V.before_buf) then
-    out[#out + 1] = V.before_buf
   end
   return out
 end
@@ -1342,6 +1352,9 @@ local function setup_main_keymaps(buf)
     },
     ["gr"] = { M.refresh, "Reload the diff" },
     ["gp"] = { M.toggle_panel, "Show or hide the file tree" },
+    -- From the `g` family the other view-level commands come from, and clear of `gt`/`gT`,
+    -- which are how `<CR>`'s new tab is returned from.
+    ["gl"] = { M.toggle_layout, "Switch between the unified and split layouts" },
     ["<CR>"] = { M.open_file, "Open the real file here" },
     ["Q"] = { M.review_queue, "Review the queue" },
     ["<C-t>"] = { M.pick_target, "Choose the delivery target" },
@@ -1411,6 +1424,7 @@ local function setup_panel_keymaps()
     ["<C-p>"] = { M.pick_file, "Jump to a file" },
     ["<Tab>"] = { M.toggle_focus, "Focus the diff" },
     ["gp"] = { M.toggle_panel, "Hide the file tree" },
+    ["gl"] = { M.toggle_layout, "Switch between the unified and split layouts" },
     ["R"] = { M.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { M.close, "Close the review" },
   })
@@ -1425,6 +1439,57 @@ local function scratch(buf, name)
   vim.bo[buf].modifiable = false
   vim.bo[buf].filetype = name
   vim.api.nvim_buf_set_name(buf, name .. "://" .. tostring(buf))
+end
+
+---Give a review buffer everything it carries: the diff's keys, and the two autocommands
+---that watch its cursor.
+---
+---An operation of its own rather than a loop in `open`, because a before pane's buffer is
+---`bufhidden = "wipe"`. Toggling the layout back to unified destroys it, and toggling to
+---split again builds a *new* one that has to be given all of this over -- the same lesson
+---the panel learned when it became dismissible, and the same failure if it is forgotten: a
+---pane that comes back with no keymaps at all.
+---@param buf integer
+local function attach_pane(buf)
+  setup_main_keymaps(buf)
+
+  -- The review buffer is nomodifiable, so insert mode is never meaningful in it. It can
+  -- still be arrived at while already inserting: a composer opened with `startinsert` and
+  -- submitted from an insert-mode mapping closes its window without ending insert, and
+  -- focus lands here mid-insert -- no InsertEnter fires, because insert never ended.
+  -- Every navigation key is then a failed edit rather than a motion.
+  vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "InsertEnter" }, {
+    group = V.augroup,
+    buffer = buf,
+    callback = function()
+      if vim.fn.mode():sub(1, 1) == "i" then
+        vim.schedule(function()
+          if vim.fn.mode():sub(1, 1) == "i" then
+            vim.cmd("stopinsert")
+          end
+        end)
+      end
+    end,
+  })
+
+  -- Highlighting is bounded by the viewport, so scrolling into an un-parsed file is what
+  -- triggers its parse. Cheap on every other scroll: already-painted files are skipped
+  -- and already-parsed ones repaint from cache.
+  vim.api.nvim_create_autocmd({ "WinScrolled", "CursorMoved" }, {
+    group = V.augroup,
+    buffer = buf,
+    callback = function()
+      if not M.current() then
+        return
+      end
+      if config.get().syntax then
+        require("codereview.syntax").apply(V, NS)
+      end
+      -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
+      -- immediately unless the cursor crossed into a different file.
+      sync_panel()
+    end,
+  })
 end
 
 ---@param win integer
@@ -1465,7 +1530,29 @@ local function show_before_pane()
     vim.wo[w].cursorbind = true
   end
 
+  attach_pane(buf)
   vim.api.nvim_set_current_win(V.win)
+end
+
+---Dismiss the before pane, leaving the after pane as the whole review view.
+---
+---Its buffer is `bufhidden = "wipe"`, so closing the window destroys the buffer and every
+---keymap and autocommand bound to it. Nothing is kept back to re-attach later: showing the
+---pane again builds a new one and gives it the set over.
+---
+---The binding is lifted from the surviving pane rather than left set on it, so that the
+---unified layout is the same single window it has always been.
+local function hide_before_pane()
+  local win = V.before_win
+  V.before_buf, V.before_win, V.before_render = nil, nil, nil
+  vim.wo[V.win].scrollbind = false
+  vim.wo[V.win].cursorbind = false
+  -- Leave it deliberately rather than letting Neovim pick a successor for a window it is
+  -- about to close: the after pane is where the review continues.
+  if vim.api.nvim_get_current_win() == win then
+    vim.api.nvim_set_current_win(V.win)
+  end
+  pcall(vim.api.nvim_win_close, win, true)
 end
 
 ---Give the two panes equal width.
@@ -1544,6 +1631,97 @@ function M.toggle_panel()
   M.paint()
 end
 
+--- The layout ------------------------------------------------------------------
+
+---Row in `rendered` carrying the same anchor, or the file's header when it carries none.
+---
+---Anchor indices -- file, hunk and line -- mean the same thing in both layouts, because a
+---layout decides where a row is drawn and not what a row is. Buffer rows do not: the same
+---line of the same hunk sits at a different row in each. So the anchor is what a toggle
+---carries across, and this is the scan the queue float's jump and `]a` already make.
+---
+---**Filler** is the one anchor with no counterpart -- it exists only in the split layout,
+---and names a place the unified layout draws no row for at all -- so it finds nothing and
+---falls through to the header, which needs no branch of its own. That is the same reading
+---target resolution already gives it: the cursor is on nothing, so this means the file.
+---@param rendered CRRender
+---@param anchor CRAnchor
+---@return integer
+local function row_carrying(rendered, anchor)
+  for row = 1, #rendered.lines do
+    local a = rendered.anchors[row]
+    if a and a.kind == anchor.kind and a.file == anchor.file and a.hunk == anchor.hunk and a.line == anchor.line then
+      return row
+    end
+  end
+  return rendered.file_rows[anchor.file] or 1
+end
+
+---Whether an anchor names a place in the before pane, and so which pane receives the cursor.
+---
+---The line's side decides, through the key that already carries it: only a pure deletion
+---produces a pre-image key, and a context line exists in both images with its key preferring
+---the post-image. No new rule -- it is the one that already decides which pane a note is
+---drawn in and which pane the queue float jumps to.
+---@param anchor CRAnchor
+---@return boolean
+local function belongs_to_before(anchor)
+  if anchor.kind ~= "line" then
+    return false
+  end
+  local file = V.files[anchor.file]
+  return render.is_before_key(render.line_key(file.path, file.hunks[anchor.hunk].lines[anchor.line]))
+end
+
+---Switch between the unified and split layouts, from either pane or from the file tree.
+---
+---Configuration decides the layout a review opens in; this decides it from there on, and
+---the choice is remembered for the rest of the session rather than for this review only.
+---
+---What survives the switch is the **anchor** under the cursor, never the row: the same line
+---of the same hunk sits at a different row in each layout, so a row carried across would
+---land on unrelated code. The result is centred, because the row moved structurally and an
+---exact scroll offset preserved across that would be preserving something meaningless.
+function M.toggle_layout()
+  if not M.current() then
+    return
+  end
+  -- Read before the rebuild, from whichever pane has focus. Asked from the tree it answers
+  -- for the after pane, which is where the diff cursor is.
+  local anchor = anchor_at_cursor()
+  local in_panel = V.panel_win ~= nil and vim.api.nvim_get_current_win() == V.panel_win
+
+  if has_before() then
+    hide_before_pane()
+  else
+    show_before_pane()
+  end
+  V.layout = has_before() and "split" or "unified"
+  session_layout = V.layout
+
+  -- The panes have just taken columns from each other, or handed them all back to one
+  -- window, and a file header is padded to the width of the window drawing it -- so this
+  -- repaints rather than leaning on the resize autocommand, which fires from the main loop
+  -- and therefore lands after the toggle has returned.
+  --
+  -- No balancing beside it: a `vsplit` halves the window it splits, and closing one half
+  -- gives its columns back to the other, so the two panes are already comparable. What is
+  -- not is the panel arriving or leaving beside them, which is where `balance_panes` lives.
+  M.paint()
+
+  if not anchor then
+    return
+  end
+  local to_before = has_before() and belongs_to_before(anchor)
+  local rendered = to_before and V.before_render or V.render
+  -- Focus follows the code, unless it was never in the diff to begin with: a reviewer who
+  -- toggled from the tree asked for a different layout, not for a different window. Set
+  -- either way rather than only when it moves, because building a pane takes focus to
+  -- split the window and the tree has to be handed it back.
+  vim.api.nvim_set_current_win(in_panel and V.panel_win or (to_before and V.before_win or V.win))
+  goto_row(row_carrying(rendered, anchor), "zz")
+end
+
 --- Opening --------------------------------------------------------------------
 
 ---@param spec string|nil
@@ -1586,6 +1764,9 @@ function M.open(spec)
   window_opts(main_win)
 
   local key = scope_key(scope)
+  -- Configuration decides this only until a reviewer has said otherwise; from then on their
+  -- choice does, for the rest of the session.
+  local layout = opening_layout()
   V = {
     root = root,
     scope = scope,
@@ -1598,8 +1779,9 @@ function M.open(spec)
     collapsed = {},
     buf = buf,
     win = main_win,
-    layout = cfg.layout,
+    layout = layout,
     tab = tab,
+    augroup = vim.api.nvim_create_augroup("CodeReviewView", { clear = true }),
   }
   V.reviewed = V.per_scope[key].reviewed
   V.expanded = V.per_scope[key].expanded
@@ -1609,7 +1791,7 @@ function M.open(spec)
 
   -- Before the panel, so the panel's `topleft`/`botright` split lands outside both panes
   -- rather than between them.
-  if cfg.layout == "split" then
+  if layout == "split" then
     show_before_pane()
   end
   if cfg.panel.enabled then
@@ -1617,63 +1799,19 @@ function M.open(spec)
   end
   balance_panes()
 
-  for _, b in ipairs(pane_bufs()) do
-    setup_main_keymaps(b)
-  end
-
-  local augroup = vim.api.nvim_create_augroup("CodeReviewView", { clear = true })
+  -- The before pane, if there is one, was given its own by `show_before_pane` -- which is
+  -- also what gives it back to a pane the layout toggle rebuilt.
+  attach_pane(V.buf)
 
   -- Header padding is width-dependent, so a resize needs a full repaint.
   vim.api.nvim_create_autocmd({ "VimResized", "WinResized" }, {
-    group = augroup,
+    group = V.augroup,
     callback = function()
       if M.current() then
         M.paint()
       end
     end,
   })
-
-  -- The review buffer is nomodifiable, so insert mode is never meaningful in it. It can
-  -- still be arrived at while already inserting: a composer opened with `startinsert` and
-  -- submitted from an insert-mode mapping closes its window without ending insert, and
-  -- focus lands here mid-insert -- no InsertEnter fires, because insert never ended.
-  -- Every navigation key is then a failed edit rather than a motion.
-  for _, b in ipairs(pane_bufs()) do
-    vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter", "InsertEnter" }, {
-      group = augroup,
-      buffer = b,
-      callback = function()
-        if vim.fn.mode():sub(1, 1) == "i" then
-          vim.schedule(function()
-            if vim.fn.mode():sub(1, 1) == "i" then
-              vim.cmd("stopinsert")
-            end
-          end)
-        end
-      end,
-    })
-  end
-
-  -- Highlighting is bounded by the viewport, so scrolling into an un-parsed file is what
-  -- triggers its parse. Cheap on every other scroll: already-painted files are skipped
-  -- and already-parsed ones repaint from cache.
-  for _, b in ipairs(pane_bufs()) do
-    vim.api.nvim_create_autocmd({ "WinScrolled", "CursorMoved" }, {
-      group = augroup,
-      buffer = b,
-      callback = function()
-        if not M.current() then
-          return
-        end
-        if config.get().syntax then
-          require("codereview.syntax").apply(V, NS)
-        end
-        -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
-        -- immediately unless the cursor crossed into a different file.
-        sync_panel()
-      end,
-    })
-  end
 
   M.paint()
   place(1)

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # open-time report, not a 
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 600 cases in ~5 seconds.
+The whole suite is about 800 cases in ~6 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -25,6 +25,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `fixtures/*.sh` | Build a fixture repository from scratch at a given path. Take a target path; safe to run by hand. |
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
+| `codereview/layout_child.lua` | Spawned by `layout_spec` — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
@@ -37,6 +38,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
 | `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling |
 | `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring with no windows; then the binding, annotation parity against the unified layout, and the two intersections nobody else owns |
+| `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `syntax_spec` | Treesitter harvest/replay, caching, guardrails |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
@@ -61,10 +63,12 @@ interchangeable, and the assertions know which one they are looking at.
   modified, deleted, added, renamed-and-edited, staged, unstaged, untracked, untracked
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
-  `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `split_spec` and
-  `interactive_spec`. It already covers everything the split layout has to render,
-  including the files that exist on only one side and the additions between context lines
-  that produce filler — so that slice needed no fixture of its own.
+  `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `split_spec`,
+  `layout_spec` and `interactive_spec`. It already covers everything the split layout has
+  to render, including the files that exist on only one side and the additions between
+  context lines that produce filler — so that slice needed no fixture of its own. The
+  layout toggle needed none either: `src/main.lua`'s deletion and its replacement collapse
+  onto one row in the split layout, which is what makes every row below them move.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec`, `focus_spec` and `queue_jump_panel_spec`.
@@ -87,6 +91,14 @@ so the out-of-core language path is still checked locally without ever failing C
   across a genuine restart; calling `state.load()` twice in one process proves nothing
   about what reached the disk. `state_child.lua` writes, the spec restarts and reads. Do
   not collapse it into one process.
+- **So is `layout_spec`, and for the opposite reason.** "The chosen layout resets when
+  Neovim exits" is a claim about what a *new* process starts with, which no assertion made
+  in the choosing one can settle. `layout_child.lua` chooses the split layout and exits;
+  the spec, which has not toggled anything yet, then opens a review and finds the
+  configured layout. It also marks a file reviewed, because "nothing about the layout came
+  back" would otherwise be satisfied by nothing coming back at all — the reviewed mark is
+  what proves the store the two share is live. Its cases therefore have to run *first*,
+  before this process has chosen a layout of its own.
 - **`norepo_spec` needs a directory that is genuinely outside a checkout**, and asserts it
   rather than assuming it. If the temp directory ever sits inside a repository, every case
   about a "loose" file silently becomes a test of the ordinary in-repository path.
@@ -172,6 +184,27 @@ so the out-of-core language path is still checked locally without ever failing C
   asserts the panes really did diverge, so the assertion cannot quietly stop measuring.
   Note that `zt` in one pane propagates through `scrollbind`, so it is no use for pulling
   them apart; that was the first attempt and the guard caught it.
+- **A toggle from a row both layouts agree about proves nothing.** Most of the fixture
+  renders at the *same* row in both layouts, because only files below a collapsed
+  deletion-and-replacement pair move at all — `src/main.lua`'s deleted line is row 12 in
+  each. A round trip started there passes with the anchor scan replaced by "keep the row",
+  which is the bug. `layout_spec` starts in `src/newname.lua` and `src/routes.lua`, both
+  below that collapse, and guards every round trip by asserting the row really did change.
+- **Centring is unobservable in a window taller than its buffer.** `split_spec` runs at 45
+  lines, where the whole fixture diff fits on screen and nothing can scroll, so a `zz`
+  assertion there passes with the `zz` deleted. `layout_spec` runs at 24 for that reason,
+  and asserts centring as "a second `zz` here changes nothing" plus a guard that the window
+  had scrolled at all.
+- **Two bound panes given the same view command land somewhere neither was asked for.**
+  `scrollbind` tracks deltas, so running `zz` in the after pane scrolls the before pane
+  before the before pane has been placed, and its own `zz` then scrolls the after pane
+  back — nine rows apart, neither centred. `place` lifts both bindings while it works and
+  puts them back, which does not scroll anything. `zt` happens to be self-correcting from
+  an aligned start, which is why no file-jump assertion caught this first.
+- **Reviewed marks and expansion are per scope, so setting them before a scope change
+  loses them.** `set_scope` swaps `V.reviewed` and `V.expanded` for the new scope's tables.
+  A fixture built and *then* switched to another scope arrives empty, and a "nothing
+  changed" assertion over it compares two empty tables and passes regardless.
 - **`interactive_spec` must keep its teeth.** To confirm it still reproduces the bug,
   remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless

--- a/tests/codereview/layout_child.lua
+++ b/tests/codereview/layout_child.lua
@@ -1,0 +1,41 @@
+-- The first half of layout_spec: a Neovim that chooses the split layout and then exits.
+--
+-- Deliberately a separate process. "The choice resets when Neovim exits" is only
+-- meaningfully tested across a genuine restart -- clearing a module-level variable by hand
+-- in one process proves nothing about what a *new* one starts with, and an assertion made
+-- in the same process would pass however the choice were stored.
+--
+-- It also marks a file reviewed, which the store genuinely does carry. That is what lets
+-- the next session prove the channel between the two is live before concluding the layout
+-- is not on it: without it, "nothing about the layout came back" would be satisfied by
+-- nothing coming back at all.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- layout_spec with XDG_STATE_HOME and FIXTURE in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 140
+vim.o.lines = 45
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+require("codereview").setup({ layout = "unified", syntax = false })
+
+local view = require("codereview.view")
+
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+assert(V.before_win == nil, "the child did not open in the configured layout")
+
+-- Progress the store does carry, made before the toggle so it cannot depend on where the
+-- toggle left the cursor.
+vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[1], 0 })
+view.toggle_reviewed()
+
+view.toggle_layout()
+assert(view.current().before_win ~= nil, "the child never reached the split layout")
+
+-- Printed so a failing layout_spec can show what the choosing process believed it did.
+-- `nvim -l` sends this to stderr, not stdout.
+print(("reviewed %s; state file: %s"):format(V.files[1].path, require("codereview.state").path(V.root)))
+vim.cmd("qa!")

--- a/tests/codereview/layout_spec.lua
+++ b/tests/codereview/layout_spec.lua
@@ -1,0 +1,832 @@
+-- Switching layout without losing your place.
+--
+-- Buffer rows mean nothing across layouts: the same line of the same hunk sits at a
+-- different row in each, because only row placement changes. So every case here asserts the
+-- **anchor** under the cursor -- file, hunk and line -- and never the row, and each one
+-- starts somewhere the two layouts genuinely disagree about. A toggle from row 1, or from a
+-- file the collapse of a deletion above it has not shifted, proves nothing: the row would
+-- have survived a toggle that carried it across unchanged, which is the bug.
+--
+-- The window is deliberately short enough that the diff does not fit in it. Centring is
+-- unobservable in a window taller than its buffer, and the assertion would pass with `zz`
+-- deleted.
+local h = require("tests.helpers")
+
+h.ui(160, 24)
+local fixture = h.cd_fixture("mkfixture")
+
+local config = require("codereview.config")
+local delivery = require("codereview.delivery")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local annotate = require("codereview.annotate")
+local view = require("codereview.view")
+
+local note_text = "a note"
+require("codereview").setup({
+  layout = "unified",
+  syntax = false,
+  compose = function(_, on_accept, _)
+    on_accept(nil, note_text)
+  end,
+  pick_target = function(cb)
+    cb({ short = "agent-7" })
+  end,
+})
+
+local root = assert(vim.uv.fs_realpath(fixture))
+
+--- Across a genuine restart ------------------------------------------------------
+
+-- First, before this process has toggled anything: a session that chose the split layout
+-- and exited, and then this one, which is the session after it.
+describe("a session that chose the split layout and exited", function()
+  -- Shares this process's throwaway XDG_STATE_HOME and nothing else, and runs with
+  -- `--clean` so no user config and no minimal_init can hand it a different one.
+  local child = vim
+    .system({
+      vim.v.progpath,
+      "--clean",
+      "-l",
+      vim.fs.joinpath(h.root, "tests", "codereview", "layout_child.lua"),
+    }, {
+      cwd = fixture,
+      text = true,
+      env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = fixture },
+    })
+    :wait(60000)
+
+  it("exits cleanly", function()
+    assert.same(0, child.code, (child.stderr or "") .. (child.stdout or ""))
+  end)
+
+  -- Without this the case below is vacuous: "nothing about the layout came back" would be
+  -- satisfied by there being no channel between the two sessions at all.
+  it("leaves a state file behind, so the two sessions really do share a store", function()
+    assert.same(1, vim.fn.filereadable(state.path(root)), "no state at " .. state.path(root))
+  end)
+
+  it("writes nothing about the layout into it", function()
+    local text = table.concat(vim.fn.readfile(state.path(root)), "\n")
+    assert.is_nil(text:find("layout", 1, true), text)
+    assert.is_nil(text:find("split", 1, true), text)
+  end)
+end)
+
+describe("the session after it", function()
+  view.open("branch")
+  local V = assert(view.current())
+
+  it("restores what the store does carry", function()
+    assert.same(1, vim.tbl_count(V.reviewed))
+  end)
+
+  -- Configuration is what decides at the start of every session, so a preference chosen in
+  -- one cannot silently override a config that has changed since.
+  it("opens in the configured layout, not the one that session chose", function()
+    assert.same("unified", config.get().layout)
+    assert.same("unified", V.layout)
+    assert.is_nil(V.before_win)
+  end)
+
+  view.close()
+  state.clear(root)
+  queue.clear()
+end)
+
+--- In one session ----------------------------------------------------------------
+
+view.open("branch")
+queue.clear()
+
+---@return CRView
+local function current()
+  return assert(view.current(), "no review view open")
+end
+
+---@param win integer
+local function focus(win)
+  vim.api.nvim_set_current_win(win)
+end
+
+---@param win integer
+---@return integer
+local function row_in(win)
+  return vim.api.nvim_win_get_cursor(win)[1]
+end
+
+---@param win integer
+---@return integer
+local function topline(win)
+  return vim.api.nvim_win_call(win, function()
+    return vim.fn.line("w0")
+  end)
+end
+
+---The anchor under the cursor, reduced to what a layout is not allowed to change.
+---@return table
+local function anchor_here()
+  local a = assert(view.anchor_at_cursor(), "no anchor under the cursor")
+  return { kind = a.kind, file = a.file, hunk = a.hunk, line = a.line }
+end
+
+---@param want "unified"|"split"
+local function in_layout(want)
+  if (current().before_win ~= nil) ~= (want == "split") then
+    view.toggle_layout()
+  end
+  assert(current().layout == want, "could not reach the " .. want .. " layout")
+end
+
+---Row in a pane holding a diff line of `path` on the given side.
+---@param rendered CRRender
+---@param path string
+---@param side "add"|"del"|"ctx"
+---@return integer
+local function side_row(rendered, path, side)
+  local V = current()
+  for row = 1, #rendered.lines do
+    local a = rendered.anchors[row]
+    if a and a.kind == "line" and V.files[a.file].path == path then
+      if V.files[a.file].hunks[a.hunk].lines[a.line].side == side then
+        return row
+      end
+    end
+  end
+  error(("no %s line for %s"):format(side, path))
+end
+
+---@param path string
+---@return integer
+local function index_of(path)
+  return assert(h.file_index(current(), path), path .. " is not in this scope")
+end
+
+-- `src/newname.lua` and `src/routes.lua` both sit *below* `src/main.lua`, whose deletion and
+-- its replacement collapse onto one row in the split layout. Every row in them therefore
+-- moves when the layout changes, which is what gives the cases below their teeth.
+local NEWNAME, ROUTES = "src/newname.lua", "src/routes.lua"
+
+---Put the cursor on a diff line in whichever layout is showing, and report where it is.
+---@param path string
+---@param side "add"|"del"|"ctx"
+---@return table anchor, integer row, integer win
+local function start_on(path, side)
+  local V = current()
+  local before = side == "del" and V.before_win ~= nil
+  local win = before and V.before_win or V.win
+  local row = side_row(before and V.before_render or V.render, path, side)
+  focus(win)
+  vim.api.nvim_win_set_cursor(win, { row, 0 })
+  return anchor_here(), row, win
+end
+
+describe("the keystroke", function()
+  ---@param buf integer
+  ---@return table<string, boolean>
+  local function bound(buf)
+    local lhs = {}
+    -- Through `vim.keycode` on both sides: the API reports a key in its own notation rather
+    -- than the one it was bound with, so comparing the strings as written can silently
+    -- never match.
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+      lhs[vim.keycode(m.lhs)] = true
+    end
+    return lhs
+  end
+
+  it("sits alongside the other view-level commands, in both panes and in the tree", function()
+    in_layout("split")
+    local V = current()
+    for _, buf in ipairs({ V.buf, V.before_buf, V.panel_buf }) do
+      local lhs = bound(buf)
+      assert.is_true(lhs[vim.keycode("gl")] == true, "gl is not bound")
+      -- The company it keeps: the other `g` commands this one was chosen to sit beside.
+      assert.is_true(lhs[vim.keycode("gp")] == true)
+    end
+  end)
+
+  -- `<CR>` opens the real file in a new tab, and `gT` is how a reviewer comes back from it.
+  it("shadows neither of the tab-switching keys anywhere in the view", function()
+    local V = current()
+    for _, buf in ipairs({ V.buf, V.before_buf, V.panel_buf }) do
+      local lhs = bound(buf)
+      assert.is_falsy(lhs[vim.keycode("gt")], "gt is shadowed")
+      assert.is_falsy(lhs[vim.keycode("gT")], "gT is shadowed")
+    end
+  end)
+
+  -- Driven through the keys rather than by calling the action: a mapping that was never
+  -- bound, or bound to a buffer that has since been rebuilt, passes every other assertion.
+  it("switches the layout when it is actually pressed in the after pane", function()
+    in_layout("split")
+    focus(current().win)
+    h.feed("gl")
+    assert.same("unified", current().layout)
+    assert.is_nil(current().before_win)
+
+    h.feed("gl")
+    assert.same("split", current().layout)
+    assert.is_truthy(current().before_win)
+  end)
+
+  it("switches it from the before pane too", function()
+    in_layout("split")
+    focus(current().before_win)
+    h.feed("gl")
+    assert.same("unified", current().layout)
+    -- The pane the key was pressed in is gone, so focus cannot have been left in it.
+    assert.same(current().win, vim.api.nvim_get_current_win())
+  end)
+
+  it("switches it from the file tree too", function()
+    in_layout("unified")
+    focus(assert(current().panel_win, "no tree to press it in"))
+    h.feed("gl")
+    assert.same("split", current().layout)
+    assert.same(current().panel_win, vim.api.nvim_get_current_win())
+  end)
+end)
+
+describe("a deleted line", function()
+  it("really starts somewhere the two layouts disagree about", function()
+    in_layout("unified")
+    local V = current()
+    local unified_row = side_row(V.render, NEWNAME, "del")
+    in_layout("split")
+    local split_row = side_row(current().before_render, NEWNAME, "del")
+    assert.is_true(
+      unified_row ~= split_row,
+      ("row %d in both layouts -- this case cannot tell an anchor from a row"):format(unified_row)
+    )
+  end)
+
+  it("lands in the before pane, on the same line of the same hunk", function()
+    in_layout("unified")
+    local start = start_on(NEWNAME, "del")
+    view.toggle_layout()
+
+    local V = current()
+    assert.same(V.before_win, vim.api.nvim_get_current_win())
+    assert.same(start, anchor_here())
+    assert.same("del", V.files[start.file].hunks[start.hunk].lines[start.line].side)
+  end)
+
+  it("comes back to exactly the row it started on", function()
+    in_layout("unified")
+    local start, row = start_on(NEWNAME, "del")
+    view.toggle_layout()
+    local moved = row_in(vim.api.nvim_get_current_win())
+    view.toggle_layout()
+
+    assert.same("unified", current().layout)
+    assert.same(current().win, vim.api.nvim_get_current_win())
+    assert.same(start, anchor_here())
+    assert.same(row, row_in(current().win))
+    -- And the round trip was not a row surviving unchanged.
+    assert.is_true(moved ~= row, ("the anchor never moved rows (%d)"):format(row))
+  end)
+end)
+
+describe("an added line", function()
+  it("lands in the after pane, on the same line of the same hunk", function()
+    in_layout("unified")
+    local start, row = start_on(NEWNAME, "add")
+    view.toggle_layout()
+
+    local V = current()
+    assert.same(V.win, vim.api.nvim_get_current_win())
+    assert.same(start, anchor_here())
+    assert.is_true(row_in(V.win) ~= row, "the anchor never moved rows")
+  end)
+
+  it("comes back to exactly where it started", function()
+    in_layout("unified")
+    local start, row = start_on(NEWNAME, "add")
+    view.toggle_layout()
+    view.toggle_layout()
+    assert.same(start, anchor_here())
+    assert.same(row, row_in(current().win))
+  end)
+end)
+
+-- A context line exists in both images and its key prefers the post-image, which is why it
+-- reads in the after pane -- the same rule that decides where its notes are drawn.
+describe("a context line", function()
+  it("lands in the after pane", function()
+    in_layout("unified")
+    local start, row = start_on(ROUTES, "ctx")
+    view.toggle_layout()
+
+    assert.same(current().win, vim.api.nvim_get_current_win())
+    assert.same(start, anchor_here())
+    assert.is_true(row_in(current().win) ~= row, "the anchor never moved rows")
+  end)
+end)
+
+describe("a cursor on filler", function()
+  ---Filler in the before pane with real code above it in the same pane -- so a walk upward
+  ---would have found a line the reviewer was not looking at, which is the whole reason
+  ---filler carries an anchor of its own.
+  ---@return integer row, integer above
+  local function filler_row()
+    local V = current()
+    local fi = index_of(ROUTES)
+    local above
+    for row = 1, #V.before_render.lines do
+      local a = V.before_render.anchors[row]
+      if a.file == fi and a.kind == "line" then
+        above = row
+      elseif a.file == fi and a.kind == "fill" and above then
+        return row, above
+      end
+    end
+    error("no filler with code above it in " .. ROUTES)
+  end
+
+  it("really starts on filler, with unrelated code above it", function()
+    in_layout("split")
+    local row, above = filler_row()
+    local V = current()
+    assert.same("fill", V.before_render.anchors[row].kind)
+    assert.same("line", V.before_render.anchors[above].kind)
+    assert.is_true(row > above)
+  end)
+
+  -- It has no counterpart in the unified layout at all, so it means the file: the same
+  -- reading target resolution already gives it.
+  it("falls back to that file's header", function()
+    in_layout("split")
+    local row, above = filler_row()
+    local V = current()
+    local above_anchor = V.before_render.anchors[above]
+    focus(V.before_win)
+    vim.api.nvim_win_set_cursor(V.before_win, { row, 0 })
+
+    view.toggle_layout()
+    local after = current()
+    assert.same({ kind = "file", file = index_of(ROUTES) }, anchor_here())
+    assert.same(after.render.file_rows[index_of(ROUTES)], row_in(after.win))
+    -- Not the line above it, which is what a walk upward would have carried across.
+    assert.is_true(anchor_here().line ~= above_anchor.line)
+  end)
+end)
+
+describe("a collapsed file's header", function()
+  it("stays on that file's header", function()
+    in_layout("unified")
+    local V = current()
+    local fi = index_of(NEWNAME)
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[fi], 0 })
+    view.toggle_expand()
+    assert.is_false(V.expanded[NEWNAME], "the file never collapsed")
+
+    view.toggle_layout()
+    assert.same({ kind = "file", file = fi }, anchor_here())
+    assert.same(current().render.file_rows[fi], row_in(current().win))
+    -- Collapse is layout-independent, so it is still collapsed on the other side.
+    assert.is_false(current().expanded[NEWNAME])
+
+    view.toggle_expand()
+    assert.is_true(current().expanded[NEWNAME])
+  end)
+end)
+
+describe("the landing line", function()
+  it("is far enough down that centring is observable at all", function()
+    in_layout("unified")
+    local V = current()
+    local row = side_row(V.render, "src/untracked.lua", "add")
+    assert.is_true(
+      row > vim.api.nvim_win_get_height(V.win),
+      ("row %d fits in a %d-row window, so nothing can scroll"):format(row, vim.api.nvim_win_get_height(V.win))
+    )
+  end)
+
+  it("is centred", function()
+    in_layout("unified")
+    start_on("src/untracked.lua", "add")
+    view.toggle_layout()
+
+    local win = vim.api.nvim_get_current_win()
+    local was = topline(win)
+    -- Centred is exactly "a `zz` here would change nothing".
+    vim.api.nvim_win_call(win, function()
+      vim.cmd("normal! zz")
+    end)
+    assert.same(was, topline(win))
+    assert.is_true(was > 1, "the window never scrolled, so this measured nothing")
+  end)
+
+  it("leaves both panes reading the same rows", function()
+    in_layout("unified")
+    start_on("src/untracked.lua", "add")
+    view.toggle_layout()
+
+    local V = current()
+    assert.same(row_in(V.win), row_in(V.before_win))
+    assert.same(topline(V.win), topline(V.before_win))
+  end)
+end)
+
+-- Putting a row on screen runs the same view command in both panes, and the toggle's
+-- centring shares that with every jump. Asserted here rather than in `split_spec`, whose
+-- window is taller than the whole diff: nothing scrolls there, so nothing can come apart.
+describe("a jump in a window shorter than the diff", function()
+  it("leaves both panes on the same row and the same top line", function()
+    in_layout("split")
+    local V = current()
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    for _ = 1, #V.files do
+      view.jump("file", true)
+    end
+
+    assert.is_true(topline(V.win) > 1, "no jump ever scrolled, so this measured nothing")
+    assert.same(row_in(V.win), row_in(V.before_win))
+    assert.same(topline(V.win), topline(V.before_win))
+  end)
+end)
+
+describe("toggling from the file tree", function()
+  it("keeps focus in the tree and moves the diff underneath it", function()
+    in_layout("unified")
+    local start, row = start_on(NEWNAME, "add")
+    local V = current()
+    focus(assert(V.panel_win, "no tree to toggle from"))
+
+    view.toggle_layout()
+    assert.same("split", current().layout)
+    assert.same(current().panel_win, vim.api.nvim_get_current_win())
+    -- The diff cursor moved even though focus did not: `anchor_at_cursor` answers for the
+    -- after pane when it is asked from neither.
+    assert.same(start, anchor_here())
+    assert.is_true(row_in(current().win) ~= row)
+  end)
+
+  it("comes back the same way", function()
+    focus(assert(current().panel_win))
+    view.toggle_layout()
+    assert.same("unified", current().layout)
+    assert.same(current().panel_win, vim.api.nvim_get_current_win())
+  end)
+end)
+
+describe("with the tree dismissed", function()
+  it("really dismissed it", function()
+    in_layout("unified")
+    focus(current().win)
+    view.toggle_panel()
+    assert.is_nil(current().panel_win)
+  end)
+
+  it("switches layout with no tree beside it, keeping the anchor", function()
+    local start = start_on(NEWNAME, "del")
+    view.toggle_layout()
+
+    local V = current()
+    assert.same("split", V.layout)
+    assert.is_nil(V.panel_win)
+    assert.same(V.before_win, vim.api.nvim_get_current_win())
+    assert.same(start, anchor_here())
+  end)
+
+  it("gives the columns the tree is not using to both panes", function()
+    local V = current()
+    local before, after = vim.api.nvim_win_get_width(V.before_win), vim.api.nvim_win_get_width(V.win)
+    assert.is_true(math.abs(before - after) <= 1, ("%d vs %d"):format(before, after))
+    assert.same(vim.o.columns, before + after + 1)
+  end)
+
+  it("summons the tree back beside two panes", function()
+    view.toggle_panel()
+    local V = current()
+    assert.is_truthy(V.panel_win and vim.api.nvim_win_is_valid(V.panel_win))
+    local before, after = vim.api.nvim_win_get_width(V.before_win), vim.api.nvim_win_get_width(V.win)
+    assert.is_true(math.abs(before - after) <= 1, ("%d vs %d"):format(before, after))
+  end)
+end)
+
+describe("annotations queued before a toggle", function()
+  ---Every extmark in `buf` carrying virtual lines, and the text of the first of them.
+  ---@param buf integer
+  ---@return table<integer, string> by 0-indexed row
+  local function notes_on(buf)
+    local out = {}
+    for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, h.NS, 0, -1, { details = true })) do
+      if m[4].virt_lines then
+        local text = ""
+        for _, line in ipairs(m[4].virt_lines) do
+          for _, chunk in ipairs(line) do
+            text = text .. chunk[1]
+          end
+        end
+        out[m[2]] = text
+      end
+    end
+    return out
+  end
+
+  in_layout("unified")
+  queue.clear()
+  do
+    note_text = "about the deletion"
+    start_on(NEWNAME, "del")
+    annotate.annotate("bug")
+    note_text = "about the addition"
+    start_on(NEWNAME, "add")
+    annotate.annotate("bug")
+    note_text = "a note"
+  end
+
+  it("really queued both, in the layout that has one pane", function()
+    assert.same("unified", current().layout)
+    assert.same(2, queue.count())
+  end)
+
+  it("draws both in the one buffer before the toggle", function()
+    local drawn = notes_on(current().buf)
+    local text = table.concat(vim.tbl_values(drawn), "|")
+    assert.is_truthy(text:find("about the deletion", 1, true))
+    assert.is_truthy(text:find("about the addition", 1, true))
+  end)
+
+  it("re-draws each on the pane its line belongs to", function()
+    view.toggle_layout()
+    local V = current()
+    local del_row = side_row(V.before_render, NEWNAME, "del")
+    local add_row = side_row(V.render, NEWNAME, "add")
+
+    assert.is_truthy(notes_on(V.before_buf)[del_row - 1], "the deletion's note is not in the before pane")
+    assert.is_truthy(
+      notes_on(V.before_buf)[del_row - 1]:find("about the deletion", 1, true),
+      notes_on(V.before_buf)[del_row - 1]
+    )
+    assert.is_truthy(
+      notes_on(V.buf)[add_row - 1] and notes_on(V.buf)[add_row - 1]:find("about the addition", 1, true),
+      "the addition's note is not in the after pane"
+    )
+    -- Neither note reached the pane it is not about.
+    assert.is_falsy(notes_on(V.buf)[del_row - 1]:find("about the deletion", 1, true))
+  end)
+
+  it("keeps every note through a round trip", function()
+    view.toggle_layout()
+    local drawn = table.concat(vim.tbl_values(notes_on(current().buf)), "|")
+    assert.same(2, queue.count())
+    assert.is_truthy(drawn:find("about the deletion", 1, true))
+    assert.is_truthy(drawn:find("about the addition", 1, true))
+  end)
+
+  queue.clear()
+  view.paint()
+end)
+
+-- The queue float's jump landed before the layout could be switched, and it resolves an
+-- entry's key back to a row -- so a toggle after one is a question about the row the jump
+-- chose and the pane it chose it in.
+describe("jumping from the queue float and then toggling", function()
+  it("carries the jump's anchor across the toggle", function()
+    in_layout("split")
+    queue.clear()
+    start_on(NEWNAME, "del")
+    annotate.annotate("bug")
+    local entry = queue.all()[1]
+
+    -- Somewhere else entirely, in the other pane.
+    local V = current()
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    assert.is_true(view.jump_to_entry(entry))
+    assert.same(V.before_win, vim.api.nvim_get_current_win())
+    local landed = anchor_here()
+    assert.same("line", landed.kind)
+
+    view.toggle_layout()
+    assert.same("unified", current().layout)
+    assert.same(landed, anchor_here())
+    assert.same(current().win, vim.api.nvim_get_current_win())
+
+    queue.clear()
+    view.paint()
+  end)
+end)
+
+describe("what a toggle leaves alone", function()
+  in_layout("unified")
+  queue.clear()
+  -- Cleared as well as emptied: changing scope restores the persisted queue when the
+  -- in-memory one is empty, which would hand back what an earlier case queued and make the
+  -- count below two.
+  state.clear(root)
+
+  ---@return table
+  local function everything()
+    local V = current()
+    return {
+      reviewed = vim.deepcopy(V.reviewed),
+      expanded = vim.deepcopy(V.expanded),
+      collapsed = vim.deepcopy(V.collapsed),
+      scope = V.scope.name,
+      queued = queue.count(),
+      key = queue.all()[1] and queue.all()[1].key,
+      target = delivery.target_label(),
+    }
+  end
+
+  -- Every one of these set deliberately, so that "unchanged" is not "empty on both sides".
+  -- The scope first: reviewed marks and expansion are tracked per scope, so anything set
+  -- before a scope change belongs to the scope it was set in and is not what a toggle would
+  -- have to preserve.
+  view.set_scope("worktree")
+  start_on(ROUTES, "add")
+  annotate.annotate("bug")
+  local V = current()
+  focus(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index_of("src/untracked.lua")], 0 })
+  view.toggle_reviewed()
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index_of(ROUTES)], 0 })
+  view.toggle_expand()
+  view.pick_target()
+  focus(current().panel_win)
+  do
+    local row
+    for r, dir in pairs(current().panel_render.row_dir) do
+      if dir == "src" then
+        row = r
+      end
+    end
+    vim.api.nvim_win_set_cursor(current().panel_win, { assert(row, "no src directory row"), 0 })
+    view.panel_fold(true)
+  end
+  focus(current().win)
+
+  local before_toggle = everything()
+
+  it("really had something to leave alone", function()
+    assert.is_truthy(before_toggle.reviewed["src/untracked.lua"], "nothing was marked reviewed")
+    assert.is_false(before_toggle.expanded[ROUTES])
+    assert.is_true(before_toggle.collapsed["src"] == true, "the tree's src directory never collapsed")
+    assert.same(1, before_toggle.queued)
+    assert.same("worktree", before_toggle.scope)
+    assert.same("agent-7", before_toggle.target)
+  end)
+
+  it("changes none of it", function()
+    view.toggle_layout()
+    assert.same("split", current().layout)
+    assert.same(before_toggle, everything())
+  end)
+
+  it("changes none of it coming back either", function()
+    view.toggle_layout()
+    assert.same("unified", current().layout)
+    assert.same(before_toggle, everything())
+  end)
+
+  it("still keeps the tree's collapsed directories off the screen", function()
+    local drawn = table.concat(current().panel_render.lines, "\n")
+    assert.is_falsy(drawn:find("main.lua", 1, true), drawn)
+  end)
+
+  view.set_scope("branch")
+  queue.clear()
+  state.clear(root)
+end)
+
+describe("the choice, for the rest of the session", function()
+  it("is not the configured default, which is untouched", function()
+    in_layout("split")
+    assert.same("unified", config.get().layout)
+    assert.same("split", current().layout)
+  end)
+
+  it("survives closing a review and opening another", function()
+    in_layout("split")
+    view.close()
+    assert.is_nil(view.current())
+
+    view.open("branch")
+    assert.same("split", current().layout)
+    assert.is_truthy(current().before_win and vim.api.nvim_win_is_valid(current().before_win))
+  end)
+
+  it("survives opening a review in a different scope", function()
+    view.close()
+    view.open("staged")
+    assert.same("split", current().layout)
+  end)
+
+  it("switches back the same way", function()
+    in_layout("unified")
+    view.close()
+    view.open("branch")
+    assert.same("unified", current().layout)
+    assert.is_nil(current().before_win)
+  end)
+
+  -- That store is per repository and a layout preference is not; and a persisted preference
+  -- would silently override a later configuration change.
+  it("reaches no state file, even after a write that does", function()
+    in_layout("split")
+    local V = current()
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[1], 0 })
+    view.toggle_reviewed()
+
+    assert.same(1, vim.fn.filereadable(state.path(root)), "nothing was written to compare against")
+    local text = table.concat(vim.fn.readfile(state.path(root)), "\n")
+    assert.is_nil(text:find("layout", 1, true), text)
+    assert.is_nil(text:find("split", 1, true), text)
+
+    view.toggle_reviewed()
+    state.clear(root)
+  end)
+end)
+
+-- The pane the toggle rebuilt is a *new* buffer: its predecessor was `bufhidden = "wipe"`,
+-- so closing the window took the buffer, its keymaps and its autocommands with it. Nothing
+-- that drives the view's exported actions can notice.
+describe("the pane a toggle rebuilt", function()
+  it("is not the buffer it was before", function()
+    in_layout("split")
+    local first = current().before_buf
+    in_layout("unified")
+    in_layout("split")
+    assert.is_true(current().before_buf ~= first, "the before pane came back in the same buffer")
+    assert.is_false(vim.api.nvim_buf_is_valid(first), "the dismissed pane's buffer was never wiped")
+  end)
+
+  it("carries the diff's keys again", function()
+    local lhs = {}
+    for _, m in ipairs(vim.api.nvim_buf_get_keymap(current().before_buf, "n")) do
+      lhs[vim.keycode(m.lhs)] = true
+    end
+    for _, key in ipairs({ "ab", "aa", "x", "]f", "]a", "R", "za", "gp", "gl", "<C-p>", "Q" }) do
+      assert.is_true(lhs[vim.keycode(key)] == true, ("%s is not bound in the rebuilt pane"):format(key))
+    end
+  end)
+
+  it("annotates a deleted line from it, through the keys", function()
+    queue.clear()
+    note_text = "from the rebuilt pane"
+    start_on(NEWNAME, "del")
+    h.feed("ab")
+    note_text = "a note"
+
+    assert.same(1, queue.count())
+    local entry = queue.all()[1]
+    assert.same(NEWNAME, entry.path)
+    -- Keyed to the pre-image, which is what makes it the deleted line and not its
+    -- replacement.
+    assert.is_truthy(entry.key:find(":o:", 1, true), entry.key)
+    queue.clear()
+    view.paint()
+  end)
+
+  it("is still bound to the after pane for scrolling", function()
+    local V = current()
+    focus(V.win)
+    vim.api.nvim_win_call(V.win, function()
+      vim.fn.winrestview({ topline = 1, lnum = 1, col = 0 })
+    end)
+    vim.api.nvim_win_call(V.before_win, function()
+      vim.fn.winrestview({ topline = 1, lnum = 1, col = 0 })
+    end)
+    assert.same({ 1, 1 }, { row_in(V.win), row_in(V.before_win) })
+
+    -- Driven with `normal!`: the binding follows cursor motions and not the API, so an
+    -- assertion made through `nvim_win_set_cursor` passes whether or not it exists.
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! 12j")
+    end)
+    assert.same(13, row_in(V.win))
+    assert.same(13, row_in(V.before_win))
+  end)
+end)
+
+-- The unified layout is the one every existing reviewer has, and a toggle back to it must
+-- leave a window indistinguishable from one that was never split.
+describe("coming back to one pane", function()
+  it("lifts the binding from the window that is left", function()
+    in_layout("split")
+    in_layout("unified")
+    local V = current()
+    assert.is_false(vim.wo[V.win].scrollbind)
+    assert.is_false(vim.wo[V.win].cursorbind)
+  end)
+
+  it("leaves the global scroll-options setting alone throughout", function()
+    assert.same(vim.go.scrollopt, vim.api.nvim_get_option_value("scrollopt", { scope = "global" }))
+    in_layout("split")
+    local during = vim.go.scrollopt
+    in_layout("unified")
+    assert.same(during, vim.go.scrollopt)
+  end)
+
+  it("gives the whole width back to the diff", function()
+    local V = current()
+    assert.same(vim.o.columns - vim.api.nvim_win_get_width(V.panel_win) - 1, vim.api.nvim_win_get_width(V.win))
+  end)
+end)


### PR DESCRIPTION
`gl` switches between the unified and split layouts, from either pane and from the file
tree. Configuration decided which layout a review *opened* in; this decides it from there
on, so a reviewer can reach for side by side on the one reformatted file without editing
their config.

Closes #55

## What it preserves

The **anchor** under the cursor, never the row. Rows mean nothing across layouts — a
deletion and its replacement occupy two rows in one layout and one in the other, so every
row below them moves — while anchor indices are identical, because a layout decides where a
row is drawn and not what a row is. The anchor is read before the rebuild and the row
carrying it is found after, which is the scan `]a` and the queue float's jump already make.

Three consequences follow from rules that already exist:

- which pane receives the cursor follows the line's side, through the sided key that
  already decides which pane a note is drawn in;
- switching back is unambiguous, since one anchor has one row;
- **filler** exists only in the split layout, so it matches nothing and falls through to
  the file's header — no branch of its own, and the reading target resolution already
  gives it.

The result is centred, because the row moved structurally and an exact scroll offset
carried across would mean nothing.

The choice is session-sticky: module-level rather than on the view, which is torn down when
a review closes, and deliberately not in the state store — that store is per repository and
a layout preference is not, and a stored preference would silently override a config the
reviewer had since changed.

## Two defects the tests found

**A pane the toggle dismissed leaves nothing behind.** Its buffer is `bufhidden = "wipe"`,
so the keymaps and autocommands bound to it die with it — the same lesson the panel learned
in #52. Everything a review buffer carries moved out of `open` into one operation the toggle
can run again.

**Two bound panes given the same view command land somewhere neither asked for.**
`scrollbind` tracks deltas, so `place` running `zz` in the after pane scrolled the before
pane before the before pane had been placed, and its own `zz` scrolled the after pane back.
Observed on row 37 of a 21-row window: after-pane topline **37**, before-pane topline
**28**, neither centred, and the intended centred topline for both was **28**. Lifting the
binding for the duration gives **28 / 28**. This is shared with every jump, so it is its own
commit (`beee54f`) — the pre-existing suite is green with that commit alone (759/0). `zt`
happens to be self-correcting from an aligned start, which is why no existing file-jump
assertion caught it.

## Red first

`tests/codereview/layout_spec.lua` was run against the base `view.lua`: every case that
exercises the toggle fails with `attempt to call field 'toggle_layout' (a nil value)`,
including the child process. Final state: **810 cases, 0 failures, 0 errors** (759 before
this branch), lint clean.

Every case asserts the anchor and never the row, and starts where the two layouts genuinely
disagree. Most of the fixture does not: only files below `src/main.lua`, whose deletion and
replacement collapse onto one row, move at all — `src/main.lua`'s own deleted line is row
**12** in both layouts, so a round trip started there passes with the anchor scan replaced
by "keep the row". The cases use `src/newname.lua` (deleted line: unified row **18** →
split before-pane row **17**) and `src/routes.lua`, and every round trip guards that the row
really changed before claiming the anchor survived it.

The window is 24 lines rather than `split_spec`'s 45: the fixture diff fits inside 45, so
nothing can scroll there and a centring assertion would pass with the `zz` deleted.

"Resets when Neovim exits" is a claim about what a *new* process starts with, so
`layout_child.lua` chooses the split layout and quits, and the spec — which has not toggled
anything yet, so its cases run first — opens a review and finds the configured layout. The
child also marks a file reviewed, or "nothing about the layout came back" would be satisfied
by nothing coming back at all.

## Mutation evidence

Each applied and reverted separately, against `layout_spec` (47–50 cases):

| Line removed / changed | Cases that go red |
| --- | --- |
| `session_layout = V.layout` in `toggle_layout` | 2 — *survives closing a review and opening another*; *survives opening a review in a different scope* |
| `row_carrying(rendered, anchor)` → the cursor's current row | 12 — every round trip, the filler fallback, the collapsed header, both tree cases, the dismissed-tree case, the queue-float case |
| `to_before = has_before() and belongs_to_before(anchor)` → `false` | 3 — *lands in the before pane*; *comes back to exactly the row it started on*; the dismissed-tree case |
| `"zz"` argument to `goto_row` | 1 — *the landing line is centred* |
| `attach_pane(buf)` in `show_before_pane` | 3 — *sits alongside the other view-level commands*; *carries the diff's keys again*; *annotates a deleted line from it, through the keys* (`E21: Cannot make changes, 'modifiable' is off` — the key was never bound) |
| the `in_panel and V.panel_win or` focus restore | 2 — both *toggling from the file tree* cases |
| the binding lift in `place` (`local bound = has_before()` → `false`) | 2 — *the landing line is centred*; *leaves both panes reading the same rows*. `split_spec` stays 76/0 under this mutation, which is why the case lives in the new spec |
| `place` iterating one pane instead of `panes()` | 5, including *a jump in a window shorter than the diff* |
| `vim.wo[V.win].scrollbind = false` in `hide_before_pane` | 1 — *lifts the binding from the window that is left* |

One mutation reds **nothing**: `balance_panes()` inside `toggle_layout`. A `vsplit` already
halves the window it splits and closing one half gives the columns back to the other, so the
call was dead and has been removed rather than left in as a line that measures nothing. The
width assertions stay, now measuring `vsplit`'s own behaviour, which is what the layout
relies on.