### PR TITLE
perf(syntax): look the row map up instead of rebuilding it per call

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -92,6 +92,29 @@ it was over half the open time.
 **Progress is written on mutation, not on paint.** `paint` also runs on window resize, and
 persisting there turns dragging a split into a stream of file writes.
 
+**The anchor map's inversion is cached on the view, and everything that redraws drops it.**
+The treesitter replay needs the anchor map inside out: per file, which source line is drawn
+on which row and at what byte column, plus the rows that file occupies. Derived per call it
+is a walk of the whole render, and `syntax.apply` is wired to `WinScrolled` *and*
+`CursorMoved` — on a 90,000-row review that walk alone is most of the 19 ms a reviewer paid
+per keystroke, while the parse behind it was already memoised twice over. It is a pure
+function of the render and, in the split layout, of the before render, so only a repaint can
+change it: it sits on the view as `syntax_rows`, beside `syntax_cache` and `syntax_painted`,
+and follows their rule exactly — dropped when the diff is re-read and when the scope
+changes, dropped by every paint, rebuilt by the first pass after one. What it caches is the
+*inversion*; a file is still parsed whole the first time any of its rows come near the
+window, for the reason above. Held, it is about 11 MB on a 90,000-row review — the same
+tables that were previously built and thrown away on every keystroke.
+
+**Invalidating it is the careful half, not caching it.** A map that outlives the render it
+was inverted from still produces well-formed extmarks in the right groups — on rows that now
+hold unrelated code, which is worse than highlighting that is merely missing. That is why
+the paint drops it whether or not highlighting is switched on: a map left behind by a paint
+made with `syntax = false` would otherwise be replayed the moment it was switched back on.
+It is also why `syntax_spec` asserts the map against the render on screen, and asserts that
+the marks still cover their own tokens after a repaint that moved rows, rather than merely
+asserting that a map exists.
+
 **Intra-line spans are computed when the diff is parsed, never when it is drawn.** On a
 12,000-line diff they cost about as much again as a whole repaint. Paid once per git read
 that lengthens opening by roughly a third; paid per repaint it would be a ~50% regression on

--- a/lua/codereview/syntax.lua
+++ b/lua/codereview/syntax.lua
@@ -204,47 +204,33 @@ local function viewport(view)
   return math.max(1, span[1] - VIEWPORT_MARGIN), math.min(#view.render.lines, span[2] + VIEWPORT_MARGIN)
 end
 
----Paint treesitter highlights over the rendered diff.
+---@alias CRFileRows { before: table<integer, { row: integer, col: integer }>, after: table<integer, { row: integer, col: integer }>, first: integer, last: integer }
+
+---Invert the anchor map: for each file, which source line is drawn on which row and at what
+---byte column its code text begins, plus the first and last row the file occupies.
 ---
----Bounded by the viewport, not by the diff: a file is parsed the first time any of its
----rows come near the window, and never otherwise. Without this a 60-file review pays for
----120 parses before it can draw anything, which is a second of latency on open for
----highlighting nobody can see yet.
----
----Safe to call repeatedly. Each file's captures are memoised, and `syntax_painted` stops
----already-painted files from having their extmarks emitted twice per render.
+---A pure function of the render and, in the split layout, of the before render, which is
+---why the answer is held on the view rather than derived per call: only a repaint can
+---change it. Derived per call it is a walk of the whole review, and `apply` is wired to
+---both `WinScrolled` and `CursorMoved` -- on a 90,000-row review that walk alone is most of
+---what a reviewer pays per keystroke.
 ---@param view CRView
----@param ns integer
-function M.apply(view, ns)
-  if not config.get().syntax or not view.render then
-    return
-  end
-  view.syntax_cache = view.syntax_cache or {}
-  view.syntax_painted = view.syntax_painted or {}
-
-  local lo, hi = viewport(view)
-  local split = view.before_render ~= nil
-
-  -- Invert the anchor map: for each file, which source line is drawn on which row, and at
-  -- what byte column the code text begins.
-  local per_file = {}
+---@return table<integer, CRFileRows>
+local function invert(view)
+  local out = {}
 
   ---@param anchors table<integer, CRAnchor>|nil
   ---@param pane "unified"|"after"|"before"
   local function collect(anchors, pane)
     for row, a in pairs(anchors or {}) do
       if a.kind == "line" then
-        local entry = per_file[a.file]
+        local entry = out[a.file]
         if not entry then
-          entry = { before = {}, after = {}, visible = false }
-          per_file[a.file] = entry
+          entry = { before = {}, after = {}, first = row, last = row }
+          out[a.file] = entry
         end
-        -- A file is parsed whole once any part of it is near the window: parsing only the
-        -- visible slice would cache a partial capture set that the next scroll invalidates.
-        -- The panes hold the same rows, so one pane's bounds answer for both.
-        if row >= lo and row <= hi then
-          entry.visible = true
-        end
+        entry.first = math.min(entry.first, row)
+        entry.last = math.max(entry.last, row)
         local ln = view.files[a.file].hunks[a.hunk].lines[a.line]
         if pane == "before" then
           -- In the split layout the pane decides the image, not the line. A context line is
@@ -262,14 +248,46 @@ function M.apply(view, ns)
     end
   end
 
+  local split = view.before_render ~= nil
   collect(view.render.anchors, split and "after" or "unified")
   if split then
     collect(view.before_render.anchors, "before")
   end
+  return out
+end
 
-  for fi, maps in pairs(per_file) do
+---Paint treesitter highlights over the rendered diff.
+---
+---Bounded by the viewport, not by the diff: a file is parsed the first time any of its
+---rows come near the window, and never otherwise. Without this a 60-file review pays for
+---120 parses before it can draw anything, which is a second of latency on open for
+---highlighting nobody can see yet.
+---
+---Safe to call repeatedly. The row map is inverted once per paint, each file's captures are
+---memoised, and `syntax_painted` stops already-painted files from having their extmarks
+---emitted twice per render -- so a call with nothing new near the window is a lookup.
+---@param view CRView
+---@param ns integer
+function M.apply(view, ns)
+  if not config.get().syntax or not view.render then
+    return
+  end
+  view.syntax_cache = view.syntax_cache or {}
+  view.syntax_painted = view.syntax_painted or {}
+  -- Rebuilt here rather than in the paint, so that dropping it is all a repaint has to do
+  -- and the first pass after one pays for it.
+  view.syntax_rows = view.syntax_rows or invert(view)
+
+  local lo, hi = viewport(view)
+  local split = view.before_render ~= nil
+
+  for fi, maps in pairs(view.syntax_rows) do
     local file = view.files[fi]
-    if maps.visible and not file.binary and not view.syntax_painted[file.path] then
+    -- A file is parsed whole once any part of it is near the window: parsing only the
+    -- visible slice would cache a partial capture set that the next scroll invalidates.
+    -- The panes hold the same rows, so one pane's bounds answer for both.
+    local near = maps.first <= hi and maps.last >= lo
+    if near and not file.binary and not view.syntax_painted[file.path] then
       local lang = M.lang_for(file.path)
       if lang then
         -- An untracked file has no committed pre-image; its "after" is the working tree.
@@ -285,20 +303,28 @@ function M.apply(view, ns)
   end
 end
 
----Drop memoised captures. Called when the underlying diff is re-read.
+---Drop everything memoised about the diff on screen. Called when it is re-read and when
+---the scope changes: the captures are keyed by path and side only, so they mean nothing
+---once the refs behind those sides move, and the row map describes rows drawn from files
+---that are being replaced.
 ---@param view CRView
 function M.invalidate(view)
   view.syntax_cache = {}
   view.syntax_painted = {}
+  view.syntax_rows = nil
 end
 
----Forget which files have been painted, without discarding their parsed captures.
+---Drop what a repaint invalidated, keeping the parsed captures.
 ---
----Called on every repaint: the extmarks are gone (the namespace was cleared) but the
----captures are still valid, so the files back in view repaint from cache.
+---Called on every repaint: the extmarks are gone (the namespace was cleared) and the row
+---map was inverted from renders that no longer exist, but the captures are still valid, so
+---the files back in view repaint from cache. A map that outlives its render points at rows
+---that no longer hold what it claims, which is highlighting on unrelated code rather than
+---highlighting that is merely missing.
 ---@param view CRView
-function M.reset_painted(view)
+function M.repainted(view)
   view.syntax_painted = {}
+  view.syntax_rows = nil
 end
 
 ---Forget capture-name -> highlight-group resolutions.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -353,11 +353,14 @@ function M.paint(keep_file)
     place(V.render.file_rows[keep_file])
   end
 
+  -- The namespace was just cleared and the renders above are new, so nothing a previous
+  -- paint derived from them still describes what is on screen -- but the parsed captures
+  -- behind it are still good. Unconditional, unlike the pass below it: a row map left over
+  -- from a paint made with highlighting off would be replayed onto rows it never described
+  -- the moment highlighting came back.
+  local syntax = require("codereview.syntax")
+  syntax.repainted(V)
   if config.get().syntax then
-    local syntax = require("codereview.syntax")
-    -- The namespace was just cleared, so nothing is painted any more -- but the parsed
-    -- captures behind it are still good.
-    syntax.reset_painted(V)
     syntax.apply(V, NS)
   end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring with no windows; then the binding, annotation parity against the unified layout, and the two intersections nobody else owns |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
-| `syntax_spec` | Treesitter harvest/replay, caching, guardrails |
+| `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
@@ -180,6 +180,12 @@ so the out-of-core language path is still checked locally without ever failing C
   then calls `nvim_exec_autocmds("CursorMoved", { buffer = … })`, which runs the review
   buffer's own autocommand. Timing the move alone reports microseconds and misses every
   millisecond the reviewer actually pays.
+- **A cached map only misbehaves once something has moved the rows.** The row map
+  `syntax.apply` looks up is dropped by every paint, and an assertion made after a repaint
+  that changed nothing passes with that drop deleted — every row still holds exactly what the
+  old map claimed. `syntax_spec` collapses a file *above* the one it checks, guards that the
+  rows below really did move, and only then asserts that every syntax mark still covers its
+  own token. Same trap as "a filter test needs a fixture only that filter can reject".
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.

--- a/tests/codereview/syntax_spec.lua
+++ b/tests/codereview/syntax_spec.lua
@@ -138,6 +138,141 @@ describe("caching and laziness", function()
   end)
 end)
 
+-- The map `apply` looks rows up in, rather than rebuilding per call. Its risk is not the
+-- caching but the invalidation: a map that outlives the render it was inverted from still
+-- produces well-formed extmarks, in the right groups, on rows that now hold other code.
+describe("the row map behind the replay", function()
+  local V = view.current()
+
+  ---Assert the map describes the render that is on screen: every row it records is anchored
+  ---to that same file at that same byte column, keyed by the source line drawn there, and
+  ---each file's bounds are exactly the rows it occupies -- those are what decide whether a
+  ---file is near enough to the window to be parsed.
+  ---
+  ---Both images are read out of `V.render.anchors`, which holds for the unified layout only;
+  ---this spec never opens the split one.
+  local function agrees_with_render()
+    local rows = assert(V.syntax_rows, "no row map on the view")
+    assert.is_true(vim.tbl_count(rows) > 0, "the map covers no file")
+    for fi, per_file in pairs(rows) do
+      local first, last = math.huge, 0
+      local function check(side, key_of)
+        for line, slot in pairs(side) do
+          local a = V.render.anchors[slot.row]
+          assert.is_truthy(a, ("row %d is anchored to nothing"):format(slot.row))
+          assert.same("line", a.kind)
+          assert.same(fi, a.file)
+          assert.same(a.col, slot.col)
+          assert.same(line, key_of(V.files[a.file].hunks[a.hunk].lines[a.line]))
+          first, last = math.min(first, slot.row), math.max(last, slot.row)
+        end
+      end
+      check(per_file.after, function(ln)
+        return ln.new
+      end)
+      check(per_file.before, function(ln)
+        return ln.old
+      end)
+      assert.same({ first = first, last = last }, { first = per_file.first, last = per_file.last })
+    end
+  end
+
+  ---Every syntax extmark covers exactly the token its capture came from, judged against the
+  ---buffer as it stands now. This is the symptom a stale map produces, and the reason the
+  ---invalidation is the careful half.
+  local function marks_cover_their_tokens()
+    local marks = h.syntax_marks(V)
+    assert.is_true(#marks > 0, "nothing is highlighted")
+    local buf_lines = vim.api.nvim_buf_get_lines(V.buf, 0, -1, false)
+    for _, m in ipairs(marks) do
+      local a = V.render.anchors[m[2] + 1]
+      if a and a.kind == "line" then
+        local ln = V.files[a.file].hunks[a.hunk].lines[a.line]
+        local text = buf_lines[m[2] + 1]:sub(m[3] + 1, m[4].end_col)
+        assert.is_truthy(ln.text:find(text, 1, true), ("row %d: %q not in %q"):format(m[2] + 1, text, ln.text))
+      end
+    end
+  end
+
+  it("holds a map of the render on the view", function()
+    agrees_with_render()
+  end)
+
+  it("records the row and byte column each source line is drawn at", function()
+    local row = assert(h.line_row(V, "src/main.lua"))
+    local a = V.render.anchors[row]
+    local ln = V.files[a.file].hunks[a.hunk].lines[a.line]
+    local side = ln.new and "after" or "before"
+    assert.same({ row = row, col = a.col }, V.syntax_rows[a.file][side][ln.new or ln.old])
+  end)
+
+  -- The keystroke case: `apply` is wired to CursorMoved, so a pass with nothing new near the
+  -- window must be a lookup against the map rather than another inversion of the whole
+  -- review.
+  it("reuses the map across passes with no repaint between them", function()
+    local map = V.syntax_rows
+    syntax.apply(V, h.NS)
+    syntax.apply(V, h.NS)
+    assert.are.equal(map, V.syntax_rows)
+  end)
+
+  it("rebuilds it when a repaint produces new renders", function()
+    local map = V.syntax_rows
+    view.paint()
+    assert.are_not.equal(map, V.syntax_rows)
+    agrees_with_render()
+  end)
+
+  -- Collapsing a file moves every row below it, which is exactly what a map kept past its
+  -- render would go on pointing at. The guard is that the rows really did move: without it
+  -- the case passes on a repaint that changed nothing.
+  it("replays onto the rows a repaint moved, not the ones they replaced", function()
+    local main = assert(h.file_index(V, "src/main.lua"))
+    local routes = assert(h.file_index(V, "src/routes.lua"))
+    local was = V.render.file_rows[routes]
+
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[main], 0 })
+    view.toggle_reviewed()
+    assert.is_true(V.render.file_rows[routes] ~= was, "collapsing src/main.lua moved nothing")
+
+    agrees_with_render()
+    marks_cover_their_tokens()
+
+    view.toggle_reviewed()
+    marks_cover_their_tokens()
+  end)
+
+  -- Both `refresh` and `set_scope` discard through here, and both then repaint, so the
+  -- discard itself is the only moment either of them could skip it.
+  it("goes with the captures when the diff behind them is dropped", function()
+    assert.is_not_nil(V.syntax_rows)
+    syntax.invalidate(V)
+    assert.is_nil(V.syntax_rows)
+  end)
+
+  it("comes back from the diff a re-read produced", function()
+    view.refresh()
+    agrees_with_render()
+  end)
+
+  it("comes back from the scope a change switched to", function()
+    view.set_scope("staged")
+    assert.same(
+      { "src/routes.lua" },
+      vim.tbl_map(function(f)
+        return f.path
+      end, V.files)
+    )
+    agrees_with_render()
+
+    -- Back to where the rest of this file expects to be: the branch scope, with the cursor
+    -- inside src/main.lua, which is what puts src/routes.lua near enough to the window for
+    -- the cases below to have anything to say about it.
+    view.set_scope("branch")
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[assert(h.file_index(V, "src/main.lua"))], 0 })
+  end)
+end)
+
 describe("guardrails", function()
   local V = view.current()
 


### PR DESCRIPTION
`syntax.apply` is wired to `WinScrolled` **and** `CursorMoved`, and rebuilt on every call an
inverted map of the whole render — for each file, which source line is drawn on which row
and at what byte column its code begins. On a 90,900-row review that walk is what a reviewer
pays per keystroke. The parse behind it was already memoised twice (`syntax_cache`,
`syntax_painted`); the inversion deciding *what* to memoise was not, which is why the cost
only appears at scale.

The map is a pure function of the render and, in the split layout, of the before render, so
only a repaint can change it. It now sits on the view as `syntax_rows`, beside the two
caches it belongs with, and `apply` became a viewport lookup against it: per file, the first
and last row it occupies decide whether it is near enough to the window to be parsed.

Nothing about what is drawn changes. A file is still parsed whole the first time any of its
rows come near the window — the inversion is cached, not what gets harvested — and
`render.build` is untouched.

## Invalidation

The risky half. A map that outlives the render it was inverted from still produces
well-formed extmarks, in the right groups, on rows that now hold unrelated code. It follows
exactly the rule its two neighbours follow:

- dropped when the diff is re-read and when the **scope** changes (`invalidate`)
- dropped by every paint, whether or not highlighting is switched on — otherwise a map left
  behind by a paint made with `syntax = false` would be replayed the moment it came back
- rebuilt by the first pass after a paint

`reset_painted` became `repainted`, since it now drops both things a repaint invalidates.

## Numbers

`make perf` on this machine, before and after. The `cursor move` line is the one this slice
exists to move:

| | 60 files | 300 files |
| --- | --- | --- |
| cursor move, before | 2.5 ms | 20.0 ms |
| cursor move, after | 0.0 ms | 0.0 ms |
| 50 moves (holding `j`), before | 127 ms | 999 ms |
| 50 moves, after | 0 ms | 0 ms |

Unchanged in shape: `files parsed 1/300` on open, `2/300` after scrolling to the end, and
`scroll back` still costs nothing. The repaint line is untouched by this slice (409 → 383 ms
at 300 files, which is noise) — that is #78.

The map costs about 11 MB held on a 90,000-row review, measured against a 137 MB baseline.
They are the same tables that were previously built and thrown away on every keystroke.

## Tests

Eight cases in `syntax_spec`, at the seam `syntax_spec` already uses for the two caches
beside it. The load-bearing ones assert the map *against the render on screen* rather than
merely asserting that it exists, and that every mark still covers its own token after a
repaint that moved rows — collapsing a file above the one they check, guarded by the rows
below really having moved, because an assertion made after a repaint that changed nothing
passes with the invalidation deleted.

Both invalidations were checked by deleting them: dropping the map from `repainted` reds
three cases (one of them pre-existing), dropping it from `invalidate` reds one.

Closes #77.
