### PR TITLE
feat(delivery): copy the batch to the clipboard without submitting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,11 @@ Because the queue is shared with the capture path and the float opens with or wi
 review, some of what it lists has nowhere to jump to: a bare note is about no file, there
 may be no review open, or the file may be outside the current scope. Each says which.
 
+`gy` — in the diff, in the float, or as `:CodeReviewCopy` from anywhere — puts the payload
+in the `+` register without submitting it. It is the same text `send` would have been
+handed, target and all, and it costs the batch nothing: the queue is untouched, so reading
+what an agent will be told is not a decision to send it.
+
 ### The payload
 
 Grouped by type, in the configured order, most actionable first, with anything untyped
@@ -397,6 +402,7 @@ worth a look before we ship this
 | `<CR>` | Open the real file here, in a new tab |
 | `gd` | Read this file in your own diff tool — only bound with [`open_diff`](#adapters) wired |
 | `Q` | Review the queue |
+| `gy` | Copy the batch to the `+` register, without submitting it |
 | `<C-t>` | Choose the delivery target |
 | `<C-s>` | Submit the batch |
 | `q` | Close |
@@ -454,9 +460,13 @@ under the cursor and not what a heading further up happened to say.
 | --- | --- |
 | `<CR>` | Jump to the annotation under the cursor |
 | `x` | Drop it |
+| `gy` | Copy the batch to the `+` register, without submitting it |
 | `<C-t>` | Choose the delivery target |
 | `<C-s>` | Submit the batch |
 | `q` / `<Esc>` | Close, keeping the queue |
+
+`gy` leaves the float open, because it takes nothing out of the queue — everything it is
+listing is still there.
 
 ## Configuration
 
@@ -523,7 +533,9 @@ opts = {
   -- draft. A refusal is reported as an error. Without this the payload goes to the +
   -- register, which is the default implementation of this same contract — it reports a
   -- non-dispatch (a register is not a consumer), which is why an unwired host keeps its
-  -- queue, and it is a warning rather than an error because nothing is broken.
+  -- queue, and it is a warning rather than an error because nothing is broken. `gy` puts
+  -- the payload in that register deliberately, whatever is wired here, so what an adapter
+  -- receives is readable without submitting to find out.
   send = function(payload, target) return true end,
 
   -- Choose a delivery target; call back with anything carrying `short` and `cwd`.
@@ -626,11 +638,11 @@ object minted with `git stash create`, which moves no ref, leaves the index alon
 touches your files. On a clean tree there is nothing to record that `HEAD` does not already
 say, and `HEAD` is what is stored.
 
-A dispatch writes it and nothing else does. An adapter that declined, one that raised, and
-the `+` register the default send copies to all leave it exactly as they leave the queue —
-a payload sitting in a register is not something an agent received. An immediate send is a
-batch of one and is kept as one. The most recent **twenty** batches are kept per store,
-oldest dropped on write.
+A dispatch writes it and nothing else does. An adapter that declined, one that raised, the
+`+` register the default send copies to and the one `gy` copies to deliberately all leave
+it exactly as they leave the queue — a payload sitting in a register is not something an
+agent received. An immediate send is a batch of one and is kept as one. The most recent
+**twenty** batches are kept per store, oldest dropped on write.
 
 </details>
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -40,6 +40,14 @@ files without one fall back to flat diff colours.
             :CodeReview HEAD~3
             :CodeReview main...feature
 <
+                                                            *:CodeReviewCopy*
+:CodeReviewCopy
+        Copy the queued batch to the `+` register without submitting it: the
+        same payload |codereview-opt-send| would have been handed, resolved
+        against the same target. The queue keeps every entry and nothing is
+        archived -- a register is not a consumer. Needs no review view open.
+        Also bound to `gy` in the diff and in the queue float.
+
                                                         *:CodeReviewAnnotate*
 :[range]CodeReviewAnnotate [{type}]
         Annotate the current buffer without a review open. {type} is one of
@@ -70,6 +78,7 @@ Buffer-local, inside the review view:
     gd               Read this file in the host's own diff tool --
                      bound only with |codereview-opt-open_diff| wired
     Q                Review the queue
+    gy               Copy the batch to the `+` register, without submitting
     <C-t>            Choose the delivery target
     <C-s>            Submit the batch
     q                Close the review
@@ -119,7 +128,9 @@ hands focus back to the diff. Collapsed directories belong to the review, not
 to the tree, so they are exactly as you left them when it comes back.
 
 In the queue float: <CR> jumps to the annotation under the cursor, x drops an
-entry, <C-t> routes, <C-s> submits, q closes and keeps the queue.
+entry, gy copies the batch, <C-t> routes, <C-s> submits, q closes and keeps
+the queue. `gy` leaves the float open -- it takes nothing out of the queue, so
+every row it is listing is still true.
 
 A jump closes the float and centres the line the annotation is about,
 expanding the file first if it was collapsed. The queue is shared with the
@@ -523,6 +534,10 @@ send({payload}, {target})                                *codereview-opt-send*
         because a register is not a consumer, which is why an unwired host
         keeps its queue.
 
+        With this wired, |:CodeReviewCopy| is how the payload is read: it puts
+        exactly what this adapter would be handed in that same register, and
+        submits nothing.
+
 pick_target({cb})                                 *codereview-opt-pick_target*
         Choose a delivery target and call {cb} with it. The target may carry
         `short` (shown in the winbar) and `cwd`. `cwd` matters: references are
@@ -764,9 +779,10 @@ clean tree there is nothing to record that `HEAD` does not already say, and
 `HEAD` is what is stored. Untracked files are not in such a commit.
 
 A dispatch writes it and nothing else does. An adapter that declined, one that
-raised, and the `+` register the default send copies to all leave the archive
-exactly as they leave the queue -- a payload sitting in a register is not
-something an agent received. See |codereview-opt-send|. An immediate send
+raised, the `+` register the default send copies to and the one
+|:CodeReviewCopy| copies to on purpose all leave the archive exactly as they
+leave the queue -- a payload sitting in a register is not something an agent
+received. See |codereview-opt-send|. An immediate send
 (|codereview-immediate-send|) is a batch of one and is kept as one.
 
 Records go to the same two stores the queue does, split by the same rule: an
@@ -794,6 +810,10 @@ require("codereview").queue()                           *codereview.queue()*
 require("codereview").submit()                         *codereview.submit()*
         Submit the queued annotations as one batch. The queue is emptied
         only if |codereview-opt-send| reports it went.
+require("codereview").copy()                             *codereview.copy()*
+        Copy the batch to the `+` register without submitting it -- the same
+        payload |codereview-opt-send| would have been handed. The queue is
+        untouched and nothing is archived. See |:CodeReviewCopy|.
 require("codereview").count()                           *codereview.count()*
         Number of queued annotations -- useful in a statusline.
 require("codereview").is_open()                       *codereview.is_open()*

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -148,6 +148,57 @@ local function to_clipboard(payload, _to)
   return false, "No send adapter configured — copied the batch to the + register instead"
 end
 
+---Where a batch's `@ref`s resolve against, and which repository it is going out of.
+---
+---One answer for both, because they are one question asked from two sides: the repository
+---is what the archive is keyed on, and it is also what stands in when nothing has been
+---routed. A note captured outside a checkout has none.
+---@param to table|nil
+---@param opts { root?: string }
+---@return string base, string|nil repo
+local function destination(to, opts)
+  local repo = opts.root or git.root(vim.fn.getcwd())
+  local root = repo or vim.fn.getcwd()
+  -- Resolve refs against the directory the payload is actually going to: a routed agent
+  -- reads `@path` relative to its own cwd, not this Neovim's.
+  return (to and to.cwd and to.cwd ~= "") and to.cwd or root, repo
+end
+
+---The batch as text, against a base already decided.
+---
+---The one place a batch becomes a payload. Delivering and copying arrive here from
+---different sides -- one has already had to ask where the repository is, because that is
+---what it archives against, and the other never asks -- and neither may render for itself:
+---a payload copied to a register that differs from the one submitted is a copy that
+---misrepresents the send it stands in for.
+---@param items CRAnnotation[]
+---@param base string
+---@param opts { scope_label?: string, files?: integer, reviewed?: integer }
+---@return string
+local function render_at(items, base, opts)
+  return require("codereview.payload").render(items, base, {
+    types = config.get().types,
+    scope_label = opts.scope_label,
+    files = opts.files,
+    reviewed = opts.reviewed,
+  })
+end
+
+---What handing this batch over would produce, without handing it over.
+---
+---Public because a payload is worth reading without spending it. Everything that decides
+---what it says -- the target its refs resolve against, the review it describes -- is
+---decided here exactly as `deliver` decides it, so the text a reviewer copies is the text
+---an agent would have been given.
+---@param items CRAnnotation[]
+---@param to table|nil Where it would be going, or nil for the adapter's default
+---@param opts { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---@return string
+function M.render(items, to, opts)
+  opts = opts or {}
+  return render_at(items, destination(to, opts), opts)
+end
+
 ---Render annotations as one payload and hand it to the send adapter.
 ---
 ---Shared with the immediate send, which is a batch of one (ADR-0004): one renderer and
@@ -170,20 +221,8 @@ end
 function M.deliver(items, to, opts)
   local cfg = config.get()
   opts = opts or {}
-  -- The repository the batch is going out of, when there is one: a note captured outside a
-  -- checkout has none, and the archive is keyed on a root exactly as the queue's store is.
-  local repo = opts.root or git.root(vim.fn.getcwd())
-  local root = repo or vim.fn.getcwd()
-  -- Resolve refs against the directory the payload is actually going to: a routed agent
-  -- reads `@path` relative to its own cwd, not this Neovim's.
-  local base = (to and to.cwd and to.cwd ~= "") and to.cwd or root
-
-  local text = require("codereview.payload").render(items, base, {
-    types = cfg.types,
-    scope_label = opts.scope_label,
-    files = opts.files,
-    reviewed = opts.reviewed,
-  })
+  local base, repo = destination(to, opts)
+  local text = render_at(items, base, opts)
 
   -- A raise is a non-dispatch, not a crash. A missing binary raises rather than returning
   -- anything -- that is how the process API answers -- and letting it unwind would take
@@ -273,6 +312,42 @@ function M.submit(ctx)
       target and (target.short or "agent") or "local"
     )
   )
+  return true
+end
+
+---Put the payload in the `+` register, deliberately, without submitting the batch.
+---
+---What the shipped `send` default does as a consequence of nothing being wired, done on
+---purpose and whatever is: reading what an agent will be told should not cost a submit,
+---and a host with a real adapter otherwise has no way to see it at all.
+---
+---The queue is untouched, and so is the archive. Not by a rule of its own -- by the one
+---this module already holds: a dispatch is a payload handed to the send adapter, a
+---register is not a consumer, and nothing here goes near the adapter (ADR-0005). Which is
+---also why this is not `deliver` with the send swapped out: that function's whole tail is
+---the consequence of a handoff that did not happen.
+---@param ctx { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---       What the review the batch came from can say about itself, exactly as `submit`
+---       takes it -- the payload names it in its first line, and a copy that named a
+---       different review would not be the text it stands in for.
+---@return boolean copied
+function M.copy(ctx)
+  local queue = require("codereview.queue")
+
+  ensure_queue()
+  local count = queue.count()
+  if count == 0 then
+    -- Submitting's guard, worded the same: an empty queue is an empty queue whichever key
+    -- was pressed, and there is no register-shaped consolation to offer for one.
+    info("Queue is empty — annotate something first")
+    return false
+  end
+
+  vim.fn.setreg("+", M.render(queue.all(), target, ctx))
+  -- Counted rather than merely acknowledged, because the queue looks the same afterwards:
+  -- the number is the only evidence the reviewer gets that it was this batch that went to
+  -- the register, and it reads beside "Submitted %d" rather than against it.
+  info(("Copied %d annotation%s to the + register"):format(count, count == 1 and "" or "s"))
   return true
 end
 

--- a/lua/codereview/init.lua
+++ b/lua/codereview/init.lua
@@ -24,6 +24,12 @@ function M.setup(opts)
     end,
   })
 
+  -- Takes no arguments and needs no review open: the batch it copies is the one the queue
+  -- holds, which is the same batch wherever it is asked for.
+  vim.api.nvim_create_user_command("CodeReviewCopy", M.copy, {
+    desc = "Copy the queued batch to the + register, without submitting it",
+  })
+
   vim.api.nvim_create_user_command("CodeReviewAnnotate", function(cmd)
     -- `cmd.range` counts the addresses given, not the lines covered. Reading line1/line2
     -- unconditionally would turn a bare `:CodeReviewAnnotate` into a one-line capture of
@@ -78,6 +84,15 @@ end
 ---Submit the queued annotations as one batch.
 function M.submit()
   require("codereview.view").submit()
+end
+
+---Copy the batch to the `+` register, without submitting it.
+---
+---Reads the payload rather than spending it: the queue keeps every entry, nothing is
+---handed to the `send` adapter and nothing is archived. Through the view, as submitting
+---is, so what is copied describes the open review when there is one.
+function M.copy()
+  require("codereview.view").copy()
 end
 
 ---@return integer

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1031,6 +1031,27 @@ function M.pick_target(on_done)
   end)
 end
 
+---What the review a batch is going out of can say about itself, or nothing when there is
+---no review at all.
+---
+---Handed over rather than read back: delivery knows nothing about views, and a batch that
+---leaves with none open is answered from the working directory instead. Shared by submit
+---and copy because the payload names this in its first line -- a copy assembled from a
+---different context would differ from the send it stands in for by exactly that line.
+---@return { root?: string, scope_label?: string, files?: integer, reviewed?: integer }
+local function review_ctx()
+  local V_ = M.current()
+  if not V_ then
+    return {}
+  end
+
+  local reviewed = 0
+  for _ in pairs(V_.reviewed) do
+    reviewed = reviewed + 1
+  end
+  return { root = V_.root, scope_label = V_.scope.label, files = #V_.files, reviewed = reviewed }
+end
+
 ---Submit the batch, and put the windows back the way a sent batch leaves them.
 ---
 ---The rule -- restore, deliver, empty only on a dispatch -- is delivery's, because none of
@@ -1044,27 +1065,22 @@ function M.submit()
     V.queue_win = nil
   end
 
-  local V_ = M.current()
-  local reviewed = 0
-  if V_ then
-    for _ in pairs(V_.reviewed) do
-      reviewed = reviewed + 1
-    end
-  end
-
-  local dispatched = delivery.submit({
-    -- Handed over rather than read back: delivery knows nothing about views, and a batch
-    -- submitted with none open is answered from the working directory instead.
-    root = V_ and V_.root or nil,
-    scope_label = V_ and V_.scope.label or nil,
-    files = V_ and #V_.files or nil,
-    reviewed = reviewed,
-  })
+  local dispatched = delivery.submit(review_ctx())
   -- A batch that did not go is still queued and still drawn on the diff, so there is
   -- nothing to repaint -- and the reviewer has already been told why.
   if dispatched then
     M.paint()
   end
+end
+
+---Copy the batch to the clipboard, exactly as submitting would have rendered it.
+---
+---Nothing here does what submit does with the windows, because nothing was consumed: the
+---queue still holds every entry, the diff still draws them, and a float listing them is
+---still telling the truth. That is the whole difference between the two keys, and it is
+---why this one leaves the surface alone.
+function M.copy()
+  delivery.copy(review_ctx())
 end
 
 --- The queue review float ------------------------------------------------------
@@ -1398,7 +1414,7 @@ function M.review_queue()
       n == 1 and "" or "s",
       stale > 0 and (" · %d stale"):format(stale) or ""
     )
-    cfg_win.footer = (" ^T %s · ⏎ jump · x drop · ^S submit · q close "):format(
+    cfg_win.footer = (" ^T %s · ⏎ jump · x drop · gy copy · ^S submit · q close "):format(
       #name > 24 and (name:sub(1, 23) .. "…") or name
     )
     if vim.api.nvim_win_is_valid(win) then
@@ -1474,6 +1490,10 @@ function M.review_queue()
   vim.keymap.set("n", "<C-t>", function()
     M.pick_target(paint_queue)
   end, { buffer = buf, desc = "Choose target" })
+
+  -- Leaves the float open, where submitting closes it: what is on screen still describes
+  -- the queue exactly, because copying took nothing out of it.
+  vim.keymap.set("n", "gy", M.copy, { buffer = buf, desc = "Copy the batch to the clipboard" })
 
   vim.keymap.set("n", "<C-s>", function()
     close()
@@ -1595,6 +1615,10 @@ local function setup_main_keymaps(buf)
     ["gl"] = { M.toggle_layout, "Switch between the unified and split layouts" },
     ["<CR>"] = { M.open_file, "Open the real file here" },
     ["Q"] = { M.review_queue, "Review the queue" },
+    -- `gy`, not `Y`: yank is not dead in this buffer the way append is, and pulling a code
+    -- line out of the diff is something reviewers do. From the same `g` family as the
+    -- commands above, where it shadows nothing.
+    ["gy"] = { M.copy, "Copy the batch to the clipboard" },
     ["<C-t>"] = { M.pick_target, "Choose the delivery target" },
     ["<C-s>"] = { M.submit, "Submit the batch" },
     ["q"] = { M.close, "Close the review" },

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,12 +48,12 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, and a document written before the archive existed |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
-| `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, and the draft an undispatched immediate send leaves behind |
+| `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, the draft an undispatched immediate send leaves behind, and the deliberate copy that is not a dispatch |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
-| `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, and dropping from anywhere inside one |
+| `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
 | `queue_jump_panel_spec` | That jump with the tree dismissed, summoned, and never there — the one surface neither slice could test alone |

--- a/tests/codereview/delivery_spec.lua
+++ b/tests/codereview/delivery_spec.lua
@@ -384,3 +384,199 @@ describe("an immediate send with no adapter wired", function()
     assert.same("an errand with nowhere to go", drafts.get(main))
   end)
 end)
+
+--- Copying the batch, which is not delivering it -------------------------------
+
+-- The other way a payload reaches the `+` register: on purpose, whatever the host has
+-- wired, rather than as the consequence of nothing being. Nothing is handed to the
+-- adapter, so a copy is not a **dispatch**, and the one condition this file exists to pin
+-- down never comes up: the queue and the archive are exactly where they were.
+--
+-- Driven through the public entry point rather than a key, as every case above is -- the
+-- surfaces that reach it have already moved once, and the contract has not.
+describe("copying the batch with a send adapter wired", function()
+  queue.clear()
+  local notes = { "the first, copied", "the second, copied", "the third, copied" }
+  for i, note in ipairs(notes) do
+    queue.add({
+      -- Two types, so "the same entries in the same order" is a claim about the queue and
+      -- not about a single group that could only come back one way.
+      type = i == 2 and "nitpick" or "bug",
+      kind = "file",
+      path = "src/main.lua",
+      abs_path = main,
+      key = ("src/main.lua:f:%d"):format(i),
+      note = note,
+    })
+  end
+  local ids = vim.tbl_map(function(entry)
+    return entry.id
+  end, queue.all())
+
+  local before_sent, before_archive = #sent, #archived()
+  vim.fn.setreg("+", "")
+  local msgs, restore = h.capture_notify()
+  codereview.copy()
+  restore()
+
+  -- Submitting works with nothing open and so does this, which is the reason there is a
+  -- public entry point at all. Asserted rather than assumed: with a review open, every
+  -- case below would be measuring the surface instead of the batch.
+  it("works with no review view open", function()
+    assert.is_nil(require("codereview.view").current())
+  end)
+
+  it("puts the payload in the + register", function()
+    assert.is_truthy(vim.fn.getreg("+"):find("the second, copied", 1, true), vim.fn.getreg("+"))
+  end)
+
+  -- The whole point of the key: a host whose adapter takes the batch somewhere real has
+  -- no other way to read what that adapter is handed.
+  it("hands the send adapter nothing", function()
+    assert.same(before_sent, #sent)
+  end)
+
+  it("leaves the queue with the same entries in the same order", function()
+    assert.same(3, queue.count())
+    assert.same(
+      notes,
+      vim.tbl_map(function(entry)
+        return entry.note
+      end, queue.all())
+    )
+    assert.same(
+      ids,
+      vim.tbl_map(function(entry)
+        return entry.id
+      end, queue.all())
+    )
+  end)
+
+  -- The claim the unwired case above already makes, said the other way round: a register
+  -- is not a consumer, whether the payload got there by default or deliberately.
+  it("archives nothing, because a copy is not a dispatch", function()
+    assert.same(before_archive, #archived())
+  end)
+
+  -- The queue looks identical afterwards, so the count is the only evidence a reviewer
+  -- gets that it was this batch that went to the register.
+  it("names how many annotations were copied", function()
+    assert.is_true(h.notified(msgs, "Copied 3 annotations to the + register"), vim.inspect(msgs))
+  end)
+
+  it("does not claim to have submitted anything", function()
+    assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
+  end)
+end)
+
+-- What the split renderer exists for, and the one claim a second renderer could pass
+-- today and fail the first time either side grew a rule of its own.
+describe("the text a copy leaves in the register", function()
+  queue_one("byte for byte")
+  vim.fn.setreg("+", "")
+  codereview.copy()
+  local copied = vim.fn.getreg("+")
+  local before = #sent
+  codereview.submit()
+
+  it("is what the send adapter is handed, byte for byte", function()
+    assert.same(before + 1, #sent)
+    assert.same(sent[#sent].text, copied)
+  end)
+end)
+
+-- `@ref`s resolve against wherever the payload is going, and a copy is going wherever the
+-- batch is. The same rule delivery already applies, reached through the same function --
+-- not a second one that agrees today.
+describe("a copy routed to a target", function()
+  cfg.pick_target = function(cb)
+    cb({ short = "elsewhere", cwd = "/somewhere/else" })
+  end
+  -- The one way the batch's target is set, whichever surface asked; the picker is the
+  -- seam here, exactly as `send` is.
+  require("codereview.delivery").pick_target()
+  queue_one("routed somewhere else")
+  vim.fn.setreg("+", "")
+  codereview.copy()
+  local copied = vim.fn.getreg("+")
+
+  it("resolves refs against the target's working directory", function()
+    assert.is_falsy(copied:find("@src/main.lua", 1, true), copied)
+    assert.is_truthy(copied:find(main, 1, true), copied)
+  end)
+end)
+
+-- The same batch, still queued because copying it did not spend it, going to the default
+-- instead. Which is what makes the pair a test of the base rather than of the entry.
+describe("a copy with no target chosen", function()
+  cfg.pick_target = function(cb)
+    cb(nil)
+  end
+  require("codereview.delivery").pick_target()
+  cfg.pick_target = nil
+  vim.fn.setreg("+", "")
+  codereview.copy()
+  local copied = vim.fn.getreg("+")
+
+  it("resolves refs against the repository root", function()
+    assert.is_truthy(copied:find("@src/main.lua", 1, true), copied)
+  end)
+end)
+
+-- The command exists so a host can reach this from anywhere -- its own keymap, a
+-- statusline, another plugin -- with no review view and without a Lua call.
+describe("the user command", function()
+  queue_one("copied by name")
+  vim.fn.setreg("+", "")
+  vim.cmd("CodeReviewCopy")
+
+  it("copies the batch exactly as the entry point does", function()
+    assert.is_truthy(vim.fn.getreg("+"):find("copied by name", 1, true), vim.fn.getreg("+"))
+  end)
+
+  it("leaves the queue where it was", function()
+    assert.same(1, queue.count())
+  end)
+end)
+
+describe("copying an empty queue", function()
+  queue.clear()
+  vim.fn.setreg("+", "left alone")
+  local msgs, restore = h.capture_notify()
+  codereview.copy()
+  restore()
+
+  it("takes the guard submitting an empty queue takes, worded the same", function()
+    assert.is_true(h.notified(msgs, "Queue is empty — annotate something first"), vim.inspect(msgs))
+  end)
+
+  it("leaves the register holding whatever was in it", function()
+    assert.same("left alone", vim.fn.getreg("+"))
+  end)
+end)
+
+-- With a review open the payload's first line describes it, which is the part of the text
+-- a copy could most easily get wrong: the context is the surface's to hand over, and copy
+-- reaching it by a route of its own is exactly how the two would drift.
+--
+-- Both keys are fed rather than called, as the submit case above is: what a surface hands
+-- delivery is not something to assert on directly, and `gy` being bound in the diff at all
+-- is only observable this way.
+describe("a copy taken with a review view open", function()
+  codereview.open("branch")
+  queue_one("copied out of a review")
+  vim.fn.setreg("+", "")
+  h.feed("gy")
+  local copied = vim.fn.getreg("+")
+  h.feed("<C-s>")
+
+  it("describes the review in its header", function()
+    local header = vim.split(copied, "\n")[1]
+    assert.is_truthy(header:find("on branch vs ", 1, true), header)
+    assert.is_truthy(header:find("reviewed)", 1, true), header)
+  end)
+
+  it("is still byte-identical to what the adapter was handed", function()
+    assert.same(sent[#sent].text, copied)
+  end)
+end)

--- a/tests/codereview/queue_float_spec.lua
+++ b/tests/codereview/queue_float_spec.lua
@@ -519,3 +519,55 @@ describe("submitting from the float", function()
     assert.same("local", state.archive(root)[1].target)
   end)
 end)
+
+--- Copying from the float ------------------------------------------------------
+
+-- The float is where a batch is read before it goes, so it is also where a copy of it is
+-- asked for. `gy` is `<C-s>`'s opposite in the one way that matters here: nothing is
+-- handed to the adapter, so nothing leaves the queue and nothing is archived -- which is
+-- why this key, alone among the ones that act on the batch, leaves the float open.
+--
+-- What is copied is `delivery_spec`'s to own. What this asserts is the surface: the key is
+-- bound, the footer says so, and the list is still there afterwards.
+describe("copying from the float", function()
+  fresh()
+  queued({ note = "copied from the float" })
+  queued({ type = "nitpick", note = "and this one with it" })
+
+  local before = #state.archive(root)
+  local listed = #sent
+  vim.fn.setreg("+", "")
+  local win, buf = open_float()
+  local rows = #lines(buf)
+  h.feed("gy")
+
+  it("puts the payload in the + register", function()
+    assert.is_truthy(vim.fn.getreg("+"):find("copied from the float", 1, true), vim.fn.getreg("+"))
+  end)
+
+  it("hands the send adapter nothing", function()
+    assert.same(listed, #sent)
+  end)
+
+  it("keeps the batch it was listing", function()
+    assert.same(2, queue.count())
+  end)
+
+  it("archives nothing, because a copy is not a dispatch", function()
+    assert.same(before, #state.archive(root))
+  end)
+
+  -- Where `<C-s>` must leave no float listing a batch that has gone, this must leave the
+  -- float exactly as it was: the batch has not gone, so every row is still true.
+  it("leaves the float open on the same rows", function()
+    assert.is_true(vim.api.nvim_win_is_valid(win))
+    assert.same(rows, #lines(buf))
+  end)
+
+  it("advertises the key in the footer, beside the ones already there", function()
+    local footer = vim.api.nvim_win_get_config(win).footer
+    footer = footer and tostring(footer[1][1]) or ""
+    assert.is_truthy(footer:find("gy copy", 1, true), footer)
+    assert.is_truthy(footer:find("^S submit", 1, true), footer)
+  end)
+end)


### PR DESCRIPTION
The payload already reached the `+` register, but only as the shipped `send` default — reachable only by a host that had wired none of its own. A host with a real adapter could not read what that adapter is handed without submitting and going to look for it.

`gy` copies it deliberately, whatever is wired: in the diff, in the queue float, and as `:CodeReviewCopy` / `require("codereview").copy()` with nothing open.

**A copy is not a dispatch.** Nothing is handed to the send adapter, so the one condition that empties the queue and writes the archive is never reached (ADR-0005) — a register is not a consumer, whether the payload got there by default or on purpose. #71's `delivery_spec` case, written in anticipation of this, stays green and is now joined by its counterpart for an adapter that *is* wired.

**What is copied is what would be sent.** The render is split out of `deliver` rather than repeated: one function decides the target `@ref`s resolve against and the review the header names, and both paths reach it. A case asserts the copied text is byte-identical to what the adapter is handed, with a review open and without one.

`gy` rather than `Y`: yank is not dead in the review buffer the way append is — pulling a code line out of the diff works today and reviewers do it — and `gy` joins the existing `g` family (`gs`, `gr`, `gp`, `gl`, `gd`), shadowing nothing. It leaves the float open, unlike `<C-s>`, because the list it is showing is still true afterwards.

Also: the float's footer advertises it, and the docs that enumerate what leaves the archive alone now name the deliberate copy alongside the default.

`make all` green — 976 cases.

Closes #69