### PR TITLE
feat(state): keep a batch after the dispatch that emptied the queue

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,6 +148,18 @@ _Avoid_: delivered, sent, accepted
 Delivering a single annotation on its own, without it joining the queue.
 _Avoid_: quick note, one-off, direct send
 
+**Archive**:
+The batches already dispatched from a repository, kept after the queue that held them was
+cleared. Only a **dispatch** writes it, so a payload copied to a register is not in it.
+_Avoid_: history, sent queue, outbox
+
+**Snapshot**:
+The commit object recording the working tree at the moment a batch was **dispatched**.
+Minted without touching refs, the index or the working tree, and on a clean tree it is
+`HEAD`.
+_Avoid_: stash (a stash is a thing git keeps; this one is never on the stash list),
+checkpoint
+
 ### Embedding
 
 **Host**:

--- a/README.md
+++ b/README.md
@@ -585,9 +585,9 @@ spells out which queue is which.
 
 ## Persistence
 
-Reviewed marks and the queue are stored per repository under
-`stdpath("state")/codereview/`, keyed by scope and diff base, and survive a restart. Each
-entry records the git blob it was captured against. On reload:
+Reviewed marks, the queue and the batches already dispatched are stored per repository
+under `stdpath("state")/codereview/`, keyed by scope and diff base, and survive a restart.
+Each entry records the git blob it was captured against. On reload:
 
 - a **reviewed mark** whose blob moved is silently un-marked — the file changed, so you
   have not reviewed what is there now;
@@ -608,6 +608,23 @@ goes to a single global store beside the others. Nothing ever reconciles that st
 a diff, so nothing would ever clear it: entries older than **seven days** are dropped when
 it is read. That bounds its growth but not its staleness, which is the accepted cost of not
 making those annotations second-class.
+
+</details>
+
+<details>
+<summary>What a dispatched batch leaves behind</summary>
+
+A batch that is **dispatched** is kept rather than forgotten: the annotations as they went,
+where they went, when, and a **snapshot** of the working tree at that moment — a commit
+object minted with `git stash create`, which moves no ref, leaves the index alone and never
+touches your files. On a clean tree there is nothing to record that `HEAD` does not already
+say, and `HEAD` is what is stored.
+
+A dispatch writes it and nothing else does. An adapter that declined, one that raised, and
+the `+` register the default send copies to all leave it exactly as they leave the queue —
+a payload sitting in a register is not something an agent received. An immediate send is a
+batch of one and is kept as one. The most recent **twenty** batches are kept per store,
+oldest dropped on write.
 
 </details>
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -697,7 +697,7 @@ that is what keeps code readable inside an emphasised span. Both are still
 ==============================================================================
 11. PERSISTENCE                                     *codereview-persistence*
 
-Reviewed marks and the queue are written to
+Reviewed marks, the queue and the batches already dispatched are written to
 `stdpath("state")/codereview/{repo}.json`, keyed by scope and diff base.
 Half-written notes are kept separately, in `drafts.json` -- see
 |codereview-drafts|.
@@ -752,6 +752,28 @@ first written, so queueing something else does not restart the clock.
 That bounds the store's growth but not its staleness. An old note can still
 claim a line span that has since moved, and nothing will flag it -- the
 accepted cost of not making those annotations second-class.
+
+The archive                                 *codereview-persistence-archive*
+
+A batch that is dispatched is kept rather than forgotten. Each record holds
+the annotations as they went, where they went, when, and a snapshot: a commit
+object recording the working tree at that moment, minted with `git stash
+create` -- which moves no ref, leaves the index alone and never touches the
+working tree, so nothing about a submit disturbs what you are reviewing. On a
+clean tree there is nothing to record that `HEAD` does not already say, and
+`HEAD` is what is stored. Untracked files are not in such a commit.
+
+A dispatch writes it and nothing else does. An adapter that declined, one that
+raised, and the `+` register the default send copies to all leave the archive
+exactly as they leave the queue -- a payload sitting in a register is not
+something an agent received. See |codereview-opt-send|. An immediate send
+(|codereview-immediate-send|) is a batch of one and is kept as one.
+
+Records go to the same two stores the queue does, split by the same rule: an
+annotation with a repository-relative path to that repository's file, a bare
+note or a file outside any checkout to the no-repository store. The most
+recent **twenty** batches per store are kept, and the oldest is dropped on
+write.
 
 ==============================================================================
 12. LUA API                                                 *codereview-api*

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -103,6 +103,32 @@ tree, and the whole batch silently degrades to absolute paths with pasted snippe
 resolves once per submit rather than per entry, and falls back to the string it was given:
 a routed agent can name a directory that does not exist on this machine at all.
 
+## The archive
+
+**The state document's `VERSION` must not be bumped to add a key.** A mismatched version
+is discarded on load, deliberately — restoring marks that mean something different than
+they did when written costs more than losing them. So a bump made to make room for
+`archive` would throw away every reviewed mark in every existing file, to add a key those
+files simply lack. New keys are defaulted on load instead, exactly as `scopes` and `queue`
+already are.
+
+**The queue's id counter does not survive a process, and archived entries do.** It is
+module-level and starts at 1, which was harmless while everything carrying an id was in the
+queue: the restore seeds it past whatever came back. An archived entry has left the queue
+but not the screen, so a session that dispatched ids 1..n and then restarted hands its next
+annotation an id already drawn on the diff — and dropping an annotation resolves by anchor
+key and then by id, so `x` removes the wrong one. The restore therefore seeds from the
+archive as well, *after* both stores have been read, because entries are split between them
+and an id is unique across the pair.
+
+**`git stash create` mints a commit and does nothing else.** No ref moves, the index is not
+touched and the working tree is not reverted, which is the only reason it is safe to run
+behind a submit. Two consequences worth knowing before reading a snapshot back: a clean
+tree mints *nothing* and prints nothing, so the snapshot falls back to `HEAD` — that is a
+case, not an edge — and untracked files are not in the commit at all, so a file untracked
+at dispatch is covered by the same synthesis the branch and worktree scopes already apply
+to untracked files, not by the snapshot.
+
 ## The file tree
 
 **The tree's parent directory is found by depth, not by proximity.** `h` on a file folds

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -170,7 +170,10 @@ end
 function M.deliver(items, to, opts)
   local cfg = config.get()
   opts = opts or {}
-  local root = opts.root or (git.root(vim.fn.getcwd()) or vim.fn.getcwd())
+  -- The repository the batch is going out of, when there is one: a note captured outside a
+  -- checkout has none, and the archive is keyed on a root exactly as the queue's store is.
+  local repo = opts.root or git.root(vim.fn.getcwd())
+  local root = repo or vim.fn.getcwd()
   -- Resolve refs against the directory the payload is actually going to: a routed agent
   -- reads `@path` relative to its own cwd, not this Neovim's.
   local base = (to and to.cwd and to.cwd ~= "") and to.cwd or root
@@ -201,6 +204,13 @@ function M.deliver(items, to, opts)
     -- caller can put the reason in a message without checking whether there is one.
     return false, reason or "The send adapter reported it did not deliver"
   end
+
+  -- The same rule doing its second job: a dispatch is what empties the queue, and it is
+  -- what records the batch. Everything that is not one has returned above, so a refusal, a
+  -- raise and the register the shipped default copies to leave the archive exactly where
+  -- they leave the batch. Here rather than in the two callers because a batch and a batch
+  -- of one go out through this function and must not diverge on the way (ADR-0004).
+  require("codereview.state").archive_batch(items, M.label_of(to), repo)
   return true
 end
 

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -95,6 +95,23 @@ function M.merge_base(a, b, root)
   return line({ "merge-base", a, b }, root)
 end
 
+---A commit object recording the working tree as it stands, minted and nothing else.
+---
+---`git stash create` writes the commit and prints its sha; that is the whole of what it
+---does. No ref moves, the index is left alone and the working tree is not reverted -- which
+---is what makes it safe behind a submit, where a real stash would pull the reviewer's work
+---out from under them mid-review.
+---
+---A clean tree mints nothing and prints nothing. That is an answer rather than a failure:
+---there is nothing to record that `HEAD` does not already say, so `HEAD` is what it means.
+---Untracked files are not in a `stash create` commit at all, which is the same gap the
+---branch and worktree scopes already synthesise around.
+---@param root string
+---@return string|nil sha nil only when there is no HEAD to fall back to either
+function M.snapshot(root)
+  return line({ "stash", "create" }, root) or line({ "rev-parse", "--verify", "--quiet", "HEAD" }, root)
+end
+
 --- Scopes ----------------------------------------------------------------------
 
 ---@class CRScope

--- a/lua/codereview/queue.lua
+++ b/lua/codereview/queue.lua
@@ -70,6 +70,18 @@ function M.replace(list)
   end
 end
 
+---Reserve ids up to and including `highest`, for entries that are no longer in the queue.
+---
+---An archived entry has left the queue but not the screen: it is drawn against the diff
+---beside the live ones, and dropping an annotation resolves by anchor key and then by id.
+---The counter is module-level and does not survive a process, so a session that dispatched
+---1..n and then restarted would hand its next annotation an id already on the diff --
+---which `remove` would then match first.
+---@param highest integer|nil
+function M.seed(highest)
+  next_id = math.max(next_id, (highest or 0) + 1)
+end
+
 ---Annotations grouped by anchor key, for the renderer.
 ---@return table<string, CRAnnotation[]>
 function M.by_key()

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -14,7 +14,26 @@ local queue = require("codereview.queue")
 
 local M = {}
 
+---Bumping this discards every document written before the bump, so a key added to the
+---shape is *not* a reason to touch it. `archive` was added by defaulting it on load
+---exactly as `scopes` and `queue` already are: an older document simply lacks it, which
+---costs an empty table, where a bump would cost every reviewed mark in the file.
 local VERSION = 1
+
+---A batch as it was dispatched, kept after the queue that held it was cleared.
+---@class CRBatch
+---@field at integer            When it went
+---@field target string         Short name of where it went; "local" for the adapter's default
+---@field snapshot string|nil   Commit object recording the working tree at that moment
+---@field entries CRAnnotation[]
+
+---How many dispatched batches a store keeps, oldest dropped on write.
+---
+---Public because it is a property of the store rather than a number this file happens to
+---use. Bounded for the reason the global store sweeps on age: nothing else here will ever
+---remove a batch, and a store nothing removes from grows for the life of the state
+---directory.
+M.ARCHIVE_LIMIT = 20
 
 ---@param root string
 ---@return string
@@ -30,7 +49,7 @@ end
 function M.load(root)
   local file = M.path(root)
   if vim.fn.filereadable(file) == 0 then
-    return { version = VERSION, scopes = {}, queue = {} }
+    return { version = VERSION, scopes = {}, queue = {}, archive = {} }
   end
   local ok, decoded = pcall(function()
     return vim.json.decode(table.concat(vim.fn.readfile(file), "\n"), {
@@ -41,10 +60,14 @@ function M.load(root)
     -- A corrupt or older file is discarded rather than migrated: the cost of losing
     -- review progress is far lower than the cost of restoring marks that mean something
     -- different than they did when written.
-    return { version = VERSION, scopes = {}, queue = {} }
+    return { version = VERSION, scopes = {}, queue = {}, archive = {} }
   end
   decoded.scopes = decoded.scopes or {}
   decoded.queue = decoded.queue or {}
+  -- A document written before the archive existed lacks the key entirely, and defaulting
+  -- it here is the whole of what it takes to read one: nothing about the marks stored
+  -- beside it means anything different than it did.
+  decoded.archive = decoded.archive or {}
   return decoded
 end
 
@@ -91,11 +114,33 @@ local function partition(items)
   return owned, loose
 end
 
----@return CRAnnotation[]
-function M.load_global()
+---Whatever is still inside the window, by each record's own stamp.
+---
+---One rule for the queued annotations and the archived batches alike: both are stamped
+---when written, and neither has anything else that could ever decide it is finished with.
+---@param records table[]|nil
+---@param now integer
+---@return table[]
+local function unswept(records, now)
+  local fresh = {}
+  for _, record in ipairs(records or {}) do
+    if type(record) == "table" and (now - (record.at or 0)) < GLOBAL_TTL_SECONDS then
+      fresh[#fresh + 1] = record
+    end
+  end
+  return fresh
+end
+
+---The whole store, swept.
+---
+---Read as one document rather than one key at a time, because a write has to put the
+---other key back: `save_global` used to encode the queue and nothing else, which with an
+---archive beside it would delete a dispatched batch every time an annotation was queued.
+---@return { queue: CRAnnotation[], archive: CRBatch[] }
+local function read_global()
   local file = M.global_path()
   if vim.fn.filereadable(file) == 0 then
-    return {}
+    return { queue = {}, archive = {} }
   end
   local ok, decoded = pcall(function()
     return vim.json.decode(table.concat(vim.fn.readfile(file), "\n"), {
@@ -103,26 +148,41 @@ function M.load_global()
     })
   end)
   if not ok or type(decoded) ~= "table" or decoded.version ~= VERSION then
-    return {}
+    return { queue = {}, archive = {} }
   end
 
   -- The sweep, on load rather than on a timer: this is the only moment the store is
   -- read, so it is the only moment anything is in a position to drop from it.
-  local now, fresh = os.time(), {}
-  for _, item in ipairs(decoded.queue or {}) do
-    if type(item) == "table" and (now - (item.at or 0)) < GLOBAL_TTL_SECONDS then
-      fresh[#fresh + 1] = item
-    end
+  local now = os.time()
+  return { queue = unswept(decoded.queue, now), archive = unswept(decoded.archive, now) }
+end
+
+---@param doc { queue: CRAnnotation[], archive: CRBatch[] }
+---@return boolean ok
+local function write_global(doc)
+  local file = M.global_path()
+  vim.fn.mkdir(vim.fs.dirname(file), "p")
+  local ok, encoded = pcall(vim.json.encode, { version = VERSION, queue = doc.queue, archive = doc.archive })
+  if not ok then
+    return false
   end
-  return fresh
+  return pcall(vim.fn.writefile, { encoded }, file)
+end
+
+---@return CRAnnotation[]
+function M.load_global()
+  return read_global().queue
+end
+
+---The batches dispatched with nothing repository-shaped in them, newest first.
+---@return CRBatch[]
+function M.global_archive()
+  return read_global().archive
 end
 
 ---@param items CRAnnotation[]
 ---@return boolean ok
 function M.save_global(items)
-  local file = M.global_path()
-  vim.fn.mkdir(vim.fs.dirname(file), "p")
-
   local now = os.time()
   for _, item in ipairs(items) do
     -- Stamped once and then left alone. Refreshing it on every write would restart the
@@ -130,19 +190,108 @@ function M.save_global(items)
     item.at = item.at or now
   end
 
-  local ok, encoded = pcall(vim.json.encode, { version = VERSION, queue = items })
-  if not ok then
-    return false
-  end
-  return pcall(vim.fn.writefile, { encoded }, file)
+  local doc = read_global()
+  doc.queue = items
+  return write_global(doc)
 end
 
----Forget every annotation with no repository behind it.
+---Forget every annotation with no repository behind it, queued or already dispatched.
 function M.clear_global()
   local file = M.global_path()
   if vim.fn.filereadable(file) == 1 then
     vim.fn.delete(file)
   end
+end
+
+--- The archive ------------------------------------------------------------------
+
+---Add a batch to an archive, dropping the oldest once it is full.
+---
+---Newest first, because every reader of an archive wants the newest: the scope that diffs
+---against a snapshot only ever reads that one, and the rest is there to be read back.
+---@param archive CRBatch[]
+---@param batch CRBatch
+local function push(archive, batch)
+  table.insert(archive, 1, batch)
+  -- A loop rather than one removal, so a store written when the bound was larger comes
+  -- back down instead of staying over it forever.
+  while #archive > M.ARCHIVE_LIMIT do
+    table.remove(archive)
+  end
+end
+
+---Record a batch that has just been dispatched.
+---
+---Called on a dispatch and on nothing else (ADR-0005). An adapter that refused, one that
+---raised, and the register the shipped default copies to all leave the archive exactly as
+---they leave the queue -- a payload sitting in a register is not something an agent
+---received. An **immediate send** is a batch of one (ADR-0004) and arrives here as one,
+---with no special case.
+---
+---Split across the two stores on the rule that already routes the queue: an entry with a
+---repository-relative path belongs to that repository, and a bare note or a file outside a
+---checkout belongs to the store that needs no root. A batch holding both is recorded in
+---both, because that is where its entries live.
+---@param items CRAnnotation[] The batch as it went
+---@param target string Short name of where it went, as every piece of chrome names it. The
+---       label rather than the target itself: a host's target may carry anything at all,
+---       functions included, and one that will not JSON-encode would take the whole
+---       document's write down with it.
+---@param root string|nil nil outside a repository, where only the global store applies
+function M.archive_batch(items, target, root)
+  local owned, loose = partition(items)
+  -- One stamp for the batch, taken once: the two stores are recording the same dispatch.
+  local at = os.time()
+
+  if #loose > 0 then
+    local doc = read_global()
+    -- No snapshot: these entries have no repository whose working tree could be recorded,
+    -- and a snapshot of whichever checkout happened to be current would describe nothing
+    -- they are about.
+    push(doc.archive, { at = at, target = target, entries = loose })
+    write_global(doc)
+  end
+
+  if not root or #owned == 0 then
+    return
+  end
+  local data = M.load(root)
+  push(data.archive, {
+    at = at,
+    target = target,
+    -- Minted here rather than handed in. The snapshot is the working tree at the moment of
+    -- dispatch, and it is only that if it is taken at that moment.
+    snapshot = require("codereview.git").snapshot(root),
+    entries = owned,
+  })
+  M.save(root, data)
+end
+
+---The batches already dispatched from a repository, newest first.
+---
+---Entries with nothing repository-shaped about them are in `global_archive` instead, for
+---the same reason they queue there: there is no root to key a document against.
+---@param root string|nil
+---@return CRBatch[]
+function M.archive(root)
+  return root and M.load(root).archive or {}
+end
+
+---The highest id any archived entry carries, across every archive given.
+---
+---Which is what the queue's counter has to resume past. See `queue.seed`.
+---@param archives CRBatch[][]
+---@return integer
+local function highest_archived_id(archives)
+  local highest = 0
+  for _, archive in ipairs(archives) do
+    for _, batch in ipairs(archive) do
+      for _, entry in ipairs(batch.entries or {}) do
+        highest = math.max(highest, entry.id or 0)
+      end
+    end
+  end
+  return highest
 end
 
 --- Writing and reading ----------------------------------------------------------
@@ -207,11 +356,18 @@ function M.restore_queue(root)
   end
   -- Both stores, as one queue. Which store an entry came from is a persistence detail; the
   -- queue is the queue.
-  local items = root and M.load(root).queue or {}
-  vim.list_extend(items, M.load_global())
+  local loose = read_global()
+  local data = root and M.load(root) or nil
+  local items = data and data.queue or {}
+  vim.list_extend(items, loose.queue)
   if #items > 0 then
     queue.replace(items)
   end
+  -- Taken once both stores have been read, because an id is unique across the pair and the
+  -- entries carrying one are split between them. Restoring the queue alone is not enough:
+  -- a session that dispatched everything it queued restores nothing at all and still has
+  -- ids on the diff to keep clear of.
+  queue.seed(highest_archived_id({ data and data.archive or {}, loose.archive }))
   if not root then
     return 0
   end

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # open-time report, not a 
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 880 cases in ~6 seconds.
+The whole suite is about 910 cases in ~6 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -28,6 +28,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/layout_child.lua` | Spawned by `layout_spec` — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
+| `codereview/archive_child.lua` | Spawned by `archive_spec` to dispatch a batch and exit — deliberately not a spec. |
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `perf.lua` | Open-time report on a 60-file diff, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
@@ -44,6 +45,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
+| `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, and a document written before the archive existed |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
 | `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, and the draft an undispatched immediate send leaves behind |
@@ -66,7 +68,9 @@ interchangeable, and the assertions know which one they are looking at.
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
   `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `split_spec`,
-  `layout_spec`, `open_diff_spec` and `interactive_spec`. It already covers everything the split layout has
+  `layout_spec`, `open_diff_spec`, `archive_spec` and `interactive_spec`. Its dirty working
+  tree is what makes a snapshot worth minting, so `archive_spec` builds a second copy and
+  resets it to get a clean one. It already covers everything the split layout has
   to render, including the files that exist on only one side and the additions between
   context lines that produce filler — so that slice needed no fixture of its own. The
   layout toggle needed none either: `src/main.lua`'s deletion and its replacement collapse
@@ -123,6 +127,17 @@ so the out-of-core language path is still checked locally without ever failing C
   therefore does *not* simulate a restart — the latch is still set, nothing reloads, and an
   assertion about restoring is measuring nothing. `capture_spec` spawns
   `capture_child.lua` twice for this reason.
+- **The id an archived entry holds only collides across a restart *plus* a dispatch.** The
+  queue's counter is module-level and starts at 1, so a one-process test of "a new
+  annotation does not take an id the archive already holds" passes whether or not the
+  counter is seeded — the process that dispatched is the process still counting.
+  `archive_spec` therefore dispatches in `archive_child.lua`, restarts, and queues one
+  through the ordinary capture path. It also asserts that the archive really does hold id
+  1, or the case is satisfied by an archive with nothing low enough to collide with.
+- **`git stash create` on a clean tree returns nothing**, which is a case rather than an
+  edge to assume away: the snapshot falls back to `HEAD`. `archive_spec` builds a second
+  fixture and resets it hard, because the shared one is dirty by design and can never
+  reach that branch.
 - **A send adapter that raises takes the whole `describe` with it.** Plenary runs a
   describe body immediately, so an adapter that propagates its error aborts the block
   instead of failing one case — the `it`s below it never run. `delivery_spec` asserts on

--- a/tests/codereview/archive_child.lua
+++ b/tests/codereview/archive_child.lua
@@ -1,0 +1,58 @@
+-- The dispatching half of archive_spec: a Neovim that submits a batch and exits.
+--
+-- Deliberately a separate process, for the two reasons this feature has. The archive is
+-- only meaningfully read back across a genuine restart -- reading it in the process that
+-- wrote it proves nothing about what reached the disk. And the queue's id counter is
+-- module-level, so a session that dispatched ids 1..n and then exited is the only place
+-- the collision the seed exists to prevent can be observed at all.
+--
+-- Three annotations of different provenance, so that the split across the two stores is
+-- exercised by the batch itself: one inside the repository, one about a file outside any
+-- checkout, one with no file at all.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- archive_spec with XDG_STATE_HOME, FIXTURE and LOOSE_FILE in its environment, and it must
+-- NOT load tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+local loose = assert(vim.env.LOOSE_FILE, "LOOSE_FILE is not set")
+
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+local codereview = require("codereview")
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "dispatched by an earlier session")
+  end,
+  -- Answers inline, which is all this needs: nothing here is asserting the order a picker
+  -- and a composer come in, only that the batch records where it went.
+  pick_target = function(cb)
+    cb({ short = "agent", pane_id = "wV:p9", cwd = fixture })
+  end,
+  send = function() end,
+})
+
+local queue = require("codereview.queue")
+
+vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(fixture, "src/main.lua")))
+codereview.annotate("bug")
+
+vim.cmd("edit " .. vim.fn.fnameescape(loose))
+codereview.annotate("fix")
+
+vim.cmd("enew")
+codereview.annotate("issue")
+
+-- Chosen before submitting, so the batch goes somewhere with a name rather than to the
+-- adapter's own default -- which is what makes "it records the target" an assertion.
+require("codereview.delivery").pick_target()
+codereview.submit()
+
+-- Printed so a failing archive_spec can show what the dispatching process believed it did.
+print("queued: " .. #queue.all() .. " left after submitting")
+print("state file: " .. require("codereview.state").path(assert(require("codereview.git").root(fixture))))
+vim.cmd("qa!")

--- a/tests/codereview/archive_spec.lua
+++ b/tests/codereview/archive_spec.lua
@@ -1,0 +1,299 @@
+-- The archive: the batches already dispatched, kept after the queue that held them was
+-- cleared.
+--
+-- Two processes, like state_spec and for the same reason -- persistence is only
+-- meaningfully tested across a genuine restart, and a `state.load()` called twice in one
+-- process proves nothing about what reached the disk. `archive_child.lua` dispatches a
+-- batch and exits; everything below reads it back in a Neovim that has never seen it.
+--
+-- The id case needs that second process for a reason of its own: the queue's counter is
+-- module-level, so a session that dispatched 1..n and restarted begins at 1 again, and a
+-- one-process test passes whether or not the counter is seeded from the archive.
+--
+-- Assertions go through the public accessor and against git, never against the JSON.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+local codereview = require("codereview")
+local git = require("codereview.git")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+
+local root = assert(vim.uv.fs_realpath(fixture))
+local main = assert(vim.uv.fs_realpath(vim.fs.joinpath(fixture, "src/main.lua")))
+
+-- A file that is genuinely not inside any checkout. Asserted rather than assumed: if the
+-- temp directory ever sits inside a repository, the entries this spec expects in the store
+-- that needs no root would quietly archive to a repository's instead.
+local outside = vim.fn.tempname() .. "-outside"
+vim.fn.mkdir(outside, "p")
+local outside_file = vim.fs.joinpath(outside, "loose.lua")
+vim.fn.writefile({ "local loose = true", "return loose" }, outside_file)
+
+local sent = {}
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "from this session")
+  end,
+  send = function(text, target)
+    sent[#sent + 1] = { text = text, target = target }
+  end,
+})
+
+---One queued annotation with a repository behind it, so a batch is of a known size.
+---@param note string
+local function queue_one(note)
+  queue.clear()
+  queue.add({
+    type = "bug",
+    kind = "file",
+    path = "src/main.lua",
+    abs_path = main,
+    key = "src/main.lua:f:0",
+    note = note,
+  })
+end
+
+describe("the fixture the rest of this spec depends on", function()
+  it("puts the loose file outside any repository", function()
+    assert.is_nil(git.root(outside), outside .. " is inside a checkout")
+  end)
+end)
+
+-- Read before anything of ours has run, so that "the snapshot disturbed nothing" is a
+-- comparison rather than a claim about what git happens to say afterwards.
+local head_before = h.git_lines(root, { "rev-parse", "HEAD" })
+local status_before = h.git_lines(root, { "status", "--porcelain" })
+
+describe("the dispatching process", function()
+  local cmd = {
+    vim.v.progpath,
+    "--clean",
+    "-l",
+    vim.fs.joinpath(h.root, "tests", "codereview", "archive_child.lua"),
+  }
+  local proc = vim.system(cmd, {
+    cwd = fixture,
+    text = true,
+    env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = fixture, LOOSE_FILE = outside_file },
+  })
+  local child = proc:wait(60000)
+  local output = (child.stdout or "") .. (child.stderr or "")
+
+  it("exits cleanly", function()
+    assert.same(0, child.code, output)
+  end)
+
+  it("emptied its queue on the way out, so nothing below is reading memory", function()
+    assert.is_true(output:find("queued: 0 left", 1, true) ~= nil, output)
+  end)
+end)
+
+describe("what a restart finds", function()
+  local archive = state.archive(root)
+  local loose = state.global_archive()
+
+  it("holds the batch the previous session dispatched", function()
+    assert.same(1, #archive, vim.inspect(archive))
+  end)
+
+  it("holds the entries that had a repository behind them, and only those", function()
+    assert.same(1, #archive[1].entries)
+    assert.same("src/main.lua", archive[1].entries[1].path)
+    assert.same("bug", archive[1].entries[1].type)
+  end)
+
+  it("keeps each entry's note as it went", function()
+    assert.is_truthy(archive[1].entries[1].note:find("dispatched by an earlier session", 1, true))
+  end)
+
+  it("records which target it went to", function()
+    assert.same("agent", archive[1].target)
+  end)
+
+  it("records when it went", function()
+    -- Loose, because the assertion is that a real time was stamped rather than that a
+    -- clock reads a particular value.
+    assert.is_true(math.abs(os.time() - archive[1].at) < 600, tostring(archive[1].at))
+  end)
+
+  -- The rule that already routes the queue, applied unchanged: a repository-relative path
+  -- means that repository, and everything else means the store that needs no root.
+  it("routes a bare note and a file outside a checkout to the other store", function()
+    assert.same(1, #loose, vim.inspect(loose))
+    assert.same(2, #loose[1].entries)
+    assert.same({ "fix", "issue" }, {
+      loose[1].entries[1].type,
+      loose[1].entries[2].type,
+    })
+  end)
+
+  it("keeps the loose file's absolute path, and gives the bare note no path at all", function()
+    assert.same(assert(vim.uv.fs_realpath(outside_file)), loose[1].entries[1].abs_path)
+    assert.is_nil(loose[1].entries[2].path)
+    assert.is_nil(loose[1].entries[2].abs_path)
+  end)
+
+  -- There is no repository whose working tree could be recorded, and a snapshot of
+  -- whichever checkout happened to be current would describe nothing these are about.
+  it("gives that batch no snapshot", function()
+    assert.is_nil(loose[1].snapshot)
+  end)
+end)
+
+-- Runs before anything else in this process touches the queue: the counter has issued no
+-- id yet, and `ensure_queue` latches on the first read.
+describe("an annotation queued after the restart", function()
+  it("starts from an empty queue, so every id below came off the disk", function()
+    assert.same(0, queue.count())
+  end)
+
+  local archived = {}
+  for _, store in ipairs({ state.archive(root), state.global_archive() }) do
+    for _, batch in ipairs(store) do
+      for _, entry in ipairs(batch.entries) do
+        archived[#archived + 1] = entry.id
+      end
+    end
+  end
+  table.sort(archived)
+
+  -- Without this the case is vacuous: a counter that was never seeded issues 1, and only
+  -- an archive that actually holds 1 can catch it.
+  it("has archived ids low enough to collide with", function()
+    assert.same(1, archived[1], vim.inspect(archived))
+  end)
+
+  vim.cmd("edit " .. vim.fn.fnameescape(main))
+  codereview.annotate("bug")
+
+  it("takes an id above every archived one", function()
+    local queued = assert(queue.all()[1], "nothing was queued")
+    assert.is_true(queued.id > archived[#archived], ("%d is not above %s"):format(queued.id, vim.inspect(archived)))
+  end)
+end)
+
+describe("the snapshot a dispatch minted", function()
+  local snapshot = assert(state.archive(root)[1].snapshot, "the batch was archived without one")
+
+  it("is a commit object", function()
+    assert.same({ "commit" }, h.git_lines(root, { "cat-file", "-t", snapshot }))
+  end)
+
+  -- Derived from git rather than hardcoded: which files the fixture leaves dirty is a fact
+  -- about the fixture, and hardcoded lists have gone stale in this repository before.
+  it("records the working tree rather than what HEAD says", function()
+    local dirty = h.git_lines(root, { "diff", "--name-only", "HEAD" })
+    assert.is_true(#dirty > 0, "the fixture's working tree is clean, so this proves nothing")
+    assert.same(dirty, h.git_lines(root, { "diff", "--name-only", "HEAD", snapshot }))
+  end)
+
+  it("moved no ref, and stashed nothing for real", function()
+    assert.same({}, h.git_lines(root, { "stash", "list" }))
+    assert.same(head_before, h.git_lines(root, { "rev-parse", "HEAD" }))
+  end)
+
+  it("left the index and the working tree exactly as they were", function()
+    assert.same(status_before, h.git_lines(root, { "status", "--porcelain" }))
+  end)
+end)
+
+-- `git stash create` mints nothing when there is nothing to record, which is a case rather
+-- than an edge to assume away. The fallback has to be a real ref, because everything that
+-- will read a snapshot back reads file content out of it.
+describe("a batch dispatched from a clean working tree", function()
+  local clean = h.fixture("mkfixture")
+  h.git_lines(clean, { "reset", "--hard" })
+  h.git_lines(clean, { "clean", "-fdx" })
+  local clean_root = assert(vim.uv.fs_realpath(clean))
+
+  it("is dispatched from a tree with nothing in it to record", function()
+    assert.same({}, h.git_lines(clean, { "status", "--porcelain" }))
+  end)
+
+  queue_one("from a clean tree")
+  vim.cmd("cd " .. vim.fn.fnameescape(clean))
+  local msgs, restore = h.capture_notify()
+  codereview.submit()
+  restore()
+  vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+  it("was dispatched at all", function()
+    assert.is_true(h.notified(msgs, "Submitted 1 annotation"), vim.inspect(msgs))
+  end)
+
+  it("archives to the repository it went out of", function()
+    assert.same(1, #state.archive(clean_root))
+  end)
+
+  it("falls back to HEAD, since there is nothing else to record", function()
+    assert.same(h.git_lines(clean, { "rev-parse", "HEAD" })[1], state.archive(clean_root)[1].snapshot)
+  end)
+end)
+
+-- Nothing here ever reconciles a batch against a diff, so no later moment could decide one
+-- is finished with. Without a bound the archive grows for the life of the state directory,
+-- which is the failure the other store's age sweep already exists to prevent.
+describe("the bound on how many batches are kept", function()
+  state.clear(root)
+  local overflow = state.ARCHIVE_LIMIT + 2
+
+  local _, restore = h.capture_notify()
+  for i = 1, overflow do
+    queue_one(("batch %d"):format(i))
+    codereview.submit()
+  end
+  restore()
+
+  local archive = state.archive(root)
+  local notes = vim.tbl_map(function(batch)
+    return batch.entries[1].note
+  end, archive)
+
+  it("keeps no more than the bound", function()
+    assert.same(state.ARCHIVE_LIMIT, #archive)
+  end)
+
+  it("keeps the newest, and holds it first", function()
+    assert.same(("batch %d"):format(overflow), notes[1])
+  end)
+
+  it("dropped the oldest, one per write past the bound", function()
+    assert.is_false(vim.tbl_contains(notes, "batch 1"), vim.inspect(notes))
+    assert.is_false(vim.tbl_contains(notes, "batch 2"), vim.inspect(notes))
+    assert.is_true(vim.tbl_contains(notes, "batch 3"), vim.inspect(notes))
+  end)
+end)
+
+-- The version was deliberately not bumped to make room for the archive. A mismatched
+-- version is discarded on load, so a bump would throw away every reviewed mark in the file
+-- to add a key that older documents simply lack -- which is why the document written by
+-- hand below carries version 1 and expects to be read, not discarded.
+describe("a document written before the archive existed", function()
+  local path = state.path(root)
+  local scope_key = "branch:0123456789abcdef"
+  vim.fn.writefile({
+    vim.json.encode({
+      version = 1,
+      scopes = { [scope_key] = { reviewed = { ["src/main.lua"] = "deadbeef" } } },
+      queue = { { id = 4, type = "bug", kind = "file", path = "src/main.lua", key = "k", note = "written before" } },
+    }),
+  }, path)
+  local loaded = state.load(root)
+
+  it("keeps the reviewed marks it was written with", function()
+    assert.same("deadbeef", loaded.scopes[scope_key].reviewed["src/main.lua"])
+  end)
+
+  it("keeps the queue it was written with", function()
+    assert.same(1, #loaded.queue)
+    assert.same("written before", loaded.queue[1].note)
+  end)
+
+  it("gains an empty archive rather than nothing at all", function()
+    assert.same({}, loaded.archive)
+  end)
+end)

--- a/tests/codereview/delivery_spec.lua
+++ b/tests/codereview/delivery_spec.lua
@@ -14,11 +14,23 @@ local codereview = require("codereview")
 local config = require("codereview.config")
 local drafts = require("codereview.drafts")
 local queue = require("codereview.queue")
+local state = require("codereview.state")
 
 -- Resolved, because capture realpaths every path it records and a draft is keyed by the
 -- absolute one. On macOS the fixture lives under a `/var` symlink, so the unresolved form
 -- would look up a key nothing ever wrote.
 local main = assert(vim.uv.fs_realpath(vim.fs.joinpath(fixture, "src/main.lua")))
+local root = assert(vim.uv.fs_realpath(fixture))
+
+---The batches this repository has kept, through the accessor a surface would use.
+---
+---A dispatch is the one condition that empties the queue, and it is the one condition that
+---writes here (ADR-0005): a payload sitting in a register is not something an agent
+---received. Every case below therefore asserts on this exactly as it asserts on the queue.
+---@return CRBatch[]
+local function archived()
+  return state.archive(root)
+end
 
 local sent = {}
 
@@ -49,6 +61,7 @@ end
 
 describe("an adapter that returns nothing", function()
   queue_one("returns nothing at all")
+  local before = #archived()
   local msgs, restore = h.capture_notify()
   codereview.submit()
   restore()
@@ -66,6 +79,13 @@ describe("an adapter that returns nothing", function()
 
   it("confirms what was submitted", function()
     assert.is_true(h.notified(msgs, "Submitted 1 annotation"), vim.inspect(msgs))
+  end)
+
+  -- The same condition, doing its second job: what left the queue is kept rather than
+  -- forgotten, so a reviewer can still read what they asked for after asking for it.
+  it("records the batch in the archive", function()
+    assert.same(before + 1, #archived())
+    assert.same("returns nothing at all", archived()[1].entries[1].note)
   end)
 end)
 
@@ -94,6 +114,7 @@ describe("an adapter that returns false with a reason", function()
     return false, "the agent pane is gone"
   end
   queue_one("declined by the adapter")
+  local before = #archived()
   local msgs, restore = h.capture_notify()
   codereview.submit()
   restore()
@@ -116,6 +137,12 @@ describe("an adapter that returns false with a reason", function()
     assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
   end)
 
+  -- Nothing received it, so recording that it went would make a failed send look like a
+  -- delivered one for as long as the archive is kept.
+  it("leaves the archive exactly as it was", function()
+    assert.same(before, #archived())
+  end)
+
   -- The point of keeping it: the note was typed once, and a host that comes back should
   -- not cost it. The count still describes what is really there.
   it("can be retried without retyping the note", function()
@@ -131,6 +158,7 @@ describe("an adapter that raises", function()
     error("herdr: no such pane")
   end
   queue_one("raised at the adapter")
+  local before = #archived()
   local msgs, restore = h.capture_notify()
   codereview.submit()
   restore()
@@ -140,6 +168,10 @@ describe("an adapter that raises", function()
   -- the queue, which is how a missing binary used to leave it intact.
   it("keeps the queue", function()
     assert.same(1, queue.count())
+  end)
+
+  it("leaves the archive alone too", function()
+    assert.same(before, #archived())
   end)
 
   it("reads as a sentence rather than a traceback", function()
@@ -152,6 +184,7 @@ describe("no adapter at all", function()
   cfg.send = nil
   vim.fn.setreg("+", "")
   queue_one("nothing consumed this")
+  local before = #archived()
   local msgs, restore = h.capture_notify()
   codereview.submit()
   restore()
@@ -170,6 +203,11 @@ describe("no adapter at all", function()
   it("says where it went instead", function()
     assert.is_true(h.notified(msgs, "No send adapter configured"), vim.inspect(msgs))
     assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
+  end)
+
+  -- A register is not a consumer, so there is nothing to record having been asked for.
+  it("archives nothing, because a copy is not a dispatch", function()
+    assert.same(before, #archived())
   end)
 end)
 
@@ -202,6 +240,7 @@ describe("an immediate send that was dispatched", function()
   queue.clear()
   codereview.close()
   vim.cmd("edit " .. vim.fn.fnameescape(main))
+  local before = #archived()
   local msgs, restore = h.capture_notify()
   codereview.annotate("bug", nil, { immediate = true })
   restore()
@@ -209,6 +248,14 @@ describe("an immediate send that was dispatched", function()
   it("says it was sent", function()
     assert.is_truthy(sent[#sent].text:find("an errand that landed", 1, true), sent[#sent].text)
     assert.is_true(h.notified(msgs, "Sent bug"), vim.inspect(msgs))
+  end)
+
+  -- An errand is a batch of one (ADR-0004) and is archived as one, by the same rule and
+  -- through the same function -- not by a second path that agrees with this one today.
+  it("archives as a batch of one", function()
+    assert.same(before + 1, #archived())
+    assert.same(1, #archived()[1].entries)
+    assert.is_truthy(archived()[1].entries[1].note:find("an errand that landed", 1, true))
   end)
 
   -- The composer committed its draft on submit, and a note that reached someone has


### PR DESCRIPTION
Closes #71

The plugin is strictly outbound: a dispatch empties the queue, and everything the reviewer
knew goes with it. This is the record every later slice of #67 reads — the batches already
dispatched from a repository, kept after the queue that held them was cleared, and complete
on its own: submit a batch, restart Neovim, read the archive back.

## What a dispatch writes

A batch record holds the entries as they went, the target they went to, when they went, and
a **snapshot** — a `git stash create` commit that records the working tree while moving no
ref, leaving the index alone and never touching a file. That is the only reason it is safe
to run behind a submit. A clean tree mints nothing, which is a case rather than an edge:
`HEAD` already says what there was to say, so `HEAD` is what is stored.

The one rule that empties the queue is the one rule that writes it (ADR-0005). An adapter
that refused, one that raised, and the register the shipped default copies to all leave the
archive exactly as they leave the batch — a payload sitting in a register is not something
an agent received. An immediate send goes out through the same function and is kept as the
batch of one it already is (ADR-0004), with no special case.

Entries split across the two stores the queue already uses, on the rule that already decides
it: a repository-relative path means that repository, a bare note or a file outside a
checkout means the global store. Both are bounded at the twenty most recent batches, oldest
dropped on write.

## Two things that would have been easy to get wrong

**The document version is not bumped.** A mismatched version is discarded on load, so
bumping it to make room for `archive` would throw away every reviewed mark in every existing
file to add a key those files simply lack. The new key defaults on load exactly as `scopes`
and `queue` already do, and a document written before this change loads and gains an empty
one.

**The queue's id counter is seeded from the archive.** It is module-level and does not
survive a process, so a session that dispatched ids 1..n and then restarted begins again at
1 — harmless while nothing else carries an id, and a wrong-entry deletion the moment
archived entries are drawn beside queued ones, because dropping an annotation resolves by
anchor key and then by id. The seed is taken after both stores have been read, since entries
are split between them.

## Tests

`archive_spec` owns the lifecycle, in two processes for the reason `state_spec` is: reading
the archive in the process that wrote it proves nothing about what reached the disk. The id
case needs the second process for a reason of its own — a one-process test passes whether or
not the counter is seeded, because the process that dispatched is the process still counting
— and it asserts the archive really does hold id 1, or there is nothing low enough to collide
with. The clean-tree fallback gets a second fixture, reset hard, because the shared one is
dirty by design and can never reach that branch. `delivery_spec` takes one fact each for the
outcomes it already owns.

Every mechanism was checked by breaking it: removing the seed, the `HEAD` fallback, the
bound, the load default, and moving the archive write above the dispatch check each red
exactly the cases that claim them.

## No new surface

No adapter contract changes, nothing new is bound or configurable, and a host with nothing
wired behaves as it did. `delivery.deliver` gained one line at the end and is left
comfortable to split for #69.
