### PR TITLE
feat(view): draw a queued annotation as a run of rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,12 @@ at it.
 
 ### In the queue float
 
+Each annotation is a run of rows carrying a bar in its type's colour — its location, the
+code it inlines, and its note, kept as you wrote it and wrapped to the float. The bar runs
+through blank lines *inside* a note and stops between annotations, so you can always see
+where one ends. Every row belongs to the annotation it is drawn under, so `x` drops what is
+under the cursor and not what a heading further up happened to say.
+
 | Key | Action |
 | --- | --- |
 | `<CR>` | Jump to the annotation under the cursor |

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -32,6 +32,22 @@ scroll invalidates.
 separator are multibyte, so each rendered row records where its code text actually begins;
 assuming a fixed prefix width shifts every highlight on every changed line.
 
+**The queue float's bar is buffer text, not an extmark**, and that is what makes the
+cursor-to-entry mapping exact. Every row an entry owns carries the bar, so the float can
+record which entry *every* row belongs to instead of recording headings and guessing the
+rest by nearest-above — which is how dropping used to act on an entry whose extent was
+invisible. The blank row *inside* a note carries the bar and the row *between* two entries
+does not: a blank-line separator stopped being able to hold the boundary the moment notes
+kept their own line structure, because a note can contain one. Its highlight columns are
+byte offsets for the same reason the diff's change bar's are, and the glyph is the
+configured `icons.change_bar`, so a host that sets a wider one moves those offsets too.
+
+**That float wraps its own rows and turns `wrap` off in the window.** Letting the window
+wrap folds a long line back to column zero, where there is no gutter and no bar, and the
+entry appears to end mid-note. Notes go through the renderer's own `wrap`, by display
+width — the same helper, not a copy, because splitting by byte passes every ASCII assertion
+and breaks the first CJK or emoji note.
+
 **Collapsing is done at render time, not with folds.** A collapsed file's body is never
 emitted, so the buffer and the anchor map stay small on a large review, and there is one
 mechanism instead of two.

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -29,6 +29,12 @@ local LINKS = {
   CodeReviewPanelSel = "CursorLine",
   CodeReviewPanelDir = "Directory",
 
+  -- The queue float's own chrome. The bar running down an entry is that annotation type's
+  -- group rather than one of these, so what is left is the number the entry is listed
+  -- under and the state that rides on the right of its first row.
+  CodeReviewQueueIndex = "LineNr",
+  CodeReviewQueueState = "Comment",
+
   -- Annotation types, mapped onto diagnostic severities so the visual weight already
   -- matches the intent: a bug reads as loud as an error, a nitpick as quiet as a hint.
   CodeReviewBug = "DiagnosticError",

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -116,6 +116,11 @@ local function truncate(text, width)
   return vim.fn.strcharpart(text, 0, math.max(1, width - 1)) .. "…"
 end
 
+---Exported for the queue float, which draws rows of its own into a window narrower than
+---most paths. Fitting text into a column count is this module's job wherever the text goes;
+---a second copy would be a second set of rules about what "too wide" means.
+M.truncate = truncate
+
 ---Longest prefix of `text` that fits in `width` display columns, and what is left.
 ---
 ---By display width rather than by characters: a note containing CJK or an emoji occupies
@@ -177,6 +182,12 @@ local function wrap(text, width)
   end
   return out
 end
+
+---Exported for the queue float, which wraps the same notes into rows of its own. By display
+---width is the whole point of sharing it: splitting a note by byte passes every ASCII
+---assertion and breaks the first CJK or emoji one it meets, which is the trap intra-line
+---spans already walked into once.
+M.wrap = wrap
 
 ---Split a hunk header into the halves each pane draws.
 ---@param header string "@@ -19,6 +19,8 @@ heading"

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1147,6 +1147,180 @@ function M.jump_to_entry(entry)
   return true
 end
 
+--- Rendering the queue as rows ------------------------------------------------
+
+---Extmarks belonging to the float, in a namespace of its own so clearing them cannot
+---disturb the diff's or the tree's.
+local NS_QUEUE = vim.api.nvim_create_namespace("codereview_queue")
+
+---One column to the left of every bar, reserved so a later change can put a selection
+---marker there without moving anything. Nothing draws in it yet.
+local GUTTER = " "
+
+---Where a queued entry is, and what state rides on the right of its first row.
+---
+---Not `annotate.describe`, which folds the tag into the location because a composer title
+---is one line with everything to say in it. A row has a right-hand column, so the tag reads
+---as state rather than as part of the path -- and that column is where staleness now lives,
+---instead of the `⚠` prefix that was this float's entire vocabulary for saying anything
+---about an entry.
+---@param entry CRAnnotation
+---@return string where, { text: string, hl: string }[] state
+local function entry_state(entry)
+  local state = {}
+  if entry.stale then
+    state[#state + 1] = { text = "⚠ stale", hl = "CodeReviewStale" }
+  end
+  -- A bare note is about no file, so there is no location to print and no tag to print it
+  -- with; every branch below reads a path this one does not have.
+  if entry.kind == "note" then
+    return "(no file)", state
+  end
+  -- Outside a checkout there is no repository-relative path, and the absolute one is the
+  -- only name the file has.
+  local where = entry.path or entry.abs_path
+  if entry.kind == "file" then
+    state[#state + 1] = { text = entry.tag or "whole file", hl = "CodeReviewQueueState" }
+    return where, state
+  end
+  if entry.tag then
+    state[#state + 1] = { text = entry.tag, hl = "CodeReviewQueueState" }
+  end
+  local range = entry.first == entry.last and tostring(entry.first) or ("%d-%d"):format(entry.first, entry.last)
+  return ("%s:%s"):format(where, range), state
+end
+
+---Turn the queue into the float's rows.
+---
+---An entry is a run of rows carrying a bar in its annotation type's group -- its heading,
+---its inlined diff block, every wrapped line of its note, and the blank lines *inside* that
+---note. The blank row *between* two entries carries none. That is what makes the boundary
+---hold whatever a note contains: once notes keep their own line structure, a blank line can
+---no longer separate entries, because a note can contain one. It costs no extra rows over
+---the flat list it replaces, and it makes an entry's type legible at every row rather than
+---only where the reviewer happened to enter it.
+---
+---The bar is buffer text rather than an extmark, as the diff's change bar is. That is what
+---keeps `rows` -- which maps *every* row to the entry owning it, not only the headings --
+---trivially exact, so resolving the cursor stops being a nearest-heading-above guess and a
+---reviewer can no longer drop something whose extent they cannot see.
+---
+---Its highlight columns are byte offsets, not display columns: the bar glyph is multibyte,
+---and so is anything a host configures in its place.
+---@param items CRAnnotation[]
+---@param opts { types: CRType[], bar: string, width: integer }
+---@return { lines: string[], marks: table[], rows: table<integer, integer> }
+local function build_queue(items, opts)
+  local lines, marks, rows = {}, {}, {}
+  local bar = opts.bar
+  local bar_col, bar_end = #GUTTER, #GUTTER + #bar
+  -- Padded to the widest number in the batch, so entry 10 does not shift the column every
+  -- row below it is drawn in.
+  local digits = #tostring(#items)
+  local indent = GUTTER .. bar .. (" "):rep(digits + 2)
+  local body = math.max(8, opts.width - vim.fn.strdisplaywidth(indent))
+
+  ---@param row integer 1-indexed
+  ---@param col integer 0-indexed byte
+  local function mark(row, col, o)
+    marks[#marks + 1] = { row = row - 1, col = col, opts = o }
+  end
+
+  ---A row belonging to `entry`, carrying its bar and nothing else by default.
+  ---@return integer row
+  local function bar_row(id, group, text)
+    lines[#lines + 1] = text
+    rows[#lines] = id
+    mark(#lines, bar_col, { end_col = bar_end, hl_group = group })
+    return #lines
+  end
+
+  local index = 0
+  -- The same helper the payload renders through, handed the same list: what the float
+  -- shows and what the batch says have to be the one grouping, not two that agree today.
+  for gi, group in ipairs(require("codereview.types").group(items, opts.types)) do
+    if gi > 1 then
+      lines[#lines + 1] = ""
+    end
+    local label = ("## %s"):format(group.type.label)
+    local heading = label
+    if group.type.directive and group.type.directive ~= "" then
+      heading = heading .. (" — %s"):format(group.type.directive)
+    end
+    lines[#lines + 1] = heading
+    -- Painted rather than inherited. The float used to set `filetype=markdown` and take
+    -- whatever the `##` and `>` prefixes happened to attract, which coloured its chrome by
+    -- accident and an entry's annotation type not at all.
+    mark(#lines, 0, { end_col = #label, hl_group = "CodeReviewTitle" })
+    if #heading > #label then
+      mark(#lines, #label, { end_col = #heading, hl_group = "CodeReviewNote" })
+    end
+
+    -- A configured type always carries one; `types.UNTYPED` is not a configured type and
+    -- has none, and falls back to what the diff draws an unresolvable type's note in.
+    local bar_hl = group.type.hl or "CodeReviewNote"
+
+    for ei, entry in ipairs(group.items) do
+      index = index + 1
+      -- Between entries and nowhere else: this row belongs to neither of them, which is
+      -- exactly what makes the boundary visible.
+      if ei > 1 then
+        lines[#lines + 1] = ""
+      end
+
+      local where, state = entry_state(entry)
+      local right = table.concat(
+        vim.tbl_map(function(chunk)
+          return chunk.text
+        end, state),
+        " · "
+      )
+      local room = body - (right ~= "" and vim.fn.strdisplaywidth(right) + 2 or 0)
+      where = render.truncate(where, math.max(8, room))
+      local head = GUTTER .. bar .. ("%" .. digits .. "d"):format(index) .. "  " .. where
+      if right ~= "" then
+        head = head .. (" "):rep(math.max(1, room - vim.fn.strdisplaywidth(where) + 2)) .. right
+      end
+
+      local row = bar_row(entry.id, bar_hl, head)
+      mark(row, bar_end, { end_col = bar_end + digits, hl_group = "CodeReviewQueueIndex" })
+      mark(row, #indent, { end_col = #indent + #where, hl_group = "CodeReviewFileHeader" })
+      -- From the right, chunk by chunk: the pad before it is display width and the columns
+      -- an extmark wants are bytes, so the only offset that can be counted on is the end.
+      local col = #head
+      for i = #state, 1, -1 do
+        mark(row, col - #state[i].text, { end_col = col, hl_group = state[i].hl })
+        col = col - #state[i].text - #" · "
+      end
+
+      -- The code an entry carries travels inside its bar. `+`/`-` already say which side a
+      -- line is, so they are drawn in the colours the diff gives them.
+      if entry.inline and entry.lines then
+        for _, code in ipairs(entry.lines) do
+          local text = indent .. render.truncate(code, body)
+          local r = bar_row(entry.id, bar_hl, text)
+          local sign = code:sub(1, 1)
+          if sign == "+" or sign == "-" then
+            mark(r, #indent, { end_col = #text, hl_group = sign == "+" and "CodeReviewAdd" or "CodeReviewDel" })
+          end
+        end
+      end
+
+      -- Kept as the reviewer wrote it: newlines used to be replaced with spaces before
+      -- rendering, so prose that was structured read back as a run-on. Wrapped by display
+      -- width, which is why the renderer's helper is shared rather than copied -- splitting
+      -- by byte passes every ASCII assertion and corrupts the first CJK or emoji note.
+      for _, text in ipairs(render.wrap(entry.note, body)) do
+        -- A blank line inside a note is a bar and nothing after it, which is what keeps the
+        -- entry unbroken across one.
+        bar_row(entry.id, bar_hl, text == "" and (GUTTER .. bar) or (indent .. text))
+      end
+    end
+  end
+
+  return { lines = lines, marks = marks, rows = rows }
+end
+
 ---List the queued annotations, drop any of them, then submit the batch.
 function M.review_queue()
   local queue = require("codereview.queue")
@@ -1158,7 +1332,6 @@ function M.review_queue()
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].bufhidden = "wipe"
-  vim.bo[buf].filetype = "markdown"
 
   local width = math.min(100, math.max(50, math.floor(vim.o.columns * 0.8)))
   local height = math.min(28, math.max(10, math.floor(vim.o.lines * 0.7)))
@@ -1177,15 +1350,18 @@ function M.review_queue()
   }
 
   local win = vim.api.nvim_open_win(buf, true, cfg_win)
-  vim.wo[win].wrap = true
+  -- The rows wrap themselves, to a width they know, so that a bar keeps running down the
+  -- left of every one of them. Letting the window wrap instead would fold a long line back
+  -- to column zero, where there is no bar and no gutter, and the entry would appear to end.
+  vim.wo[win].wrap = false
   -- Recorded so `submit` can close the float no matter which window it was triggered
   -- from; a submitted batch must never leave a dialog listing it still on screen.
   if V then
     V.queue_win = win
   end
 
-  ---Rendered row of each entry's heading, so `x` can map a cursor position back to it.
-  local anchors = {}
+  ---The rows on screen, and which entry each of them belongs to.
+  local painted = { lines = {}, marks = {}, rows = {} }
 
   local function close()
     if V and V.queue_win == win then
@@ -1198,35 +1374,22 @@ function M.review_queue()
 
   local function paint_queue()
     local cfg = config.get()
-    local lines = {}
-    anchors = {}
-    local index = 0
-    -- The same helper the payload renders through, handed the same list: what the float
-    -- shows and what the batch says have to be the one grouping, not two that agree today.
-    for _, group in ipairs(require("codereview.types").group(queue.all(), cfg.types)) do
-      local heading = ("## %s"):format(group.type.label)
-      if group.type.directive and group.type.directive ~= "" then
-        heading = heading .. (" — %s"):format(group.type.directive)
-      end
-      lines[#lines + 1] = heading
-      for _, entry in ipairs(group.items) do
-        index = index + 1
-        anchors[#lines + 1] = entry.id
-        local where = require("codereview.annotate").describe(entry)
-        lines[#lines + 1] = ("%d. %s%s %s"):format(index, entry.stale and "⚠ " or "", group.type.icon, where)
-        if entry.inline and entry.lines then
-          for _, d in ipairs(entry.lines) do
-            lines[#lines + 1] = "   " .. d
-          end
-        end
-        lines[#lines + 1] = "   > " .. entry.note:gsub("\n", " ")
-      end
-      lines[#lines + 1] = ""
-    end
+    painted = build_queue(queue.all(), {
+      types = cfg.types,
+      -- The change-bar vocabulary the diff already speaks, including when a host has
+      -- configured a glyph of its own, so an entry's bar reads as structure rather than as
+      -- decoration this surface invented.
+      bar = cfg.icons.change_bar,
+      width = vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_width(win) or width,
+    })
 
     vim.bo[buf].modifiable = true
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, painted.lines)
     vim.bo[buf].modifiable = false
+    vim.api.nvim_buf_clear_namespace(buf, NS_QUEUE, 0, -1)
+    for _, m in ipairs(painted.marks) do
+      pcall(vim.api.nvim_buf_set_extmark, buf, NS_QUEUE, m.row, m.col, m.opts)
+    end
 
     local n, stale = queue.count(), queue.stale_count()
     local name = delivery.target_label()
@@ -1243,16 +1406,27 @@ function M.review_queue()
     end
   end
 
-  ---The entry the cursor is inside: the nearest heading at or above it.
+  ---The entry the cursor is on. Exact, because every row of an entry is mapped to it --
+  ---a group heading and the blank row between two entries belong to none, and answer nil.
   local function entry_at_cursor()
-    local row = vim.api.nvim_win_get_cursor(win)[1]
-    local best
-    for anchor, id in pairs(anchors) do
-      if anchor <= row and (not best or anchor > best.anchor) then
-        best = { anchor = anchor, id = id }
+    return painted.rows[vim.api.nvim_win_get_cursor(win)[1]]
+  end
+
+  ---Put the cursor back on an entry after a repaint.
+  ---
+  ---Dropping the last entry of a group leaves the cursor on the blank row that separated it
+  ---from the next one, or on a heading -- rows that deliberately belong to nothing now that
+  ---resolving one is exact. Without this, the second `x` of a run would silently do nothing.
+  local function settle_cursor()
+    local row = math.min(vim.api.nvim_win_get_cursor(win)[1], math.max(#painted.lines, 1))
+    for _, range in ipairs({ { row, #painted.lines, 1 }, { row, 1, -1 } }) do
+      for r = range[1], range[2], range[3] do
+        if painted.rows[r] then
+          pcall(vim.api.nvim_win_set_cursor, win, { r, 0 })
+          return
+        end
       end
     end
-    return best and best.id or nil
   end
 
   ---That entry as it sits in the queue.
@@ -1294,6 +1468,7 @@ function M.review_queue()
       return
     end
     paint_queue()
+    settle_cursor()
   end, { buffer = buf, desc = "Drop annotation" })
 
   vim.keymap.set("n", "<C-t>", function()

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
+| `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, and dropping from anywhere inside one |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
 | `queue_jump_panel_spec` | That jump with the tree dismissed, summoned, and never there — the one surface neither slice could test alone |
@@ -68,10 +69,10 @@ interchangeable, and the assertions know which one they are looking at.
   modified, deleted, added, renamed-and-edited, staged, unstaged, untracked, untracked
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
-  `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `split_spec`,
-  `layout_spec`, `open_diff_spec`, `archive_spec` and `interactive_spec`. Its dirty working
-  tree is what makes a snapshot worth minting, so `archive_spec` builds a second copy and
-  resets it to get a clean one. It already covers everything the split layout has
+  `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `queue_float_spec`,
+  `split_spec`, `layout_spec`, `open_diff_spec`, `archive_spec` and `interactive_spec`. Its
+  dirty working tree is what makes a snapshot worth minting, so `archive_spec` builds a
+  second copy and resets it to get a clean one. It already covers everything the split layout has
   to render, including the files that exist on only one side and the additions between
   context lines that produce filler — so that slice needed no fixture of its own. The
   layout toggle needed none either: `src/main.lua`'s deletion and its replacement collapse
@@ -255,6 +256,12 @@ so the out-of-core language path is still checked locally without ever failing C
   in both panes on its row passes with the before pane never drawing anything, because the
   case is then reading the after pane twice. `spans_spec` uses `src/nonl.md`, the fixture's
   only pair that changes something on each side.
+- **Two entries of different types are separated by a group, not by a row.** The queue
+  float's boundary between entries is one blank row carrying no bar, and an assertion about
+  it needs two entries of the *same* annotation type — give them different ones and what
+  sits between them is a blank row plus a group heading, so the assertion is measuring the
+  gap between groups instead. `queue_float_spec` keeps a third entry of another type for
+  the claim that actually is about types.
 - **`interactive_spec` must keep its teeth.** To confirm it still reproduces the bug,
   remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless

--- a/tests/codereview/queue_float_spec.lua
+++ b/tests/codereview/queue_float_spec.lua
@@ -1,0 +1,451 @@
+-- How the queue float draws an entry.
+--
+-- The float lists a batch that is read once, before submitting it, so what is asserted here
+-- is that an entry has visible extent: a bar in its annotation type's group running down
+-- every row it owns, and no bar on the row between it and the next. That boundary is not
+-- decoration -- it is the same fact `x` resolves against, so an entry whose extent is
+-- visible is an entry that cannot be dropped by accident.
+--
+-- Rows and highlight *groups*, never colours: what a colorscheme resolves a group to is
+-- deliberately not covered anywhere in this suite.
+local h = require("tests.helpers")
+
+h.ui(100, 30)
+h.cd_fixture("mkfixture")
+
+require("codereview").setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "a note")
+  end,
+  send = function() end,
+})
+
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+local config = require("codereview.config")
+
+local NS = vim.api.nvim_create_namespace("codereview_queue")
+
+---The reserved gutter and the bar, as the float draws them. Multibyte on purpose: every
+---column an extmark is placed at below is a *byte* offset, which is the trap the diff's own
+---change bar already records in `docs/design-notes.md`.
+local GUTTER = " "
+local BAR = config.get().icons.change_bar
+
+---@param over table Fields to set on the entry
+---@return CRAnnotation
+local function queued(over)
+  return queue.add(vim.tbl_extend("force", {
+    type = "bug",
+    kind = "line",
+    path = "src/main.lua",
+    abs_path = vim.fs.joinpath(vim.fn.getcwd(), "src/main.lua"),
+    key = "src/main.lua:n:1",
+    first = 1,
+    last = 1,
+    note = "a note",
+  }, over))
+end
+
+---@return integer win, integer buf
+local function open_float()
+  view.review_queue()
+  local win = vim.api.nvim_get_current_win()
+  return win, vim.api.nvim_win_get_buf(win)
+end
+
+---@param buf integer
+---@return string[]
+local function lines(buf)
+  return vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+end
+
+---Every extmark starting on a row, as { col, end_col, hl }.
+---@param buf integer
+---@param row integer 1-indexed
+---@return { col: integer, end_col: integer, hl: string }[]
+local function marks_on(buf, row)
+  local out = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, NS, { row - 1, 0 }, { row - 1, -1 }, { details = true })) do
+    out[#out + 1] = { col = m[3], end_col = m[4].end_col, hl = m[4].hl_group }
+  end
+  return out
+end
+
+---The group the bar on a row is drawn in, or nil when the row carries no bar.
+---
+---Identified by the byte span the bar occupies rather than by "the first mark", so a row
+---that merely happens to be highlighted somewhere cannot pass for one carrying a bar.
+---@param buf integer
+---@param row integer
+---@return string|nil
+local function bar_group(buf, row)
+  local text = lines(buf)[row]
+  if not text or text:sub(#GUTTER + 1, #GUTTER + #BAR) ~= BAR then
+    return nil
+  end
+  for _, m in ipairs(marks_on(buf, row)) do
+    if m.col == #GUTTER and m.end_col == #GUTTER + #BAR then
+      return m.hl
+    end
+  end
+end
+
+---@param buf integer
+---@param group string
+---@return { col: integer, end_col: integer, hl: string }|nil
+local function mark_of(buf, row, group)
+  for _, m in ipairs(marks_on(buf, row)) do
+    if m.hl == group then
+      return m
+    end
+  end
+end
+
+---Rows carrying an entry's bar, from the row its number is drawn on downwards.
+---@param buf integer
+---@param index integer
+---@return integer first, integer last
+local function extent(buf, index)
+  local first
+  for row, text in ipairs(lines(buf)) do
+    if text:match("^%s*" .. vim.pesc(BAR) .. "%s*" .. index .. "  ") then
+      first = row
+      break
+    end
+  end
+  assert(first, ("entry %d is not listed in the float"):format(index))
+  local last = first
+  while bar_group(buf, last + 1) do
+    last = last + 1
+  end
+  return first, last
+end
+
+local function fresh()
+  queue.clear()
+end
+
+--- One entry, drawn as a run of rows ------------------------------------------
+
+describe("an entry with an inlined diff block and a multi-line note", function()
+  fresh()
+  queued({
+    inline = true,
+    lines = { "-const cfg = load()", "+const cfg = loadCfg()" },
+    first = 20,
+    last = 21,
+    stale = true,
+    note = "why the rename? we lose the cached path here\n\nnothing else calls loadCfg yet",
+  })
+  queued({
+    path = "src/routes.lua",
+    key = "src/routes.lua:o:14",
+    first = 14,
+    last = 14,
+    tag = "deleted",
+    note = "the old handler is still referenced from tests",
+  })
+  -- A third, of another type, so "the bar is this entry's type" is a claim about the entry
+  -- rather than about the whole float.
+  queued({ type = "nitpick", note = "a nitpick" })
+
+  local win, buf = open_float()
+  local text = lines(buf)
+  local first, last = extent(buf, 1)
+  local second = extent(buf, 2)
+  local third = extent(buf, 3)
+
+  it("draws the group heading and its directive exactly as the payload's grouping says", function()
+    assert.same("## Bugs — diagnose and fix these", text[1])
+  end)
+
+  it("starts the entry directly under its heading", function()
+    assert.same(2, first)
+  end)
+
+  it("carries a bar in the annotation type's group on every row it owns", function()
+    for row = first, last do
+      assert.same("CodeReviewBug", bar_group(buf, row), ("row %d: %q"):format(row, text[row]))
+    end
+  end)
+
+  it("keeps the note's own lines rather than flattening them to one", function()
+    assert.is_truthy(vim.tbl_contains(text, GUTTER .. BAR .. "   why the rename? we lose the cached path here"))
+    assert.is_truthy(vim.tbl_contains(text, GUTTER .. BAR .. "   nothing else calls loadCfg yet"))
+  end)
+
+  it("runs the bar through the blank line inside that note", function()
+    local blank
+    for row = first, last do
+      if text[row] == GUTTER .. BAR then
+        blank = row
+      end
+    end
+    assert.is_truthy(blank, table.concat(text, "\n"))
+    assert.same("CodeReviewBug", bar_group(buf, blank))
+  end)
+
+  it("renders the inlined diff block inside the same bar", function()
+    local rows = {}
+    for row = first, last do
+      if text[row]:find("loadCfg()", 1, true) or text[row]:find("load()", 1, true) then
+        rows[#rows + 1] = row
+      end
+    end
+    assert.same(2, #rows, table.concat(text, "\n"))
+    for _, row in ipairs(rows) do
+      assert.same("CodeReviewBug", bar_group(buf, row))
+    end
+  end)
+
+  it("separates the two entries with a row belonging to neither", function()
+    assert.same(last + 2, second)
+    assert.same("", text[last + 1])
+    assert.is_nil(bar_group(buf, last + 1))
+  end)
+
+  it("draws an entry of another type in that type's group", function()
+    assert.same("CodeReviewBug", bar_group(buf, second))
+    assert.same("CodeReviewNitpick", bar_group(buf, third))
+  end)
+
+  it("marks the stale entry as stale, and only that one", function()
+    assert.is_truthy(mark_of(buf, first, "CodeReviewStale"), text[first])
+    assert.is_nil(mark_of(buf, second, "CodeReviewStale"), text[second])
+  end)
+
+  it("puts the entry's tag in the state column beside it", function()
+    local state = assert(mark_of(buf, second, "CodeReviewQueueState"), text[second])
+    assert.same("deleted", text[second]:sub(state.col + 1, state.end_col))
+  end)
+
+  -- The bar glyph is multibyte, and extmark columns are byte offsets. A highlight placed at
+  -- the display column instead lands inside the glyph and paints nothing recognisable --
+  -- the same trap the diff's change bar records in the design notes.
+  it("highlights the bar by byte offset, not by display column", function()
+    assert.is_true(#BAR > vim.fn.strdisplaywidth(BAR), "the bar under test is not multibyte")
+    local bar = mark_of(buf, first, "CodeReviewBug")
+    assert.same({ col = #GUTTER, end_col = #GUTTER + #BAR }, { col = bar.col, end_col = bar.end_col })
+  end)
+
+  it("reserves the gutter to the left of every bar", function()
+    for row = first, last do
+      assert.same(GUTTER, text[row]:sub(1, #GUTTER), ("row %d: %q"):format(row, text[row]))
+    end
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- Wrapping --------------------------------------------------------------------
+
+describe("a note wider than the float", function()
+  fresh()
+  -- No spaces, so the wrap has nowhere to break but mid-word -- which is where cutting by
+  -- byte or by character count goes wrong. Each of these occupies two display columns.
+  local cjk = ("字"):rep(120)
+  queued({ note = cjk })
+  queued({ type = "nitpick", note = ("🎉"):rep(60) })
+
+  local win, buf = open_float()
+  local width = vim.api.nvim_win_get_width(win)
+  local text = lines(buf)
+  local first, last = extent(buf, 1)
+  local body = {}
+  for row = first + 1, last do
+    body[#body + 1] = text[row]:sub(#GUTTER + #BAR + 1):gsub("^%s+", "")
+  end
+
+  it("wrapped it over several rows", function()
+    assert.is_true(#body > 1, table.concat(body, "\n"))
+  end)
+
+  it("keeps every row inside the float", function()
+    for row = 1, #text do
+      assert.is_true(
+        vim.fn.strdisplaywidth(text[row]) <= width,
+        ("row %d is %d columns wide in a %d-column float"):format(row, vim.fn.strdisplaywidth(text[row]), width)
+      )
+    end
+  end)
+
+  -- The assertion that fails when the wrap counts characters rather than columns: each of
+  -- these is two columns, so a row holding as many characters as it has columns to spend is
+  -- twice as wide as the float.
+  it("wrapped by display width rather than by character count", function()
+    for _, row in ipairs(body) do
+      assert.is_true(vim.fn.strchars(row) < vim.fn.strdisplaywidth(row) + 1, row)
+      assert.is_true(vim.fn.strdisplaywidth(row) > vim.fn.strchars(row), row)
+    end
+  end)
+
+  it("breaks between characters, not inside one", function()
+    assert.same(cjk, table.concat(body))
+  end)
+
+  it("wraps an emoji note the same way", function()
+    local from, to = extent(buf, 2)
+    local out = {}
+    for row = from + 1, to do
+      out[#out + 1] = text[row]:sub(#GUTTER + #BAR + 1):gsub("^%s+", "")
+    end
+    assert.is_true(#out > 1, table.concat(out, "\n"))
+    assert.same(("🎉"):rep(60), table.concat(out))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- Resolving the cursor --------------------------------------------------------
+
+describe("dropping from anywhere inside an entry", function()
+  ---Drop with the cursor on `row`, and say what survived.
+  ---@param row integer
+  ---@return string[] remaining notes
+  local function drop_at(row)
+    local win = select(1, open_float())
+    vim.api.nvim_win_set_cursor(win, { row, 0 })
+    h.feed("x")
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+    return vim.tbl_map(function(item)
+      return item.note
+    end, queue.all())
+  end
+
+  ---Two entries, the first of them tall enough to have a middle and a last row.
+  local function two()
+    fresh()
+    queued({ note = "first\n\nnote", inline = true, lines = { "+one", "+two" } })
+    queued({ type = "nitpick", note = "second" })
+  end
+
+  two()
+  local win, buf = open_float()
+  local first, last = extent(buf, 1)
+  local second = extent(buf, 2)
+  vim.api.nvim_win_close(win, true)
+
+  it("has an entry several rows tall to act on", function()
+    assert.is_true(last > first + 1, ("rows %d..%d"):format(first, last))
+  end)
+
+  it("drops it from its first row", function()
+    two()
+    assert.same({ "second" }, drop_at(first))
+  end)
+
+  it("drops it from a middle row", function()
+    two()
+    assert.same({ "second" }, drop_at(first + 1))
+  end)
+
+  -- The one the old nearest-heading-above resolution got wrong: the last row of an entry
+  -- is as far from its heading as a row can be while still belonging to it.
+  it("drops it from its last row", function()
+    two()
+    assert.same({ "second" }, drop_at(last))
+  end)
+
+  it("drops the second entry from its own row, not the first one", function()
+    two()
+    assert.same({ "first\n\nnote" }, drop_at(second))
+  end)
+
+  -- All three of these dropped the *previous* entry while the cursor resolved to the
+  -- nearest heading above it, which is the hazard: none of them is anywhere a reviewer can
+  -- see an entry, and one is a whole group away from what used to answer for it.
+  it("drops nothing from the row between two entries", function()
+    two()
+    assert.same({ "first\n\nnote", "second" }, drop_at(last + 1))
+  end)
+
+  it("drops nothing from the heading of the group below", function()
+    two()
+    assert.same({ "first\n\nnote", "second" }, drop_at(second - 1))
+  end)
+
+  it("drops nothing from the first group's heading", function()
+    two()
+    assert.same({ "first\n\nnote", "second" }, drop_at(1))
+  end)
+end)
+
+describe("dropping the last entry of a group", function()
+  fresh()
+  queued({ note = "bug one" })
+  queued({ type = "nitpick", note = "nit one" })
+
+  local win, buf = open_float()
+  local _, last = extent(buf, 1)
+  vim.api.nvim_win_set_cursor(win, { last, 0 })
+  h.feed("x")
+  local landed = vim.api.nvim_win_get_cursor(win)[1]
+  local after = vim.api.nvim_win_get_buf(win)
+
+  -- Otherwise the cursor is left on the heading the repaint moved under it, and the second
+  -- `x` of a run silently does nothing.
+  it("leaves the cursor on an entry rather than on chrome", function()
+    assert.same("CodeReviewNitpick", bar_group(after, landed), lines(after)[landed])
+  end)
+
+  it("acts on that entry next", function()
+    h.feed("x")
+    assert.same(0, queue.count())
+  end)
+
+  it("closes once the queue is empty", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+end)
+
+--- Types and their groups ------------------------------------------------------
+
+describe("an entry carrying no annotation type", function()
+  fresh()
+  -- Added by hand rather than through the helper: `tbl_extend` cannot express "and no
+  -- type", which is the one thing this case is about.
+  queue.add({
+    kind = "line",
+    path = "src/main.lua",
+    abs_path = vim.fs.joinpath(vim.fn.getcwd(), "src/main.lua"),
+    key = "src/main.lua:n:1",
+    first = 1,
+    last = 1,
+    note = "untyped",
+  })
+
+  local win, buf = open_float()
+  local text = lines(buf)
+  local row = extent(buf, 1)
+
+  it("still gets its own heading, with no directive on it", function()
+    assert.same("## Untyped", text[1])
+  end)
+
+  it("falls back to the group an unresolvable type's note is drawn in", function()
+    assert.same("CodeReviewNote", bar_group(buf, row))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+describe("the float's own highlight groups", function()
+  local hl = require("codereview.hl")
+
+  it("are links a colorscheme already defines", function()
+    assert.same("LineNr", vim.api.nvim_get_hl(0, { name = "CodeReviewQueueIndex" }).link)
+    assert.same("Comment", vim.api.nvim_get_hl(0, { name = "CodeReviewQueueState" }).link)
+  end)
+
+  -- `default = true` is what makes an override stick: re-applying, as a colorscheme change
+  -- does, must not take a user's definition back.
+  it("leave an override alone when they are re-applied", function()
+    vim.api.nvim_set_hl(0, "CodeReviewQueueState", { link = "ErrorMsg" })
+    hl.apply()
+    assert.same("ErrorMsg", vim.api.nvim_get_hl(0, { name = "CodeReviewQueueState" }).link)
+  end)
+end)

--- a/tests/codereview/queue_float_spec.lua
+++ b/tests/codereview/queue_float_spec.lua
@@ -11,19 +11,31 @@
 local h = require("tests.helpers")
 
 h.ui(100, 30)
-h.cd_fixture("mkfixture")
+local fixture = h.cd_fixture("mkfixture")
+
+---What the send adapter was handed. An adapter that returns nothing dispatches, which is
+---the one condition that both empties the queue and records the batch.
+local sent = {}
 
 require("codereview").setup({
   syntax = false,
   compose = function(_, on_accept)
     on_accept(nil, "a note")
   end,
-  send = function() end,
+  send = function(text, target)
+    sent[#sent + 1] = { text = text, target = target }
+  end,
 })
 
 local view = require("codereview.view")
 local queue = require("codereview.queue")
 local config = require("codereview.config")
+local state = require("codereview.state")
+
+-- Resolved, because the archive is keyed on the root git answers with and git answers with
+-- symlinks resolved. On macOS the fixture lives under a `/var` symlink, so the unresolved
+-- form would read a document nothing ever wrote.
+local root = assert(vim.uv.fs_realpath(fixture))
 
 local NS = vim.api.nvim_create_namespace("codereview_queue")
 
@@ -447,5 +459,63 @@ describe("the float's own highlight groups", function()
     vim.api.nvim_set_hl(0, "CodeReviewQueueState", { link = "ErrorMsg" })
     hl.apply()
     assert.same("ErrorMsg", vim.api.nvim_get_hl(0, { name = "CodeReviewQueueState" }).link)
+  end)
+end)
+
+--- Where submitting from the float ends up -------------------------------------
+
+-- The case neither slice could have written, and the reason it is here.
+--
+-- This float was restructured against a base with no archive; the archive was built
+-- against a base with the old float. They meet at one keystroke: `<C-s>` closes the float
+-- and submits, and a **dispatch** is the single condition that both empties the queue and
+-- records the batch. Each side was green in isolation and nothing covered the join.
+--
+-- Driven through the float's own key rather than `view.submit()`, because what is in doubt
+-- is the path from this surface, not the rule at the end of it -- `delivery_spec` already
+-- owns which outcomes write to the archive, and `archive_spec` owns what survives a
+-- restart.
+describe("submitting from the float", function()
+  fresh()
+  queued({ note = "went out from the float" })
+  queued({ type = "nitpick", note = "and this one with it" })
+
+  local before = #state.archive(root)
+  local listed = #sent
+  local win = select(1, open_float())
+  h.feed("<C-s>")
+
+  it("hands the batch to the send adapter", function()
+    assert.same(listed + 1, #sent)
+    assert.is_truthy(sent[#sent].text:find("went out from the float", 1, true), sent[#sent].text)
+  end)
+
+  it("empties the queue", function()
+    assert.same(0, queue.count())
+  end)
+
+  -- The invariant the float's window handle is recorded for, restated here because this is
+  -- the keystroke that has to honour it: a batch that has gone must not be left on screen.
+  it("leaves no float listing a batch that has already gone", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+
+  it("records the batch in the archive", function()
+    assert.same(before + 1, #state.archive(root))
+  end)
+
+  it("archives every entry the float was listing, and only those", function()
+    assert.same(
+      { "went out from the float", "and this one with it" },
+      vim.tbl_map(function(entry)
+        return entry.note
+      end, state.archive(root)[1].entries)
+    )
+  end)
+
+  -- The same name the float's own footer was reporting while it was open, so what the
+  -- archive says about where a batch went agrees with what the reviewer was told.
+  it("names where it went", function()
+    assert.same("local", state.archive(root)[1].target)
   end)
 end)

--- a/tests/codereview/queue_jump_panel_spec.lua
+++ b/tests/codereview/queue_jump_panel_spec.lua
@@ -69,10 +69,14 @@ local function open_float()
 end
 
 ---Put the float's cursor on the only entry it is listing, and press the jump key.
+---
+---An entry's number no longer sits at column zero: it is drawn behind the reserved gutter
+---and the bar that runs down every row the entry owns, so the row is found by that prefix.
 ---@param win integer
 local function jump_from(win)
+  local bar = vim.pesc(require("codereview.config").get().icons.change_bar)
   for row, text in ipairs(vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, -1, false)) do
-    if text:match("^1%. ") then
+    if text:match("^%s*" .. bar .. "%s*1  ") then
       vim.api.nvim_win_set_cursor(win, { row, 0 })
       h.feed("<CR>")
       return

--- a/tests/codereview/queue_jump_spec.lua
+++ b/tests/codereview/queue_jump_spec.lua
@@ -79,13 +79,17 @@ local function open_float()
 end
 
 ---Put the float's cursor inside the numbered entry.
+---
+---An entry's number no longer sits at column zero: it is drawn behind the reserved gutter
+---and the bar that runs down every row the entry owns, so the row is found by that prefix.
 ---@param win integer
 ---@param index integer The number the float printed against the entry
 ---@param offset integer|nil Rows below the heading, for the "cursor is inside it" case
 local function cursor_on(win, index, offset)
+  local bar = vim.pesc(require("codereview.config").get().icons.change_bar)
   local buf = vim.api.nvim_win_get_buf(win)
   for row, text in ipairs(vim.api.nvim_buf_get_lines(buf, 0, -1, false)) do
-    if text:match("^" .. index .. "%. ") then
+    if text:match("^%s*" .. bar .. "%s*" .. index .. "  ") then
       vim.api.nvim_win_set_cursor(win, { row + (offset or 0), 0 })
       return row
     end


### PR DESCRIPTION
Closes #68

The queue float listed the batch as flat markdown lines. An entry with an inlined diff
block and a multi-line note ran straight into the next with nothing between them, and the
float resolved the cursor to an entry by finding the nearest heading at or above it — so a
reviewer pressing `x` was acting on something whose extent they could not see. The note was
flattened to one line, the annotation type's highlight group was discarded in favour of
whatever `filetype=markdown` gave the `##` and `>` prefixes, and staleness was a `⚠` prefix,
which was the whole vocabulary the float had for saying anything about an entry.

## What it looks like now

```
## Bugs — diagnose and fix these
 ▍1  src/main.lua:20-21                                              ⚠ stale
 ▍   -const cfg = load()
 ▍   +const cfg = loadCfg()
 ▍   why the rename? we lose the cached path here, and
 ▍
 ▍   nothing else calls loadCfg yet

 ▍2  src/routes.lua:14                                               deleted
 ▍   the old handler is still referenced from tests
```

Rows, not boxed cards: the float caps its height and density is what it is for — a border
per entry costs three to four rows each and halves what fits on screen.

The bar runs down **every** row an entry owns, including the blank lines *inside* its note,
and is absent between entries. That is the only separator that still holds once notes stop
being flattened, because a note can contain a blank line. It costs no extra rows, and it
makes the type legible wherever the eye lands rather than only at the heading. It is the
configured `icons.change_bar`, so it is the vocabulary the diff already speaks.

## The real fix

The bar is buffer text rather than an extmark, as the diff's change bar is, which is what
lets **every** row be mapped to the entry owning it instead of headings alone. Resolving the
cursor is then exact — dropping from an entry's last row drops that entry, and dropping from
the row between two drops neither. That is the actual hazard in #68, and it falls out of the
restructure rather than needing work of its own.

The gutter to the left of every bar is reserved and unused, so #69 can put a selection
marker there without moving anything.

## Kept as it was

- The grouping is still `types.group`, shared with the payload — one grouping, not two that
  agree today. Group headings and their directives are unchanged.
- Jump, drop, choose target, submit and close all behave as before, and the footer still
  reports the target and the keys.
- Highlight groups are `default = true` links; two are new, `CodeReviewQueueIndex` and
  `CodeReviewQueueState`. Everything else reuses what exists — the type's own `hl` for the
  bar, `CodeReviewStale` for staleness.
- A separator rule between entries was deliberately deferred, per the issue.

## Rebased onto master, and the intersection it exposed

Rebased onto `origin/master` after #79, #76 and #71 landed. One conflict, in
`tests/README.md`: this slice and #71 each added a spec to the `mkfixture` user list. Both
kept, in the table's existing order. Nothing else moved.

**#71 and this slice meet at `<C-s>` and nothing covered the join.** This float was
restructured against a base with no archive; the archive was built against a base with the
old float. Both were green in isolation. `queue_float_spec` now drives the float's own key
and asserts the batch reached the archive — that it is recorded, that it holds every entry
the float was listing and only those, and that it names where it went — alongside the
existing invariant that a dispatched batch leaves no float on screen. It sits in
`queue_float_spec` because what is in doubt is the path from this surface; which outcomes
write to the archive is `delivery_spec`'s and what survives a restart is `archive_spec`'s.

**Dropping by id is unaffected by archived ids, and needs no test.** `queue.seed` reserves
ids an archived entry holds, but the float resolves a drop against `queue.all()`, which
never contains an archived entry, and live ids are unique by construction. Verified rather
than argued: with `seed` neutered, so a restored session mints ids 1 and 2 against archived
ids 1 and 2, dropping through the float still removes exactly the entry under the cursor.
The collision `seed` exists to prevent belongs to a different consumer — an archived entry
drawn on the diff beside a live one — which `archive_spec` already owns.

## Note for review — two test locators changed

`queue_jump_spec` and `queue_jump_panel_spec` find an entry's row by matching `^%d+%. ` at
column zero. An entry's number now sits behind the reserved gutter and the bar, so that
locator cannot match whatever the new rendering is. **Only those two locator helpers
changed; every assertion in both files is byte-identical.** `focus_spec` is untouched.

## Verification

`make all` on the rebased tree: **954 cases green, 0 failures, 0 errors.**

Mutations applied **separately**, each restored before the next, so neither could mask the
other:

| Mutation | Result |
| --- | --- |
| Cursor-to-entry resolution reverted to nearest-heading-above (`view.lua`) | **red — 2 cases**: "drops nothing from the row between two entries" and "drops nothing from the heading of the group below". Restored → 38/38 green. |
| Archive write removed from `delivery.deliver` | **red — 3 cases**: "records the batch in the archive", "archives every entry the float was listing, and only those", "names where it went". Restored → 38/38 green. |

The rendering assertions were mutation-checked earlier the same way — a flattened note, a
character-count wrap, a display-column bar highlight, no bar on a blank note line, one fixed
bar colour, and no row between entries each red the spec.