### PR TITLE
test(perf): report the keystroke cost, and at 300 files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ make test                                            # the whole suite
 make test-file FILE=tests/codereview/diff_spec.lua   # one spec, in-process
 make lint                                            # stylua --check
 make format                                          # stylua, in place
-make perf                                            # open-time report, not part of CI
+make perf                                            # timing report at two sizes, not part of CI
 ```
 
 New behaviour needs a spec. [`tests/README.md`](tests/README.md) covers the layout, the

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ lint:
 format:
 	@stylua lua/ tests/
 
-## perf  -- open-time report on a 60-file diff. Not part of `make test`.
+## perf  -- open, scroll, keystroke and repaint timings at 60 files and at 300. Only the
+## 60-file open is budgeted; the larger tier reports. Not part of `make test`.
 perf:
 	@$(NVIM) --headless -u NONE -l tests/perf.lua
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ make deps                                             # clone plenary into .test
 make test                                             # the whole suite
 make test-file FILE=tests/codereview/diff_spec.lua    # one spec, in-process
 make lint                                             # stylua --check
-make perf                                             # open-time report, not a gate
+make perf                                             # timing report at two sizes, not a gate
 ```
 
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
@@ -30,7 +30,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
-| `perf.lua` | Open-time report on a 60-file diff, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
+| `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
 
 | Spec | Covers |
 | --- | --- |
@@ -76,7 +76,11 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec`, `focus_spec` and `queue_jump_panel_spec`.
-- **`mkbig.sh`** — 60 files, 12k changed lines, for `perf.lua` only.
+- **`mkbig.sh`** — files of a given size, half of every file rewritten, for `perf.lua` only.
+  It takes counts as well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and
+  200), which is what lets the report measure two sizes without a second script: it builds a
+  60-file, 12k-line repository and a 300-file, 60k-line one, per run, in a temporary
+  directory. Neither is committed.
 
 The sources are Lua and Markdown rather than TypeScript because Neovim core ships both
 parsers **and** their `highlights` queries. `syntax_spec` therefore exercises the real
@@ -152,6 +156,13 @@ so the out-of-core language path is still checked locally without ever failing C
   whatever changed the width has returned — and in a headless spec, which never pumps the
   loop, it does not land at all. Anything that changes a window's width has to repaint for
   itself; the resize autocmd is for the reviewer dragging a border, nothing else.
+- **Moving the cursor from a script does not fire `CursorMoved`.** Neither
+  `nvim_win_set_cursor` nor a `normal! j` inside `nvim_win_call` raises it under `nvim -l` —
+  measured rather than assumed, the same way `scrollbind` was. So anything claiming to cost
+  what a keystroke costs has to dispatch the event itself: `perf.lua` moves the cursor and
+  then calls `nvim_exec_autocmds("CursorMoved", { buffer = … })`, which runs the review
+  buffer's own autocommand. Timing the move alone reports microseconds and misses every
+  millisecond the reviewer actually pays.
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.
@@ -250,6 +261,7 @@ so the out-of-core language path is still checked locally without ever failing C
   `scrollopt` is global, and the plugin deliberately does not set it. What *is* covered is
   that it stays untouched.
 - **Timing and wall clock.** `perf.lua` reports numbers and fails only past a deliberately
-  loose ceiling. It is a report you read, not a gate; it is not in CI, where a shared
-  runner would make it noise.
+  loose ceiling, and only at 60 files: the 300-file tier reports and cannot fail the
+  command, because a second ceiling would be a second figure to tune per machine. It is a
+  report you read, not a gate; it is not in CI, where a shared runner would make it noise.
 - **Windows.** The fixture scripts are bash and the suite assumes POSIX paths.

--- a/tests/fixtures/mkbig.sh
+++ b/tests/fixtures/mkbig.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 # Rebuild the large fixture repo used by tests/perf.lua.
 #
-# 60 files of 200 lines, with half of every file rewritten on the feature branch: roughly
-# 12k rendered rows once headers and context are counted. Sized to be the shape that
-# actually hurt -- a review big enough that parsing every file up front is a second of
-# latency on open.
+# 60 files of 200 lines by default, with half of every file rewritten on the feature
+# branch: roughly 12k rendered rows once headers and context are counted. Sized to be the
+# shape that actually hurt -- a review big enough that parsing every file up front is a
+# second of latency on open.
+#
+# Both counts are arguments because one size cannot show everything: every cost in the
+# review view is linear in the size of the diff, so `perf.lua` asks for this same shape at
+# 60 files and again at 300, where a keystroke and a repaint are large enough to read a
+# change from.
 set -e
 # Hermetic: no user or system git config. Without this the fixture inherits things that
 # change what it is (commit.gpgsign, diff.renames, core.autocrlf, hooks) -- gpg signing in
 # particular fails outright on a machine with no key, which is every CI runner.
 export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
-R="${1:?usage: mkbig.sh <path>}"
+R="${1:?usage: mkbig.sh <path> [files] [lines]}"
 FILES="${2:-60}"
 LINES="${3:-200}"
 rm -rf "$R"; mkdir -p "$R"; cd "$R"

--- a/tests/perf.lua
+++ b/tests/perf.lua
@@ -1,34 +1,60 @@
--- Open-time budget on a large review. Deliberately NOT part of `make test`.
+-- Open-time and per-keystroke report on a large review. Deliberately NOT part of `make test`.
 --
 -- Wall-clock numbers are machine-dependent, so this is a report you read rather than an
--- assertion you trust. The ceiling below is loose on purpose: it catches a regression that
--- changes the shape of the work (parsing every file up front, hashing blobs one at a
+-- assertion you trust. The one ceiling here is loose on purpose: it catches a regression
+-- that changes the shape of the work (parsing every file up front, hashing blobs one at a
 -- time), not the ordinary spread between a laptop and a CI runner.
 --
 -- Run with:  make perf
 --
--- Two things keep opening a 60-file review fast: syntax harvesting bounded by the
--- viewport, and batched blob hashing. If this regresses, suspect one of those two. The
--- third cost is the character-level spans, reported separately at the bottom because they
--- are paid once per git read and must never appear in the repaint line.
+-- Two tiers, because every cost here is linear in the size of the review and the small one
+-- hides them. 60 files is the size the budget has always watched and the only tier that can
+-- fail this command; at 300 files the same operations are large enough to read a change
+-- from. The larger tier reports and never asserts: a second budget would be a second number
+-- to tune per machine, on a file that is read rather than gated.
+--
+-- The line to read first is `cursor move`. It is the body of the autocommand that fires on
+-- every CursorMoved, which a reviewer pays per row while holding `j` -- unlike open, scroll
+-- and repaint, which are paid at moments a reviewer expects to wait.
+--
+-- Two things keep opening a review fast: syntax harvesting bounded by the viewport, and
+-- batched blob hashing. If open regresses, suspect one of those two. The third cost is the
+-- character-level spans, reported at the foot of each tier because they are paid once per
+-- git read and must never appear in the repaint line.
 local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
 vim.opt.runtimepath:prepend(root)
 
 vim.o.columns = 140
 vim.o.lines = 50
 
--- A five-fold regression fails; ordinary machine variance does not.
+-- A five-fold regression fails; ordinary machine variance does not. The 60-file tier only:
+-- see the header for why the larger one carries no ceiling.
 local BUDGET_MS = tonumber(vim.env.CODEREVIEW_PERF_BUDGET_MS) or 2000
 
-local fixture = vim.env.BIG
-if not fixture or fixture == "" then
-  fixture = vim.fn.tempname() .. "-big"
-  local sh = vim.fs.joinpath(root, "tests", "fixtures", "mkbig.sh")
-  local res = vim.system({ "bash", sh, fixture }, { text = true }):wait(120000)
+-- Held down rather than tapped: one move is too short to time against a millisecond clock,
+-- and fifty rows is roughly what leaning on `j` through a hunk costs a reviewer.
+local MOVES = 50
+
+local MKBIG = vim.fs.joinpath(root, "tests", "fixtures", "mkbig.sh")
+
+---Build one tier's fixture repository and answer with its path.
+---
+---Built per run rather than taken from the environment: `mkbig.sh` already takes the file
+---and line counts, so each tier asks it for its own size, and a single pre-built path could
+---only ever be one of the two. It costs about half a second per tier.
+---@param files integer
+---@param lines integer
+---@return string path
+local function build(files, lines)
+  local path = ("%s-big-%dx%d"):format(vim.fn.tempname(), files, lines)
+  local res = vim.system({ "bash", MKBIG, path, tostring(files), tostring(lines) }, { text = true }):wait(120000)
   assert(res.code == 0, res.stderr)
-  io.write(res.stdout)
+  -- Through `print`, which `nvim -l` sends to stderr, rather than writing the script's own
+  -- stdout: the whole report then arrives on one stream and stays in order however it is
+  -- redirected.
+  print(vim.trim(res.stdout))
+  return path
 end
-vim.cmd("cd " .. vim.fn.fnameescape(fixture))
 
 local function ms(fn)
   local t0 = vim.uv.hrtime()
@@ -50,65 +76,125 @@ local function syntax_marks(buf)
   end, vim.api.nvim_buf_get_extmarks(buf, NS, 0, -1, { details = true }))
 end
 
-local open_ms = ms(function()
-  view.open("branch")
-end)
-local V = view.current()
-
-print(("open:            %6.0f ms   (budget %d ms)"):format(open_ms, BUDGET_MS))
-print(("  rows           %6d"):format(#V.render.lines))
-print(("  files parsed   %6d / %d"):format(vim.tbl_count(V.syntax_painted), #V.files))
-print(("  syntax marks   %6d"):format(syntax_marks(V.buf)))
-
--- Scroll to the bottom: files there must get parsed on demand, not up front.
-print(("scroll to end:   %6.0f ms"):format(ms(function()
-  vim.api.nvim_win_set_cursor(V.win, { #V.render.lines, 0 })
-  vim.api.nvim_win_call(V.win, function()
-    vim.cmd("normal! zz")
-  end)
-  syntax.apply(V, NS)
-end)))
-print(("  files parsed   %6d / %d"):format(vim.tbl_count(V.syntax_painted), #V.files))
-
-print(("scroll back:     %6.0f ms   (cached)"):format(ms(function()
+---Time the work one `CursorMoved` does, averaged over a held-down key.
+---
+---The event is dispatched rather than provoked: neither `nvim_win_set_cursor` nor a
+---`normal! j` raises `CursorMoved` in a headless `nvim -l` -- measured, not assumed -- so a
+---report that only moved the cursor would time the move and none of the work. Dispatching
+---runs the review buffer's own autocommand, so this is the whole body a reviewer pays for
+---(the syntax pass and the tree sync together), not a stand-in for it.
+---
+---Warmed first, because the file under the cursor is parsed by the first pass after a
+---paint, and that one-off parse is not what a keystroke costs. The moves stay inside that
+---file for the same reason.
+---@param V CRView
+---@return number total_ms
+local function cursor_moves(V)
   vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
-  vim.api.nvim_win_call(V.win, function()
-    vim.cmd("normal! zz")
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+  return ms(function()
+    for i = 1, MOVES do
+      vim.api.nvim_win_set_cursor(V.win, { 1 + i, 0 })
+      vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+    end
   end)
-  syntax.apply(V, NS)
-end)))
+end
 
-print(("repaint:         %6.0f ms"):format(ms(function()
-  view.paint()
-end)))
+---Report one tier, and answer with the figures the two tiers are compared on.
+---@param files integer
+---@param lines integer
+---@param budget_ms integer|nil the ceiling this tier is judged against; nil means it only reports
+---@return { open: number, move: number, repaint: number }
+local function tier(files, lines, budget_ms)
+  print(("\n=== %d files x %d lines ==="):format(files, lines))
+  vim.cmd("cd " .. vim.fn.fnameescape(build(files, lines)))
 
--- Spans are computed once per git read and never during a repaint, which is the whole
--- reason they live in the parser. Both parses are timed so the cost has a home of its own:
--- if it ever stops showing up here and starts showing up in the repaint line above, the
--- work has moved back into the render and every resize is paying for it.
-local cwd = vim.fn.getcwd()
-local scope = assert(git.resolve_scope("branch", cwd))
-local diff_text = assert(git.diff(scope, cwd, 3))
-local plain_ms = ms(function()
-  diff.parse(diff_text)
-end)
-local spans_ms = ms(function()
-  diff.parse(diff_text, { spans = true })
-end)
-local spanned = 0
-for _, file in ipairs(diff.parse(diff_text, { spans = true })) do
-  for _, hunk in ipairs(file.hunks) do
-    for _, ln in ipairs(hunk.lines) do
-      spanned = spanned + (ln.spans and 1 or 0)
+  local open_ms = ms(function()
+    view.open("branch")
+  end)
+  local V = view.current()
+
+  local verdict = budget_ms and ("(budget %d ms)"):format(budget_ms) or "(reported, never fails this command)"
+  print(("open:            %6.0f ms   %s"):format(open_ms, verdict))
+  print(("  rows           %6d"):format(#V.render.lines))
+  print(("  files parsed   %6d / %d"):format(vim.tbl_count(V.syntax_painted), #V.files))
+  print(("  syntax marks   %6d"):format(syntax_marks(V.buf)))
+
+  -- Scroll to the bottom: files there must get parsed on demand, not up front.
+  print(("scroll to end:   %6.0f ms"):format(ms(function()
+    vim.api.nvim_win_set_cursor(V.win, { #V.render.lines, 0 })
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! zz")
+    end)
+    syntax.apply(V, NS)
+  end)))
+  print(("  files parsed   %6d / %d"):format(vim.tbl_count(V.syntax_painted), #V.files))
+
+  print(("scroll back:     %6.0f ms   (cached)"):format(ms(function()
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! zz")
+    end)
+    syntax.apply(V, NS)
+  end)))
+
+  -- The interactive path, and the only line here that is paid per keystroke.
+  local moves_ms = cursor_moves(V)
+  print(("cursor move:     %6.1f ms   (per keystroke: one CursorMoved, autocommand and all)"):format(moves_ms / MOVES))
+  print(("  %2d moves       %6.0f ms   (holding `j`)"):format(MOVES, moves_ms))
+
+  local repaint_ms = ms(function()
+    view.paint()
+  end)
+  print(("repaint:         %6.0f ms   (every resize, expansion, reviewed toggle, scope change)"):format(repaint_ms))
+
+  -- Spans are computed once per git read and never during a repaint, which is the whole
+  -- reason they live in the parser. Both parses are timed so the cost has a home of its own:
+  -- if it ever stops showing up here and starts showing up in the repaint line above, the
+  -- work has moved back into the render and every resize is paying for it.
+  local cwd = vim.fn.getcwd()
+  local scope = assert(git.resolve_scope("branch", cwd))
+  local diff_text = assert(git.diff(scope, cwd, 3))
+  local plain_ms = ms(function()
+    diff.parse(diff_text)
+  end)
+  local spans_ms = ms(function()
+    diff.parse(diff_text, { spans = true })
+  end)
+  local spanned = 0
+  for _, file in ipairs(diff.parse(diff_text, { spans = true })) do
+    for _, hunk in ipairs(file.hunks) do
+      for _, ln in ipairs(hunk.lines) do
+        spanned = spanned + (ln.spans and 1 or 0)
+      end
     end
   end
-end
-print(("parse:           %6.0f ms   (once per git read, not per repaint)"):format(plain_ms))
-print(("  spans          %6.0f ms   (+%.0f ms)"):format(spans_ms, spans_ms - plain_ms))
-print(("  lines spanned  %6d"):format(spanned))
+  print(("parse:           %6.0f ms   (once per git read, not per repaint)"):format(plain_ms))
+  print(("  spans          %6.0f ms   (+%.0f ms)"):format(spans_ms, spans_ms - plain_ms))
+  print(("  lines spanned  %6d"):format(spanned))
 
-if open_ms > BUDGET_MS then
-  print(("\nFAIL: open took %.0f ms, over the %d ms budget"):format(open_ms, BUDGET_MS))
+  -- Each tier gets its own review, on its own repository: whatever the next one measures, it
+  -- must not be measuring what this one left open.
+  view.close()
+  return { open = open_ms, move = moves_ms / MOVES, repaint = repaint_ms }
+end
+
+local small = tier(60, 200, BUDGET_MS)
+local large = tier(300, 200, nil)
+
+-- Side by side, because the point of the larger tier is the ratio: every one of these costs
+-- is linear in the size of the review, so five times the files should be about five times
+-- the milliseconds, and a change that flattens one of these lines is what the two slices
+-- after this one are for.
+-- The blank line is a prefix rather than a `print("")`: an empty message is dropped, not
+-- echoed, so a line of its own would leave the table welded to the tier above it.
+print(("\n%-16s %12s %12s"):format("side by side", "60 files", "300 files"))
+print(("%-16s %9.0f ms %9.0f ms"):format("  open", small.open, large.open))
+print(("%-16s %9.1f ms %9.1f ms"):format("  cursor move", small.move, large.move))
+print(("%-16s %9.0f ms %9.0f ms"):format("  repaint", small.repaint, large.repaint))
+
+if small.open > BUDGET_MS then
+  print(("\nFAIL: open took %.0f ms, over the %d ms budget"):format(small.open, BUDGET_MS))
   vim.cmd("cq")
 end
 print("\nOK")


### PR DESCRIPTION
`make perf` reported open, scroll, repaint and parse on a 60-file diff. Neither cost that
makes a large review feel broken had a line there: the work that fires on every
`CursorMoved` was not reported at all, and at 60 files every figure is small enough to sit
inside a budget that only ever watched *open*.

Two additions.

**A `cursor move` line.** It times the body of the review buffer's own autocommand — the
syntax pass and the tree sync together — averaged over fifty moves, because fifty rows is
roughly what leaning on `j` through a hunk costs. The event is dispatched rather than
provoked: neither `nvim_win_set_cursor` nor `normal! j` raises `CursorMoved` under
`nvim -l`, which was measured rather than assumed, so a report that only moved the cursor
would time the move and none of the work. The moves are warmed and stay inside one file, so
the figure is the steady-state per-keystroke cost rather than a one-off parse.

**A 300-file tier, alongside the 60-file one rather than replacing it.** Every cost here is
linear in the size of the review, so the small tier hides them. Each tier builds its own
fixture from `mkbig.sh <path> <files> <lines>` — no new script, nothing committed — and each
block is headed by its size, with a side-by-side table at the foot for the three figures
worth comparing.

The 60-file budget assertion is unchanged in value and in behaviour, and it is still the
only thing that can fail the command. The larger tier reports: a second ceiling would be a
second figure to tune per machine on a file that is read rather than gated, which is the
same reasoning that keeps `perf.lua` out of CI. The `BIG` override is gone, since one
prepared path can only ever be one of the two sizes.

Sample run, and the shape #77 and #78 have to change:

```
=== 60 files x 200 lines ===
open:               187 ms   (budget 2000 ms)
cursor move:        1.9 ms   (per keystroke: one CursorMoved, autocommand and all)
  50 moves           94 ms   (holding `j`)
repaint:             75 ms   (every resize, expansion, reviewed toggle, scope change)

=== 300 files x 200 lines ===
open:               636 ms   (reported, never fails this command)
cursor move:       17.9 ms   (per keystroke: one CursorMoved, autocommand and all)
  50 moves          897 ms   (holding `j`)
repaint:            362 ms   (every resize, expansion, reviewed toggle, scope change)

side by side         60 files    300 files
  open                 187 ms       636 ms
  cursor move          1.9 ms      17.9 ms
  repaint               75 ms       362 ms
```

Docs follow the code: `tests/README.md` on what the report now covers, what `mkbig.sh`
builds and why timing is still not asserted on, plus a "things that bite" entry for the
`CursorMoved` dispatch; the `Makefile` and `CONTRIBUTING.md` command lists; and `mkbig.sh`'s
own header, which claimed a fixed 60 files.

`make test` is untouched — the report is still outside the suite.

Closes #76
