### PR TITLE
docs(map): give the module directory an index that arrives unasked

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -9,9 +9,9 @@ This repo is **single-context**: one `CONTEXT.md` and one `docs/adr/` at the rep
 - **`CONTEXT.md`** at the repo root — the domain glossary.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+Both exist, and `docs/adr/` holds several ADRs. Read the ones touching your area rather than assuming the decision is still open.
 
-Neither file exists yet — that is the expected starting state.
+The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) adds to them lazily, as terms and decisions actually get resolved.
 
 ## File structure
 

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -1,0 +1,79 @@
+# `lua/codereview/`
+
+What each module owns, and the three things their headers cannot say from inside: how they
+stack, where the one cycle is, and which of them are settled.
+
+Every module opens with a docstring that says more than its row here does. The rows are for
+choosing which of those to read — not for skipping them.
+
+## Modules
+
+`pure` means data in, data out: no buffers, no windows, no git. `stateful` carries what a
+change there is felt through.
+
+| Module | Owns | |
+| --- | --- | --- |
+| `annotate.lua` | The review path: cursor to entry, the deleted-line and hunk inlining rules, drop, grouping | stateful (queue, view) |
+| `capture.lua` | The capture path: the same entry from an ordinary buffer, no review view involved | stateful (queue, buffer) |
+| `composer.lua` | The shipped composer and its `@` reference picker — the default `compose` adapter, not a lesser one | stateful (float) |
+| `config.lua` | `setup()`, the defaults, and the injected adapters: `send`, `pick_target`, `pick_file`, `compose`, `open_diff` | stateful (options) |
+| `delivery.lua` | Where a batch is going, how that is chosen, and the submit that empties the queue only on dispatch | stateful (target, queue) |
+| `diff.lua` | Unified-diff parsing, and the intra-line spans within a paired line | pure |
+| `drafts.lua` | Note text abandoned in a composer, keyed by absolute path, in a store of its own | stateful (disk) |
+| `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes | stateful (git) |
+| `hl.lua` | The highlight groups, all `default = true` links into whatever colorscheme is active | stateful (editor) |
+| `init.lua` | The public surface a host reaches: `setup`, the user commands, `annotate(type)` | stateful (setup) |
+| `panel.lua` | The file tree: build, chain compaction, folding, per-directory tallies | pure |
+| `payload.lua` | The queue rendered as the message an agent receives; `@ref`s resolved at submit time | pure |
+| `queue.lua` | The queue itself — module-level, not per-view, so reopening a view scatters nothing | stateful (memory) |
+| `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk | pure |
+| `state.lua` | Persisted review progress, and the blob-hash check that makes persisting safe | stateful (disk) |
+| `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
+| `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
+| `view.lua` | The review view: buffers, windows, keymaps, navigation, both layouts, the queue float | stateful (windows) |
+
+## How they stack
+
+- **Require nothing**: `diff`, `drafts`, `panel`, `queue`, `types`.
+- **Above them**, in that order: `git`, `payload`, `render`; then `state`, `config`; then
+  `delivery`, `syntax`; then `composer`, `hl`.
+- **The hubs**: `view` requires twelve of the modules above, `annotate` nine. A change that
+  is not local to a leaf almost certainly reaches one of them.
+- **On top**: `capture`, then `init`.
+
+## The one cycle
+
+`view` and `annotate` require each other. This is known and accepted — not a defect to fix
+in passing. `annotate` needs the focused pane, the current view, the repaint and the anchor
+under the cursor, which are genuine dependencies, and both sides use a function-local
+`require`, so Lua resolves it lazily and nothing loads at file scope before it is ready.
+Forcing the two apart costs more than it returns.
+
+## Where reading pays
+
+- **Settled**, one to three commits each: `panel`, `drafts`, `diff`, `git`, `syntax`,
+  `render`, `hl`. Read one when you need it, not to orient yourself.
+- **Carries the churn**: `view` and `annotate` by a wide margin, then `config`, `composer`
+  and `state`.
+
+Re-derive with `git log --oneline --follow -- lua/codereview/<name>.lua` before leaning on
+that grouping; it moves.
+
+## One hop away
+
+- [`CONTEXT.md`](../../CONTEXT.md) — the vocabulary, including the terms this project
+  deliberately avoids and why. Use its words.
+- [`docs/adr/`](../../docs/adr/) — the decisions. Contradicting one is allowed; doing it
+  silently is not.
+- [`docs/design-notes.md`](../../docs/design-notes.md) — the traps, grouped by subsystem.
+  Read the group before changing rendering, diff parsing, blob hashing, references, or
+  anything touching windows and modes. Several obvious-looking approaches here are wrong
+  for reasons the code does not reveal.
+- [`tests/README.md`](../../tests/README.md) — what each spec pins down, and a long list of
+  ways a test here can pass while measuring nothing.
+
+## This file is pinned
+
+`tests/codereview/map_spec.lua` asserts that every module above has a row and that no row
+names a module that is gone. Prose is not checked and cannot be; terseness is what keeps it
+true. Add a module, add a row.

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,6 +55,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
 | `queue_jump_panel_spec` | That jump with the tree dismissed, summoned, and never there — the one surface neither slice could test alone |
 | `interactive_spec` | The insert-mode leak, and where a completed or cancelled `@` leaves you, in a real pty-backed Neovim |
+| `map_spec` | That `lua/codereview/CLAUDE.md` lists exactly the modules that exist — the only part of the map a machine can check |
 
 ## Fixtures
 
@@ -232,6 +233,11 @@ so the out-of-core language path is still checked locally without ever failing C
   remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless
   version of that test passes whether or not the fix exists, which is why it drives a pty.
+- **A set comparison passes when one set was never read.** `map_spec` matches the module
+  map's rows with a pattern over the table's first column, so reformatting that column —
+  dropping the backticks, say — silently yields no rows, and "no row names a module that is
+  gone" then holds over nothing. It asserts both sides are non-empty before comparing them,
+  which is the only reason that reformatting reds two cases instead of one.
 
 ## Deliberately not covered
 

--- a/tests/codereview/map_spec.lua
+++ b/tests/codereview/map_spec.lua
@@ -1,0 +1,74 @@
+-- The module map lists exactly the modules that exist.
+--
+-- `lua/codereview/CLAUDE.md` is loaded automatically for work in that directory, so it is
+-- read without being asked for -- which is why a stale row costs more here than in a
+-- document someone chose to open. `docs/agents/domain.md` announced that `CONTEXT.md` and
+-- `docs/adr/` did not exist yet, long after both did, and nothing noticed. That is the
+-- drift this pins.
+--
+-- Only the row set is checked, in both directions: a module with no row, and a row naming
+-- a module that is gone. Prose accuracy is not machine-checkable and is not attempted --
+-- the map stays terse so that keeping it true by hand is cheap.
+local h = require("tests.helpers")
+
+local dir = vim.fs.joinpath(h.root, "lua", "codereview")
+local map = vim.fs.joinpath(dir, "CLAUDE.md")
+
+---Every module in `lua/codereview/`, by name, without the extension.
+---@return string[]
+local function modules()
+  local names = {}
+  for entry, kind in vim.fs.dir(dir) do
+    local name = kind ~= "directory" and entry:match("^(.+)%.lua$")
+    if name then
+      names[#names + 1] = name
+    end
+  end
+  table.sort(names)
+  return names
+end
+
+---Every module named in the first column of the map's table.
+---@return string[]
+local function rows()
+  local names = {}
+  for _, line in ipairs(vim.fn.readfile(map)) do
+    local name = line:match("^|%s*`([%w_]+)%.lua`%s*|")
+    if name then
+      names[#names + 1] = name
+    end
+  end
+  table.sort(names)
+  return names
+end
+
+---@param subject string[]
+---@param allowed string[]
+---@return string[]
+local function missing_from(subject, allowed)
+  local index = {}
+  for _, name in ipairs(allowed) do
+    index[name] = true
+  end
+  return vim.tbl_filter(function(name)
+    return not index[name]
+  end, subject)
+end
+
+describe("the module map", function()
+  -- Both cases below compare one set against another, and everything is present in a set
+  -- that was never read. A row pattern that quietly stopped matching would leave "no row
+  -- names a module that is gone" passing with no rows at all.
+  it("has both sides to compare", function()
+    assert.is_true(#modules() > 0)
+    assert.is_true(#rows() > 0)
+  end)
+
+  it("carries a row for every module", function()
+    assert.same({}, missing_from(modules(), rows()))
+  end)
+
+  it("names no module that does not exist", function()
+    assert.same({}, missing_from(rows(), modules()))
+  end)
+end)


### PR DESCRIPTION
An agent working in `lua/codereview/` cannot cheaply answer the question it always has
first: *what must I read to change this correctly?* The eighteen modules are a flat list of
filenames. This adds the index.

## What lands

**`lua/codereview/CLAUDE.md`** — one row per module: what it owns, and whether it is pure
(data in, data out — no buffers, windows or git) or stateful, with what a change there is
felt through. Assembled from the docstrings each module already opens with, not written
afresh: that material is ~2,400 tokens against ~70,300 of source, and the waste was never
missing information, only that obtaining it cost eighteen reads.

It sits in the module directory rather than being pointed at from the root `CLAUDE.md`,
because a map that has to be discovered still costs the hop this removes. The trade-off —
a Claude-specific delivery mechanism where `docs/agents/` is tool-agnostic — is the one the
PRD accepted deliberately.

Then the three things no header can say from inside, verified against this tree rather than
carried over from the PRD:

- **The layering.** `diff`, `drafts`, `panel`, `queue` and `types` require nothing; a middle
  tier sits above them; `view` and `annotate` are the hubs, requiring twelve and nine.
- **The one cycle**, `view` ↔ `annotate`, recorded as known and accepted — both sides use a
  function-local `require`, and the note says not to break it in passing.
- **Stability.** Seven modules have changed in one to three commits and are settled;
  `view` and `annotate` carry the churn, then `config`, `composer` and `state`. The command
  to re-derive it is given, since the grouping moves.

It points at `CONTEXT.md`, `docs/adr/`, `docs/design-notes.md` and `tests/README.md`.

**`tests/codereview/map_spec.lua`** — the map's rows and the directory must name the same
modules, in both directions. Prose accuracy is not machine-checkable and is not attempted.

**`docs/agents/domain.md`** — corrected. It claimed `CONTEXT.md` and `docs/adr/` did not
exist yet; both do, alongside five ADRs. That is the local proof that a document describing
this tree rots, and it is why the map is pinned at all.

## The spec was checked for teeth

Three deliberate breakages, each reverted:

| Break | Result |
| --- | --- |
| A module added with no row | `carries a row for every module` red |
| A row naming a module that is gone | `names no module that does not exist` red, naming it |
| The table's first column reformatted so no rows parse | the non-empty guard and the row check both red |

That third one is why the guard case exists: with no rows parsed, `names no module that
does not exist` passes over an empty set. It is noted in `tests/README.md`'s "Things that
bite" for the next person who reformats the table.

`make all`: 857 passing, 0 failures, 0 errors. No module source is modified and no existing
spec was edited.

Closes #79