### PR TITLE
feat(view): read a file in the host's own diff tool

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -149,7 +149,8 @@ _Avoid_: consumer, client, user config
 
 **Adapter**:
 A function the host injects to supply a capability the plugin deliberately lacks — choosing
-a target, picking a file, delivering a batch, composing a note.
+a target, picking a file, delivering a batch, composing a note, reading a file in a diff
+tool of its own.
 _Avoid_: hook, callback, plugin, provider
 
 ### Staleness

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ that lists the batch, jumps to any entry with `<CR>`, drops, routes and submits.
 annotation that skips the queue. Staleness tracked by blob hash, so an annotation whose file
 moved is flagged rather than silently trusted.
 
-**Embedding** — [four adapters](#adapters): `send`, `pick_target`, `pick_file` and
-`compose`. None are required. With none of them wired the plugin still renders, annotates
-and queues, and the batch reaches the `+` register.
+**Embedding** — [five adapters](#adapters): `send`, `pick_target`, `pick_file`, `compose`
+and `open_diff`. None are required. With none of them wired the plugin still renders,
+annotates and queues, and the batch reaches the `+` register.
 
 ## Requirements
 
@@ -277,6 +277,7 @@ override a `layout` you had since changed.
 | `gp` | Show or hide the file tree |
 | `gl` | Switch between the unified and split layouts |
 | `<CR>` | Open the real file here, in a new tab |
+| `gd` | Read this file in your own diff tool — only bound with [`open_diff`](#adapters) wired |
 | `Q` | Review the queue |
 | `<C-t>` | Choose the delivery target |
 | `<C-s>` | Submit the batch |
@@ -306,6 +307,7 @@ cursor last was.
 | Key | Action |
 | --- | --- |
 | `<CR>` / `o` | Open the file, or fold the directory |
+| `gd` | Read the file under the cursor in your own diff tool — only bound with [`open_diff`](#adapters) wired |
 | `h` / `zc` | Collapse the directory — on a file, collapses its parent |
 | `l` / `zo` | Expand the directory |
 | `za` | Toggle the directory |
@@ -446,8 +448,8 @@ worth a look before we ship this
 
 ## Adapters
 
-The plugin has no opinion about where a review goes, or about which pickers you use. Four
-optional functions inject that:
+The plugin has no opinion about where a review goes, about which pickers you use, or about
+which diff tool you read a rewrite in. Five optional functions inject that:
 
 ```lua
 opts = {
@@ -482,8 +484,28 @@ opts = {
   -- the target *this note* will reach. Name it, and change it with `pick`. It is absent
   -- for a note joining the queue, which the batch routes.
   compose = function(ctx, on_accept, label) on_accept(nil, "text") end,
+
+  -- Read one file in the diff tool you already have — DiffviewOpen, :Gdiffsplit, your own
+  -- diffthis pair. The plugin ships none of that: it hands over the file and the two refs
+  -- its scope is between and stops caring. `path` is absolute and is the post-image path,
+  -- so for a rename the pre-image lives elsewhere in `before`. `after` is nil whenever the
+  -- post-image is the working tree — that is most scopes, and it is not an error: nil
+  -- means the file on disk. `line` is nil when the file was named from the file tree,
+  -- which knows a file and no position in it.
+  --
+  -- Bound to `gd` only while this is wired, in the diff and in the tree. A key that
+  -- silently did nothing would be worse than no key.
+  open_diff = function(spec)
+    local rev = spec.after and (spec.before .. ".." .. spec.after) or spec.before
+    vim.cmd(("DiffviewOpen %s -- %s"):format(rev, vim.fn.fnameescape(spec.path)))
+  end,
 }
 ```
+
+**You cannot annotate in whatever `open_diff` opens.** Nothing there has an anchor map, so
+it is a one-way trip: read the file closely, then come back to the review to say anything
+about it. It is for the rewrite that Neovim's own diff mode reads better than a unified
+diff does — a reformat, a re-indent, a file moved wholesale — not a second review surface.
 
 [ADR-0005](docs/adr/0005-a-send-reports-dispatch-not-arrival.md) records why "dispatched"
 is the narrow promise — the adapter most hosts wire is asynchronous, and holding the queue

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -67,6 +67,8 @@ Buffer-local, inside the review view:
     gp               Show or hide the file tree
     gl               Switch between the unified and split layouts
     <CR>             Open the real file here, in a new tab
+    gd               Read this file in the host's own diff tool --
+                     bound only with |codereview-opt-open_diff| wired
     Q                Review the queue
     <C-t>            Choose the delivery target
     <C-s>            Submit the batch
@@ -92,6 +94,8 @@ was. Jumping to a file that is collapsed because it is reviewed expands it.
 In the file tree:                                         *codereview-tree*
 
     <CR> o           Open the file, or fold the directory
+    gd               Read the file under the cursor in the host's own diff
+                     tool -- bound only with |codereview-opt-open_diff| wired
     h zc             Collapse the directory; on a file, its parent
     l zo             Expand the directory
     za               Toggle the directory
@@ -435,10 +439,11 @@ any other note you walked away from.
 ==============================================================================
 8. ADAPTERS                                            *codereview-adapters*
 
-The plugin has no opinion about where a review goes, or about which pickers
-you use. Four optional functions inject that. With none of them wired
-everything still works: the payload reaches the `+` register instead of an
-agent and the batch stays queued, and `@` in the composer stays a literal `@`.
+The plugin has no opinion about where a review goes, about which pickers you
+use, or about which diff tool you read a rewrite in. Five optional functions
+inject that. With none of them wired everything still works: the payload
+reaches the `+` register instead of an agent and the batch stays queued, `@`
+in the composer stays a literal `@`, and `gd` is not bound to anything.
 
 send({payload}, {target})                                *codereview-opt-send*
         Deliver the rendered batch. {target} is whatever `pick_target`
@@ -544,6 +549,45 @@ compose({ctx}, {on_accept}, {label})                  *codereview-opt-compose*
         recorded last -- and that stops being the annotation's window the
         moment the composer opens a picker of its own.
 
+open_diff({spec})                                   *codereview-opt-open_diff*
+        Read one file in whatever diff tool you already have -- Diffview,
+        `:Gdiffsplit`, your own `diffthis` pair. The plugin ships none of that
+        and keeps no opinion about it: it hands over the file and the two refs
+        the current scope is between and stops caring. >
+            open_diff = function(spec)
+              local rev = spec.after and (spec.before .. ".." .. spec.after)
+                or spec.before
+              vim.cmd(("DiffviewOpen %s -- %s"):format(rev, spec.path))
+            end,
+<
+        {spec} is: >
+            path    absolute path to the file, the post-image path -- for a
+                    rename the pre-image lives elsewhere in `before`
+            before  ref for the pre-image; ":0" means the index
+            after   ref for the post-image, or nil
+            line    line in the post-image, or nil
+<
+        `after` is nil for every scope whose post-image is the working tree,
+        which is most of them. That is not an error and there is no sentinel
+        for it: nil means the file on disk, which is what a diff tool would
+        have opened anyway.
+
+        `line` is the line |<CR>| would have opened the file at, deleted-line
+        fallback included -- a deleted line exists in no post-image, so it
+        resolves to the nearest preceding line that does. It is nil when the
+        file was named from the tree, which knows a file and no position in
+        it, and on a file or hunk header for the same reason.
+
+        Wiring this binds `gd` in the diff and in the tree; without it `gd`
+        is bound to nothing, because a key that silently did nothing would be
+        worse than no key.
+
+        You **cannot annotate** in whatever this opens. Nothing there has an
+        anchor map, so it is a one-way trip: read the file closely, come back
+        to the review to say anything about it. It is for the rewrite Neovim's
+        own diff mode reads better than a unified diff does -- a reformat, a
+        re-indent, a file moved wholesale -- not a second review surface.
+
 ==============================================================================
 9. CONFIGURATION                                  *codereview-configuration*
 
@@ -560,7 +604,8 @@ Defaults: >
         collapsed = "▸", expanded = "▾", change_bar = "▌",
       },
       types = nil,
-      send = nil, pick_target = nil, compose = nil,
+      send = nil, pick_target = nil, pick_file = nil,
+      compose = nil, open_diff = nil,
     })
 <
 `max_syntax_bytes` bounds the one operation with a real performance cliff.

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -1,10 +1,10 @@
 ---Configuration and adapter injection.
 ---
----The three adapters (`send`, `pick_target`, `compose`) are what keep this plugin
----distributable. With none of them wired it still renders, annotates and queues -- the
----payload just reaches the `+` register instead of an agent, and the batch stays queued
----because nothing consumed it. A host config injects its own Claude/herdr plumbing rather
----than the plugin hardcoding any.
+---The adapters (`send`, `pick_target`, `pick_file`, `compose`, `open_diff`) are what keep
+---this plugin distributable. With none of them wired it still renders, annotates and
+---queues -- the payload just reaches the `+` register instead of an agent, the batch stays
+---queued because nothing consumed it, and `gd` is bound to nothing. A host config injects
+---its own Claude/herdr plumbing rather than the plugin hardcoding any.
 local M = {}
 
 M.defaults = {
@@ -76,6 +76,21 @@ M.defaults = {
   ---absent for a note joining the queue, which is routed by the batch it joins.
   ---@type fun(ctx: table, on_accept: fun(target: table|nil, text: string), label: string)|nil
   compose = nil,
+  ---Read one file in whatever diff tool the host already has -- `DiffviewOpen`, a
+  ---`:Gdiffsplit`, its own `diffthis` pair. The plugin ships none of that and keeps no
+  ---opinion about it; it hands over the file and the two refs its scope is between.
+  ---
+  ---`path` is absolute, and the post-image path -- for a rename the pre-image lives
+  ---elsewhere in `before`. `after` is nil for the scopes whose post-image is the working
+  ---tree, which the adapter must handle: nil means "the file on disk", not an error.
+  ---`line` is nil when the file was named from the file tree, which knows a file and no
+  ---position in it.
+  ---
+  ---Bound to `gd` only while this is wired -- a key that silently did nothing would be
+  ---worse than no key. Nothing the host opens has an anchor map, so it is a read-only
+  ---detour: you cannot annotate in there.
+  ---@type fun(spec: { path: string, before: string, after: string|nil, line: integer|nil })|nil
+  open_diff = nil,
 }
 
 ---@type table

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -781,6 +781,52 @@ function M.open_file()
   vim.cmd("normal! zz")
 end
 
+---Hand a file and the refs its scope is between to the host's diff tool, and stop caring.
+---
+---The plugin ships no diff tool and keeps no opinion about which one this is, the same way
+---it keeps none about delivery (ADR-0001): everything the host needs to fetch either image
+---is in the spec, and what it does with them is its own. Nothing it opens has an anchor
+---map, so this is a read-only detour -- there is nowhere in there to annotate from.
+---@param file CRFile
+---@param line integer|nil nil when the caller knows a file but no position in it
+local function hand_to_diff(file, line)
+  local adapter = config.get().open_diff
+  if not adapter then
+    -- Reachable only when a host bound this itself: the view binds no key without an
+    -- adapter, precisely so that pressing one can never do nothing quietly.
+    warn("No open_diff adapter configured")
+    return
+  end
+  adapter({
+    -- Absolute, because the spec carries no root to read a relative path against. From
+    -- this the host can reach both the file and the repository it is in.
+    path = vim.fs.joinpath(V.root, file.path),
+    before = V.scope.before,
+    -- nil when the post-image is the working tree, which is most scopes. Not an error and
+    -- not worth a sentinel: nil says "the file on disk", which is what a diff tool would
+    -- have opened anyway.
+    after = V.scope.after,
+    line = line,
+  })
+end
+
+---`gd`: read the file under the cursor in the host's diff tool.
+---
+---At the line `<CR>` opens, deleted-line fallback and all -- one rule about where a diff
+---row lands in the post-image, not two. A row that names no line hands over none rather
+---than inventing line 1: a file header knows which file and nothing about where in it.
+function M.open_diff()
+  if not M.current() then
+    return
+  end
+  local anchor = anchor_at_cursor()
+  if not anchor then
+    return
+  end
+  local file = V.files[anchor.file]
+  hand_to_diff(file, anchor.kind == "line" and worktree_line(file, anchor) or nil)
+end
+
 --- Panel actions ---------------------------------------------------------------
 
 ---@return integer|nil file_index, string|nil dir_path, integer row
@@ -821,6 +867,21 @@ function M.panel_select()
   end
   vim.api.nvim_set_current_win(V.win)
   goto_row(V.render.file_rows[fi], "zt")
+end
+
+---`gd` in the tree: read the file under the cursor in the host's diff tool.
+---
+---With no line. The tree knows which file you are looking at and nothing about where in
+---it, and a row that is a directory names no file at all.
+function M.panel_open_diff()
+  if not M.current() then
+    return
+  end
+  local fi = panel_at_cursor()
+  if not fi then
+    return
+  end
+  hand_to_diff(V.files[fi], nil)
 end
 
 ---@param shut boolean|nil nil toggles
@@ -1361,6 +1422,14 @@ local function setup_main_keymaps(buf)
     ["<C-s>"] = { M.submit, "Submit the batch" },
     ["q"] = { M.close, "Close the review" },
   })
+
+  -- Only once the adapter is injected. Every adapter is nil by default, and a key that
+  -- silently does nothing is worse than no key at all -- it also keeps `gd` free for
+  -- whatever a host that wired no diff tool would rather have there. From the same `g`
+  -- family as the commands above, and clear of `gt`/`gT`.
+  if config.get().open_diff then
+    bind(buf, { ["gd"] = { M.open_diff, "Read this file in the host's diff tool" } })
+  end
 end
 
 local function setup_panel_keymaps()
@@ -1428,6 +1497,10 @@ local function setup_panel_keymaps()
     ["R"] = { M.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { M.close, "Close the review" },
   })
+
+  if config.get().open_diff then
+    bind(V.panel_buf, { ["gd"] = { M.panel_open_diff, "Read this file in the host's diff tool" } })
+  end
 end
 
 ---@param buf integer

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,6 +44,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
+| `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
 | `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, and the draft an undispatched immediate send leaves behind |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
@@ -64,7 +65,7 @@ interchangeable, and the assertions know which one they are looking at.
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
   `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `split_spec`,
-  `layout_spec` and `interactive_spec`. It already covers everything the split layout has
+  `layout_spec`, `open_diff_spec` and `interactive_spec`. It already covers everything the split layout has
   to render, including the files that exist on only one side and the additions between
   context lines that produce filler — so that slice needed no fixture of its own. The
   layout toggle needed none either: `src/main.lua`'s deletion and its replacement collapse

--- a/tests/codereview/open_diff_spec.lua
+++ b/tests/codereview/open_diff_spec.lua
@@ -1,0 +1,328 @@
+-- The `open_diff` adapter: what a host is handed, and whether the key exists at all.
+--
+-- The adapter is a stub here, as every adapter in this suite is -- the seam is the point,
+-- and there is no diff tool to drive. What is asserted is therefore what the adapter
+-- *receives*: the absolute path, the two refs the scope is between, and the line.
+--
+-- The two halves have to run in this order. Whether `gd` is bound is decided when a review
+-- opens, from whether the adapter is configured, so "nothing is bound" can only be asserted
+-- by a process that has not yet injected one.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+local view = require("codereview.view")
+
+local root = assert(vim.uv.fs_realpath(fixture))
+
+---Normal-mode mappings bound to a buffer, as a set.
+---
+---Through `vim.keycode` on both sides: the API reports a key in its own notation rather
+---than the one it was bound with, so comparing the strings as written can silently never
+---match.
+---@param buf integer
+---@return table<string, boolean>
+local function bound(buf)
+  local lhs = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+    lhs[vim.keycode(m.lhs)] = true
+  end
+  return lhs
+end
+
+---@return CRView
+local function current()
+  return assert(view.current(), "no review view open")
+end
+
+---@param path string
+---@param pred fun(anchor: table): boolean
+---@return integer
+local function row_of(path, pred)
+  return assert(h.row_of(current(), path, pred), "no such row for " .. path)
+end
+
+---@param path string
+---@return integer
+local function index_of(path)
+  return assert(h.file_index(current(), path), path .. " is not in this scope")
+end
+
+--- With nothing injected -------------------------------------------------------
+
+require("codereview").setup({ syntax = false })
+
+describe("with no open_diff adapter wired", function()
+  view.open("branch")
+  local V = current()
+
+  -- A key that silently does nothing is worse than no key: a reviewer who presses it
+  -- learns nothing, and `gd` stays free for whatever else the host wants it for.
+  it("binds nothing to gd, in the diff or in the tree", function()
+    assert.is_nil(bound(V.buf)[vim.keycode("gd")], "gd is bound in the diff")
+    assert.is_nil(bound(assert(V.panel_buf))[vim.keycode("gd")], "gd is bound in the tree")
+  end)
+
+  it("leaves the keys it sits beside alone", function()
+    assert.is_true(bound(V.buf)[vim.keycode("gl")] == true)
+    assert.is_true(bound(V.buf)[vim.keycode("gp")] == true)
+  end)
+
+  -- The action is exported, so a host can bind it itself. On that path the same silence
+  -- would be the same defect, so it says what is missing instead.
+  it("says what is missing when the action is called anyway", function()
+    local msgs, restore = h.capture_notify()
+    view.open_diff()
+    restore()
+    assert.is_true(h.notified(msgs, "open_diff"), "nothing said that the adapter is absent")
+  end)
+
+  view.close()
+end)
+
+--- With one injected -----------------------------------------------------------
+
+---@type table[]
+local handed = {}
+
+require("codereview").setup({
+  syntax = false,
+  open_diff = function(spec)
+    handed[#handed + 1] = spec
+  end,
+})
+
+---The one spec the adapter was handed since the last call, and nothing else.
+---@return table
+local function only()
+  assert.same(1, #handed)
+  return handed[1]
+end
+
+local function reset()
+  handed = {}
+end
+
+view.open("branch")
+
+describe("the keystroke", function()
+  local V = current()
+
+  it("is bound in the diff and in the tree once the adapter is there", function()
+    assert.is_true(bound(V.buf)[vim.keycode("gd")] == true, "gd is not bound in the diff")
+    assert.is_true(bound(assert(V.panel_buf))[vim.keycode("gd")] == true, "gd is not bound in the tree")
+  end)
+
+  -- Opening a file from the review is a new tab, and `gt`/`gT` are how a reviewer comes
+  -- back from it. Nothing added here may take them.
+  it("shadows neither of the tab-switching keys", function()
+    for _, buf in ipairs({ V.buf, assert(V.panel_buf) }) do
+      assert.is_nil(bound(buf)[vim.keycode("gt")], "gt is shadowed")
+      assert.is_nil(bound(buf)[vim.keycode("gT")], "gT is shadowed")
+    end
+  end)
+
+  it("reaches the adapter when it is actually pressed", function()
+    reset()
+    local V2 = current()
+    vim.api.nvim_set_current_win(V2.win)
+    vim.api.nvim_win_set_cursor(V2.win, {
+      row_of("src/fresh.lua", function(a)
+        return a.kind == "line"
+      end),
+      0,
+    })
+    h.feed("gd")
+    assert.same("src/fresh.lua", only().path:sub(#root + 2))
+  end)
+end)
+
+--- What the adapter receives ---------------------------------------------------
+
+describe("a scope whose post-image is the working tree", function()
+  local base = h.git_lines(root, { "merge-base", "master", "HEAD" })[1]
+
+  before_each(reset)
+
+  it("hands over an absolute path and the ref the scope is against", function()
+    vim.api.nvim_set_current_win(current().win)
+    vim.api.nvim_win_set_cursor(current().win, {
+      row_of("src/fresh.lua", function(a)
+        return a.kind == "line"
+      end),
+      0,
+    })
+    view.open_diff()
+    local spec = only()
+    assert.same(vim.fs.joinpath(root, "src/fresh.lua"), spec.path)
+    assert.same(base, spec.before)
+  end)
+
+  -- Not an error and not worth a sentinel: nil says the post-image is the file on disk,
+  -- which is exactly what a diff tool would open anyway.
+  it("says the post-image is the working tree with nil, not a sentinel", function()
+    vim.api.nvim_win_set_cursor(current().win, {
+      row_of("src/fresh.lua", function(a)
+        return a.kind == "line"
+      end),
+      0,
+    })
+    view.open_diff()
+    assert.is_nil(only().after)
+  end)
+
+  it("passes the post-image line the cursor is on", function()
+    vim.api.nvim_win_set_cursor(current().win, {
+      row_of("src/main.lua", function(a)
+        return a.kind == "line" and a.line == 3
+      end),
+      0,
+    })
+    view.open_diff()
+    assert.same(2, only().line)
+  end)
+
+  -- The rule `<CR>` already uses, reused rather than written a second time: a deletion
+  -- exists in no post-image, so it resolves to the nearest preceding line that does --
+  -- line 1 here, not the 2 the deleted line held in the pre-image.
+  it("resolves a deleted line to the nearest preceding line that exists", function()
+    vim.api.nvim_win_set_cursor(current().win, {
+      row_of("src/main.lua", function(a)
+        return a.kind == "line" and a.line == 2
+      end),
+      0,
+    })
+    view.open_diff()
+    assert.same(1, only().line)
+  end)
+
+  -- A file header knows which file, and nothing about where in it.
+  it("passes no line from a file header", function()
+    vim.api.nvim_win_set_cursor(current().win, { current().render.file_rows[index_of("src/main.lua")], 0 })
+    view.open_diff()
+    assert.is_nil(only().line)
+  end)
+end)
+
+describe("a scope whose post-image is a ref", function()
+  before_each(reset)
+
+  it("hands over both refs", function()
+    view.set_scope("staged")
+    vim.api.nvim_set_current_win(current().win)
+    vim.api.nvim_win_set_cursor(current().win, {
+      row_of("src/routes.lua", function(a)
+        return a.kind == "line"
+      end),
+      0,
+    })
+    view.open_diff()
+    local spec = only()
+    assert.same({ "HEAD", ":0" }, { spec.before, spec.after })
+    assert.same(vim.fs.joinpath(root, "src/routes.lua"), spec.path)
+  end)
+
+  view.set_scope("branch")
+end)
+
+--- From the tree ---------------------------------------------------------------
+
+describe("from the file tree", function()
+  before_each(reset)
+
+  ---Put the tree's cursor on a file's row and take focus there.
+  ---@param path string
+  local function on_tree_row(path)
+    local V = current()
+    local win = assert(V.panel_win, "the tree is not showing")
+    local want = index_of(path)
+    for row, fi in pairs(assert(V.panel_render).row_file) do
+      if fi == want then
+        vim.api.nvim_set_current_win(win)
+        vim.api.nvim_win_set_cursor(win, { row, 0 })
+        return
+      end
+    end
+    error("no tree row for " .. path)
+  end
+
+  -- The tree knows a file, not a position, so there is no line to invent.
+  it("hands over the file with no line", function()
+    on_tree_row("src/main.lua")
+    h.feed("gd")
+    local spec = only()
+    assert.same(vim.fs.joinpath(root, "src/main.lua"), spec.path)
+    assert.is_nil(spec.line)
+  end)
+
+  it("does nothing on a directory row", function()
+    local V = current()
+    local win = assert(V.panel_win, "the tree is not showing")
+    local dir_row
+    for row, dir in pairs(assert(V.panel_render).row_dir) do
+      if dir then
+        dir_row = row
+        break
+      end
+    end
+    vim.api.nvim_set_current_win(win)
+    vim.api.nvim_win_set_cursor(win, { assert(dir_row, "the tree has no directory row"), 0 })
+    h.feed("gd")
+    assert.same(0, #handed)
+  end)
+end)
+
+--- In the split layout ---------------------------------------------------------
+
+-- Last, because toggling the layout is remembered for the rest of the session.
+describe("in the split layout", function()
+  before_each(reset)
+
+  ---Row in a pane holding a diff line of `path` on the given side.
+  ---@param rendered CRRender
+  ---@param path string
+  ---@param side "add"|"del"
+  ---@return integer
+  local function side_row(rendered, path, side)
+    local V = current()
+    for row = 1, #rendered.lines do
+      local a = rendered.anchors[row]
+      if a and a.kind == "line" and V.files[a.file].path == path then
+        if V.files[a.file].hunks[a.hunk].lines[a.line].side == side then
+          return row
+        end
+      end
+    end
+    error(("no %s line for %s"):format(side, path))
+  end
+
+  vim.api.nvim_set_current_win(current().win)
+  view.toggle_layout()
+
+  it("is bound in the before pane too", function()
+    assert.is_true(bound(assert(current().before_buf))[vim.keycode("gd")] == true)
+  end)
+
+  -- `src/main.lua`'s deletion and its replacement collapse onto one row here, so the two
+  -- panes genuinely disagree about that row: the before pane holds the deleted line and
+  -- the after pane the line that replaced it. Which pane has focus is the whole answer.
+  it("resolves from the pane that has focus", function()
+    local V = current()
+    local after_row = side_row(V.render, "src/main.lua", "add")
+    local before_row = side_row(assert(V.before_render), "src/main.lua", "del")
+    assert.same(after_row, before_row, "the two panes do not share the row this case is about")
+
+    vim.api.nvim_set_current_win(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { after_row, 0 })
+    view.open_diff()
+    assert.same(2, only().line)
+
+    reset()
+    local before_win = assert(V.before_win, "there is no before pane")
+    vim.api.nvim_set_current_win(before_win)
+    vim.api.nvim_win_set_cursor(before_win, { before_row, 0 })
+    view.open_diff()
+    assert.same(1, only().line)
+  end)
+end)


### PR DESCRIPTION
Closes #50

A fifth optional adapter, `open_diff`, letting a host open one file in whatever diff tool it
already has — `DiffviewOpen`, `:Gdiffsplit`, its own `diffthis` pair. The plugin ships none of
that and keeps having no opinion about it: it hands over the path and the two refs the current
scope is between and stops caring, the same seam delivery has (ADR-0001).

```lua
---@type fun(spec: { path: string, before: string, after: string|nil, line: integer|nil })|nil
open_diff = nil,
```

**Bound to `gd`, and only while the adapter is wired** — in the diff and in the tree. Every
adapter here is nil by default, and a key that silently does nothing is worse than no key. It
joins the `g` family the other view-level commands use (`gs`, `gr`, `gp`, `gl`) and takes
neither `gt` nor `gT`, which are how a reviewer comes back from what `<CR>` opened.

**`after` is nil wherever the post-image is the working tree** — most scopes. Not an error and
no sentinel stands in for it: nil already says "the file on disk".

**The line is the one `<CR>` already computes**, deleted-line fallback included, rather than a
second rule about where a diff row lands in the post-image. A row that names no position — a
file header, or a file named from the tree — hands over none rather than inventing line 1.

**You cannot annotate in whatever the host opens.** Nothing there has an anchor map, so it is a
one-way trip to read a file closely and come back. Said plainly in both the README and the
reference rather than left to be discovered.

## Red first

`tests/codereview/open_diff_spec.lua` was written and run before any of `lua/` moved: **13 of
its 16 cases failed**, twelve on `attempt to call field 'open_diff' (a nil value)` or `gd is
not bound`. The three that passed are the negative half — nothing was bound to `gd`, which is
what the absent-adapter side asserts and had to keep asserting afterwards.

Observed after: **805 cases, 0 failures** (789 on `master` here, +16). Lint clean.

Each of the three decisions was then mutation-checked, one failing case each:

| Mutation | Case that failed |
| --- | --- |
| bind `gd` unconditionally | `with no open_diff adapter wired binds nothing to gd, in the diff or in the tree` |
| always pass `worktree_line`, never nil | `passes no line from a file header` |
| `after = V.scope.after or "WORKTREE"` | `says the post-image is the working tree with nil, not a sentinel` |

What the adapter receives is asserted across both kinds of scope — `staged`, whose post-image
is the ref `:0`, and `branch`, whose post-image is the working tree — from both panes of the
split layout and from the file tree. The split case starts on the row where `src/main.lua`'s
deletion and its replacement collapse onto one, so the panes genuinely disagree about it: line
1 from the before pane, line 2 from the after pane, and focus is the whole answer.