### PR TITLE
feat(git): a scope for what changed since the last batch went out

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,8 +9,8 @@ receives it.
 ### Reviewing
 
 **Scope**:
-What a review covers — a branch, the staged or unstaged changes, the whole worktree, or any
-git revspec.
+What a review covers — a branch, the staged or unstaged changes, the whole worktree,
+whatever changed since the last **batch** went out, or any git revspec.
 _Avoid_: mode, filter, range (a range is a span of lines, see **Range**)
 
 **Review view**:

--- a/README.md
+++ b/README.md
@@ -69,11 +69,20 @@ inside the view to cycle between them in place.
 | `:CodeReview staged` | The index |
 | `:CodeReview unstaged` | Working tree vs index |
 | `:CodeReview worktree` | Everything uncommitted |
+| `:CodeReview since-batch` | What changed since the last batch went out |
 | `:CodeReview HEAD~3` | Any git revspec |
 | `:CodeReview main...feature` | Any range |
 
 Files are marked reviewed **against their git blob**, so a mark stops meaning anything
 once the file changes underneath it.
+
+**`since-batch` is the one to reach for while an agent is working.** Submitting records a
+snapshot of the working tree, and this scope diffs against it — so what you get is the
+agent's response to your review, without the work you already had in flight when you sent
+it. It behaves like every other scope in every other respect: highlighted, navigable,
+collapsible, annotatable, and drawn in both layouts. `gs` reaches it once something has
+been dispatched from the repository, and never before that; asking for it by name with
+nothing dispatched says so in a sentence.
 
 ### Unified or side by side
 
@@ -395,7 +404,7 @@ worth a look before we ship this
 | `x` | Drop the annotation under the cursor |
 | `R` | Toggle reviewed on this file (collapses it) |
 | `za` | Toggle expansion without marking reviewed |
-| `gs` | Cycle scope, re-rendering in place |
+| `gs` | Cycle scope, re-rendering in place — `since-batch` joins once a batch has gone |
 | `gr` | Re-read the diff from git |
 | `gp` | Show or hide the file tree |
 | `gl` | Switch between the unified and split layouts |

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -34,12 +34,16 @@ files without one fall back to flat diff colours.
                                                                 *:CodeReview*
 :CodeReview [{scope}]
         Open the review view. {scope} is one of `branch` (default), `staged`,
-        `unstaged`, `worktree`, or any git revspec: >
+        `unstaged`, `worktree`, `since-batch`, or any git revspec: >
             :CodeReview
             :CodeReview staged
+            :CodeReview since-batch
             :CodeReview HEAD~3
             :CodeReview main...feature
-<
+<       Completion offers every named scope, `since-batch` included, whether
+        or not this repository has anything in its archive; asking for it with
+        nothing dispatched reports a sentence. See |codereview-scopes|.
+
                                                             *:CodeReviewCopy*
 :CodeReviewCopy
         Copy the queued batch to the `+` register without submitting it: the
@@ -70,7 +74,8 @@ Buffer-local, inside the review view:
     x                Drop the annotation under the cursor
     R                Toggle reviewed on this file (collapses it)
     za               Toggle expansion without marking reviewed
-    gs               Cycle scope, re-rendering in place
+    gs               Cycle scope, re-rendering in place -- `since-batch`
+                     joins once a batch has been dispatched
     gr               Re-read the diff from git
     gp               Show or hide the file tree
     gl               Switch between the unified and split layouts
@@ -159,23 +164,42 @@ scope: normal mode captures the file, a live selection captures those lines.
 ==============================================================================
 4. SCOPES                                                *codereview-scopes*
 
-    branch      merge-base with the default branch .. working tree (default)
-    staged      git diff --cached
-    unstaged    git diff
-    worktree    git diff HEAD
-    {revspec}   anything git accepts
+    branch        merge-base with the default branch .. working tree (default)
+    staged        git diff --cached
+    unstaged      git diff
+    worktree      git diff HEAD
+    since-batch   the newest snapshot in the archive .. working tree
+    {revspec}     anything git accepts
 
-`gs` cycles the first four in place. Reviewed marks are tracked per scope:
-marking a file done in `staged` says nothing about the whole branch's changes
-to it.
+`gs` cycles them in place, in that order. Reviewed marks are tracked per
+scope: marking a file done in `staged` says nothing about the whole branch's
+changes to it.
 
 The default branch is read, not assumed -- `origin/HEAD` first, then
 `origin/main`, `origin/master`, `main`, `master`. Repositories on `master` are
 common enough that hardcoding `main` would silently diff against nothing.
 
-Untracked files appear as all-added entries in `branch` and `worktree` scopes;
-set `untracked = false` to hide them. `git diff` never reports them, so a
-brand-new file would otherwise be invisible to the review.
+Untracked files appear as all-added entries in the `branch`, `worktree` and
+`since-batch` scopes; set `untracked = false` to hide them. `git diff` never
+reports them, so a brand-new file would otherwise be invisible to the review.
+
+Since the last batch                                *codereview-since-batch*
+
+`since-batch` diffs the working tree against the snapshot recorded when the
+last batch was dispatched (|codereview-persistence-archive|), so what it shows
+is the agent's response to a review rather than everything uncommitted: work
+you already had in flight when you submitted is in that snapshot, and is
+therefore not in this diff. Nothing else about it differs. It is an ordinary
+scope resolved by the ordinary path, with the snapshot as its before-image, so
+highlighting, navigation, collapse, reviewed marks, both layouts and
+annotating inside it all behave as they do anywhere else.
+
+`gs` reaches it only once something has been dispatched from the repository --
+a cycle is walked blind and must never land on an error. Asking for it by name
+with an empty archive reports why, the way `branch` does with no merge base.
+
+A file that was untracked when the batch went is in no snapshot at all, and
+comes through the same synthesis above rather than one of its own.
 
 ==============================================================================
 5. LAYOUTS                                              *codereview-layouts*
@@ -777,6 +801,11 @@ create` -- which moves no ref, leaves the index alone and never touches the
 working tree, so nothing about a submit disturbs what you are reviewing. On a
 clean tree there is nothing to record that `HEAD` does not already say, and
 `HEAD` is what is stored. Untracked files are not in such a commit.
+
+A real commit object rather than a set of blobs because it exists to be
+diffed against: |codereview-since-batch| resolves to it as an ordinary scope's
+before-image, and the diff, the blob hashes and the whole-file reads the
+highlighter makes each need a ref git can resolve.
 
 A dispatch writes it and nothing else does. An adapter that declined, one that
 raised, the `+` register the default send copies to and the one

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -160,6 +160,24 @@ key and then by id, so `x` removes the wrong one. The restore therefore seeds fr
 archive as well, *after* both stores have been read, because entries are split between them
 and an id is unique across the pair.
 
+**`since-batch` resolves through the same function every other scope does, and must.** The
+temptation is a marker — a scope that says "the archive" and is special-cased downstream —
+and it fails in three places at once: the diff parser is handed `git diff <before>`, the
+blob hashing resolves `<before>:<path>` through `cat-file`, and the syntax highlighter
+fetches whole-file content with `git show <before>:<path>`. Every one of them needs
+`before` to be something git can resolve, which is why the archive stores a commit object
+rather than a set of blobs, and why resolution reads that sha and returns an ordinary
+scope. If a new scope ever appears to need a case in the render or the view, it is not
+resolving like the others.
+
+**The scope is offered by name and in the cycle under two different rules.** Completion
+lists it unconditionally, because a reviewer who asks for it by name with an empty archive
+should be told why — that is what the `nil, err` pair is for, and `branch` already answers
+that way with no merge base. `gs` is the opposite: a cycle is walked blind, so a repository
+that has never dispatched must not have a scope in its cycle that can only report an error.
+One rule reads as two until you notice that one of them is a question and the other is a
+key held down.
+
 **`git stash create` mints a commit and does nothing else.** No ref moves, the index is not
 touched and the working tree is not reverted, which is the only reason it is safe to run
 behind a submit. Two consequences worth knowing before reading a snapshot back: a clean

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -41,13 +41,19 @@ change there is felt through.
   is not local to a leaf almost certainly reaches one of them.
 - **On top**: `capture`, then `init`.
 
-## The one cycle
+## The two cycles
 
 `view` and `annotate` require each other. This is known and accepted — not a defect to fix
 in passing. `annotate` needs the focused pane, the current view, the repaint and the anchor
 under the cursor, which are genuine dependencies, and both sides use a function-local
 `require`, so Lua resolves it lazily and nothing loads at file scope before it is ready.
 Forcing the two apart costs more than it returns.
+
+`git` and `state` are the second, and much the smaller: `state` mints a snapshot and hashes
+blobs through `git`, and `git` reads the newest snapshot back out of the archive to resolve
+the `since-batch` scope. Function-local on both sides, as above. The alternative is handing
+the snapshot in from outside, which would put the one scope that needs it into every caller
+of `resolve_scope` — and scope resolution is exactly what must stay one function.
 
 ## Where reading pays
 

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -115,15 +115,35 @@ end
 --- Scopes ----------------------------------------------------------------------
 
 ---@class CRScope
----@field name string       "branch"|"staged"|"unstaged"|"worktree"|"revspec"
+---@field name string       "branch"|"staged"|"unstaged"|"worktree"|"since-batch"|"revspec"
 ---@field label string      Shown in the view title
 ---@field args string[]     Appended to the `git diff` invocation
 ---@field before string     Ref for the pre-image; ":0" means the index
 ---@field after string|nil  Ref for the post-image; nil means the working tree
 ---@field untracked boolean Whether untracked files belong in this scope
 
----Scopes cycled by `gs`, in order. A bare revspec is resolved separately.
-M.CYCLE = { "branch", "staged", "unstaged", "worktree" }
+---Every scope with a name, in the order `gs` moves through them. A bare revspec is
+---resolved separately, and completion offers exactly this list.
+M.SCOPES = { "branch", "staged", "unstaged", "worktree", "since-batch" }
+
+---The scopes `gs` actually moves through in this repository.
+---
+---`since-batch` is reachable by name and offered in completion unconditionally -- asking
+---for it with an empty archive reports a sentence -- but the cycle drops it, because a
+---cycle is walked blind and must never land on an error in a repository nothing has ever
+---been dispatched from. Two rules, deliberately: one is a question a reviewer asked, the
+---other is a key they held down.
+---@param root string
+---@return string[]
+function M.cycle(root)
+  local names = {}
+  for _, name in ipairs(M.SCOPES) do
+    if name ~= "since-batch" or #require("codereview.state").archive(root) > 0 then
+      names[#names + 1] = name
+    end
+  end
+  return names
+end
 
 ---Resolve a scope name, or any git revspec, into the refs the rest of the plugin needs.
 ---
@@ -147,6 +167,29 @@ function M.resolve_scope(spec, root)
     return { name = "unstaged", label = "unstaged", args = {}, before = ":0", after = nil, untracked = false }
   elseif spec == "worktree" then
     return { name = "worktree", label = "worktree", args = { "HEAD" }, before = "HEAD", after = nil, untracked = true }
+  elseif spec == "since-batch" then
+    -- Resolved here rather than anywhere of its own, and to a *real ref*: the diff parser,
+    -- the blob hashing and the whole-file fetch the highlighter needs all read content out
+    -- of `before`, and none of them can read a marker. Which is why the archive keeps a
+    -- commit object -- read back here through the accessor every other consumer uses.
+    local batch = require("codereview.state").archive(root)[1]
+    if not batch then
+      return nil, "nothing has been dispatched from this repository yet"
+    end
+    if not batch.snapshot then
+      return nil, "the last batch went out with no snapshot to diff against"
+    end
+    return {
+      name = "since-batch",
+      label = "since the last batch",
+      args = { batch.snapshot },
+      before = batch.snapshot,
+      after = nil,
+      -- A file untracked at dispatch is not in the snapshot commit at all, so it arrives
+      -- through the same synthesis the branch and worktree scopes already apply rather
+      -- than through a mechanism of its own.
+      untracked = true,
+    }
   elseif spec == "branch" or spec == "" or spec == nil then
     local branch = M.default_branch(root)
     if not branch then

--- a/lua/codereview/init.lua
+++ b/lua/codereview/init.lua
@@ -17,10 +17,13 @@ function M.setup(opts)
   end, {
     nargs = "?",
     desc = "Open the code review view (scope name or any git revspec)",
+    -- Every named scope, unconditionally -- including `since-batch` in a repository with an
+    -- empty archive, which answers with a sentence. Completion says what exists; whether
+    -- there is anything to show is the scope's own answer to give.
     complete = function(lead)
       return vim.tbl_filter(function(name)
         return name:sub(1, #lead) == lead
-      end, vim.deepcopy(require("codereview.git").CYCLE))
+      end, vim.deepcopy(require("codereview.git").SCOPES))
     end,
   })
 

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -693,20 +693,23 @@ function M.reconcile()
   end
 end
 
----@param spec string|nil nil cycles to the next scope in git.CYCLE
+---@param spec string|nil nil cycles to the next scope this repository offers
 function M.set_scope(spec)
   if not M.current() then
     return
   end
   if not spec then
+    -- Asked per repository rather than read off a constant: which scopes are safe to walk
+    -- blind depends on whether anything has ever been dispatched from this one.
+    local cycle = git.cycle(V.root)
     local at = 1
-    for i, name in ipairs(git.CYCLE) do
+    for i, name in ipairs(cycle) do
       if name == V.scope.name then
         at = i
         break
       end
     end
-    spec = git.CYCLE[(at % #git.CYCLE) + 1]
+    spec = cycle[(at % #cycle) + 1]
   end
 
   local scope, err = git.resolve_scope(spec, V.root)

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, and a document written before the archive existed |
+| `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
 | `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, the draft an undispatched immediate send leaves behind, and the deliberate copy that is not a dispatch |
@@ -144,6 +145,20 @@ so the out-of-core language path is still checked locally without ever failing C
   edge to assume away: the snapshot falls back to `HEAD`. `archive_spec` builds a second
   fixture and resets it hard, because the shared one is dirty by design and can never
   reach that branch.
+- **"`since-batch` leaves out the work in flight" needs work to have been in flight.** The
+  scope excludes what the snapshot already holds, so a fixture dispatched from a *clean*
+  tree makes that assertion pass with the snapshot replaced by `HEAD` — there is nothing
+  either one could differ about. `diff_spec` and `since_batch_spec` both assert that
+  `src/routes.lua` is dirty against `HEAD` before asserting it is absent from the scope,
+  and both edit a file only *after* the dispatch, so what is on screen is the response to
+  the batch. Same trap as "a filter test needs a fixture only that filter can reject".
+- **A scope that behaves like the others cannot be tested by reading the diff.** Nothing
+  special-cases `since-batch`, so every claim about it is a claim about code no line of
+  which mentions it — which is exactly why `since_batch_spec` drives syntax, navigation,
+  collapse, reviewed marks and both layouts through it rather than trusting that. Its
+  capture case compares the entry captured in `since-batch` against the one the *same line*
+  produces in `worktree`, field for field bar the id: an entry that recorded which scope
+  caught it would differ, and nothing weaker than a comparison would notice.
 - **A send adapter that raises takes the whole `describe` with it.** Plenary runs a
   describe body immediately, so an adapter that propagates its error aborts the block
   instead of failing one case — the `it`s below it never run. `delivery_spec` asserts on

--- a/tests/codereview/diff_spec.lua
+++ b/tests/codereview/diff_spec.lua
@@ -6,6 +6,7 @@ local h = require("tests.helpers")
 
 local git = require("codereview.git")
 local diff = require("codereview.diff")
+local state = require("codereview.state")
 
 -- One fixture for the file. Nothing here mutates the repository, so rebuilding it per
 -- describe only bought four `git init`s.
@@ -217,5 +218,101 @@ describe("reading file content and blobs", function()
 
   it("hashes a deleted file too, from its pre-image", function()
     assert.is_truthy((by["src/gone.lua"].blob or ""):match("^%x+$"))
+  end)
+end)
+
+-- The scope that diffs the working tree against the newest snapshot in the archive.
+--
+-- A fixture of its own, because this one is dispatched from and *then* edited: the file
+-- above is built once and read, and every count in it would move underneath the assertions
+-- already made. Read top to bottom -- the empty-archive cases have to run before the
+-- dispatch below them, which is the only state in which they mean anything.
+describe("the since-batch scope", function()
+  local repo = h.fixture("mkfixture")
+  local repo_root = assert(vim.uv.fs_realpath(repo))
+
+  it("is offered by name whether or not anything has been dispatched", function()
+    assert.is_true(vim.tbl_contains(git.SCOPES, "since-batch"))
+  end)
+
+  it("reports a sentence rather than failing with an empty archive", function()
+    local resolved, err = git.resolve_scope("since-batch", repo_root)
+    assert.is_nil(resolved)
+    assert.is_string(err)
+  end)
+
+  it("stays out of the cycle in a repository that has never dispatched", function()
+    assert.is_false(vim.tbl_contains(git.cycle(repo_root), "since-batch"))
+  end)
+
+  -- The dispatch, through the write every dispatch goes through, and then the agent's
+  -- answer to it: one tracked file changed *after* the batch went out.
+  state.archive_batch({
+    { id = 1, type = "bug", kind = "file", path = "src/main.lua", key = "src/main.lua:f:0", note = "have a look" },
+  }, "agent", repo_root)
+  local snapshot = assert(state.archive(repo_root)[1].snapshot, "the batch was archived without a snapshot")
+
+  vim.fn.writefile({
+    'local app = require("app")',
+    "local cfg = load_config()",
+    "cfg.validate()",
+    "app.listen(cfg.port)",
+  }, vim.fs.joinpath(repo, "src/main.lua"))
+
+  local since = assert(git.resolve_scope("since-batch", repo_root))
+  local since_files = assert(git.collect(since, repo_root))
+  local paths = vim.tbl_map(function(f)
+    return f.path
+  end, since_files)
+  local since_by = {}
+  for _, f in ipairs(since_files) do
+    since_by[f.path] = f
+  end
+
+  it("carries the newest snapshot as its before-image", function()
+    assert.same({ "since-batch", snapshot }, { since.name, since.before })
+  end)
+
+  -- nil `after` means "the working tree", which is what the highlighter needs to know to
+  -- read the post-image off disk rather than out of git.
+  it("compares it against the working tree", function()
+    assert.is_nil(since.after)
+  end)
+
+  it("joins the cycle once something has been dispatched", function()
+    assert.is_true(vim.tbl_contains(git.cycle(repo_root), "since-batch"))
+  end)
+
+  -- Derived from git rather than hardcoded, as everything else in this file is: which
+  -- files a snapshot differs from is a fact about the fixture, and hardcoded lists have
+  -- gone stale in this repository before.
+  it("collects exactly what git reports against the snapshot, untracked files included", function()
+    local want = h.git_lines(repo, { "diff", "--name-only", snapshot })
+    vim.list_extend(want, h.git_lines(repo, { "ls-files", "--others", "--exclude-standard" }))
+    table.sort(want)
+    assert.same(want, paths)
+  end)
+
+  it("shows the file that changed since the batch went", function()
+    assert.same({ "M", 1, 0 }, {
+      since_by["src/main.lua"].status,
+      since_by["src/main.lua"].added,
+      since_by["src/main.lua"].removed,
+    })
+  end)
+
+  -- The point of the scope. `src/routes.lua` was dirty before the batch was dispatched and
+  -- has not been touched since, so it is in the snapshot and not in this diff -- which the
+  -- guard makes an assertion rather than a coincidence of an already-clean fixture.
+  it("leaves out the work that was already in flight when the batch went", function()
+    local uncommitted = h.git_lines(repo, { "diff", "--name-only", "HEAD" })
+    assert.is_true(vim.tbl_contains(uncommitted, "src/routes.lua"), "nothing was in flight, so this proves nothing")
+    assert.is_false(vim.tbl_contains(paths, "src/routes.lua"), vim.inspect(paths))
+  end)
+
+  -- Untracked at dispatch, so it is in no snapshot at all: it arrives through the same
+  -- synthesis the branch and worktree scopes apply, not through a rule of its own.
+  it("synthesises a file that was untracked when the batch went", function()
+    assert.same({ "U", 2 }, { since_by["src/untracked.lua"].status, since_by["src/untracked.lua"].added })
   end)
 end)

--- a/tests/codereview/since_batch_spec.lua
+++ b/tests/codereview/since_batch_spec.lua
@@ -1,0 +1,247 @@
+-- The since-batch scope inside a review view: the claim that nothing about it is second
+-- class.
+--
+-- Every case here asserts a behaviour some *other* spec owns for every other scope --
+-- syntax, navigation, collapse, reviewed marks, both layouts, capture -- because the way
+-- this scope fails is not by throwing: it is by being special-cased somewhere in the
+-- render or the view until it renders a little less than the others do.
+--
+-- The batch is dispatched through `submit`, which is the one thing that archives, and the
+-- fixture is edited *afterwards*, so what is on screen is the answer to the batch and not
+-- the work that was already in flight when it went.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+local root = assert(vim.uv.fs_realpath(fixture))
+
+local annotate = require("codereview.annotate")
+local codereview = require("codereview")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+local NOTE = "a note about the agent's own work"
+
+codereview.setup({
+  compose = function(_, on_accept)
+    on_accept(nil, NOTE)
+  end,
+  -- Reports nothing, which delivery reads as a dispatch -- and a dispatch is what archives.
+  send = function() end,
+})
+
+--- The dispatch, and the agent's answer to it ------------------------------------
+
+describe("a repository nothing has been dispatched from", function()
+  it("has an empty archive to start from", function()
+    assert.same({}, state.archive(root))
+  end)
+
+  it("does not offer the scope to `gs`", function()
+    assert.is_false(vim.tbl_contains(require("codereview.git").cycle(root), "since-batch"))
+  end)
+
+  it("still offers it by name, on the command line", function()
+    assert.is_true(vim.tbl_contains(vim.fn.getcompletion("CodeReview ", "cmdline"), "since-batch"))
+  end)
+end)
+
+-- Dirty when the batch goes: `src/routes.lua` is staged and unstaged in the fixture, which
+-- is what makes "work in flight does not appear" an assertion rather than a coincidence.
+local in_flight = h.git_lines(fixture, { "diff", "--name-only", "HEAD" })
+
+queue.add({
+  type = "bug",
+  kind = "file",
+  path = "src/main.lua",
+  abs_path = vim.fs.joinpath(root, "src/main.lua"),
+  key = "src/main.lua:f:0",
+  note = "have a look at this",
+})
+local msgs, restore = h.capture_notify()
+codereview.submit()
+restore()
+
+-- The agent's response: one line added to a file it was asked about, after the batch went.
+vim.fn.writefile({
+  'local app = require("app")',
+  "local cfg = load_config()",
+  "cfg.validate()",
+  "app.listen(cfg.port)",
+}, vim.fs.joinpath(fixture, "src/main.lua"))
+
+describe("the dispatch the rest of this spec reads back", function()
+  it("was dispatched at all", function()
+    assert.is_true(h.notified(msgs, "Submitted 1 annotation"), vim.inspect(msgs))
+  end)
+
+  it("left a batch in the archive to diff against", function()
+    assert.same(1, #state.archive(root))
+    assert.is_string(state.archive(root)[1].snapshot)
+  end)
+
+  it("went out of a working tree that had work in it already", function()
+    assert.is_true(vim.tbl_contains(in_flight, "src/routes.lua"), vim.inspect(in_flight))
+  end)
+end)
+
+--- The review view it opens ------------------------------------------------------
+
+view.open("since-batch")
+local V = assert(view.current(), "the review view did not open")
+
+---The row of the one line the agent added, in whichever pane holds it.
+---@param rendered CRRender
+---@return integer|nil
+local function added_row(rendered)
+  for row, a in pairs(rendered.anchors) do
+    local file = V.files[a.file]
+    if a.kind == "line" and file.path == "src/main.lua" then
+      local ln = file.hunks[a.hunk].lines[a.line]
+      if ln.side == "add" then
+        return row
+      end
+    end
+  end
+end
+
+describe("the review view it opens", function()
+  it("names what it is showing, so the winbar is unambiguous", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("since the last batch", 1, true), vim.wo[V.win].winbar)
+  end)
+
+  it("shows the file the agent changed after the batch went", function()
+    assert.is_number(h.file_index(V, "src/main.lua"))
+  end)
+
+  it("leaves out the work that was in flight before it", function()
+    assert.is_nil(h.file_index(V, "src/routes.lua"))
+  end)
+
+  it("carries a file that was untracked at dispatch, as any other scope does", function()
+    assert.is_number(h.file_index(V, "src/untracked.lua"))
+  end)
+
+  it("highlights it with treesitter like any other scope", function()
+    local marks = h.syntax_marks(V)
+    assert.is_true(#marks > 0)
+  end)
+
+  it("navigates by file", function()
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    view.jump("file", true)
+    assert.same(V.render.file_rows[2], vim.api.nvim_win_get_cursor(V.win)[1])
+  end)
+
+  it("navigates by hunk", function()
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    view.jump("hunk", true)
+    assert.same("hunk", V.render.anchors[vim.api.nvim_win_get_cursor(V.win)[1]].kind)
+  end)
+end)
+
+describe("marking a file reviewed in it", function()
+  local fi = assert(h.file_index(V, "src/main.lua"))
+  local rows_before = #V.render.lines
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[fi], 0 })
+  view.toggle_reviewed()
+
+  it("records the blob it was reviewed against", function()
+    assert.same(V.files[fi].blob, V.reviewed["src/main.lua"])
+  end)
+
+  it("collapses the file", function()
+    assert.is_true(#V.render.lines < rows_before)
+  end)
+
+  it("restores the rows when unmarked", function()
+    view.toggle_reviewed()
+    assert.same(rows_before, #V.render.lines)
+  end)
+
+  -- Per scope, and keyed by the snapshot the scope resolved to: the next batch is a
+  -- different before-image, so a file marked done against this one says nothing about it.
+  it("saves the mark under this scope's own key", function()
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[fi], 0 })
+    view.toggle_reviewed()
+    view.persist()
+    local saved = state.load(root).scopes["since-batch:" .. V.scope.before]
+    assert.same(V.files[fi].blob, saved.reviewed["src/main.lua"])
+    view.toggle_reviewed()
+  end)
+end)
+
+describe("the split layout", function()
+  view.toggle_layout()
+  local split = assert(view.current())
+
+  it("draws a before pane", function()
+    assert.is_true(split.before_win ~= nil and vim.api.nvim_win_is_valid(split.before_win))
+  end)
+
+  it("keeps the two panes row for row", function()
+    assert.same(#split.render.lines, #split.before_render.lines)
+  end)
+
+  it("names the snapshot as the image the before pane is showing", function()
+    assert.is_truthy(vim.wo[split.before_win].winbar:find(split.scope.before, 1, true))
+  end)
+
+  it("holds the line the agent added in the after pane", function()
+    assert.is_number(added_row(split.render))
+  end)
+
+  it("goes back to unified", function()
+    view.toggle_layout()
+    assert.same("unified", view.current().layout)
+  end)
+end)
+
+--- Capture, and the cycle --------------------------------------------------------
+
+-- Captured from the same line in two scopes, which is the whole of "no trace of which
+-- scope captured it": the two entries have to be identical bar the id they were issued.
+-- `src/main.lua` differs from the snapshot and from HEAD by exactly that line, so the same
+-- anchor exists in both scopes.
+queue.clear()
+vim.api.nvim_win_set_cursor(V.win, { assert(added_row(V.render), "the added line is not on screen"), 0 })
+annotate.annotate("bug")
+local from_since = vim.deepcopy(assert(queue.all()[1], "nothing was captured"))
+
+view.set_scope("worktree")
+local W = assert(view.current())
+queue.clear()
+vim.api.nvim_win_set_cursor(W.win, { assert(added_row(W.render), "the added line is not on screen"), 0 })
+annotate.annotate("bug")
+local from_worktree = vim.deepcopy(assert(queue.all()[1], "nothing was captured"))
+
+describe("annotating inside it", function()
+  it("captures the line it was aimed at", function()
+    assert.same({ "bug", "line", "src/main.lua", NOTE }, {
+      from_since.type,
+      from_since.kind,
+      from_since.path,
+      from_since.note,
+    })
+  end)
+
+  -- Ids apart, because they are issued in order and nothing else about an entry is.
+  it("produces the entry that line produces in any other scope", function()
+    from_since.id, from_worktree.id = nil, nil
+    assert.same(from_worktree, from_since)
+  end)
+end)
+
+describe("cycling with something in the archive", function()
+  it("is where `gs` goes after worktree", function()
+    assert.same("worktree", view.current().scope.name)
+    view.set_scope(nil)
+    assert.same("since-batch", view.current().scope.name)
+  end)
+
+  it("cycles back out of it, to the first scope", function()
+    view.set_scope(nil)
+    assert.same("branch", view.current().scope.name)
+  end)
+end)


### PR DESCRIPTION
`:CodeReview since-batch` opens an ordinary review view diffing the working tree against
the newest **snapshot** in the **archive**. What it excludes is the point: work the
reviewer already had in flight before submitting is in that snapshot, so what is on screen
is the agent's response and not everything uncommitted.

## How it resolves

Through `git.resolve_scope`, the same function every other scope resolves through, with the
snapshot as an ordinary `before` and the working tree as the after-image. Not a marker
something downstream understands — the diff, the blob hashing and the treesitter whole-file
fetch each resolve that ref through git, and a marker would need special-casing in all
three. That is why the archive stores a commit object, and it is why nothing in the render
or the view had to change: the diff of a `since-batch` scope is a diff.

The snapshot is read back through `state.archive(root)`, the accessor every consumer uses.

## The two rules that are not one

- **Completion offers it unconditionally.** With an empty archive it returns the `nil, err`
  pair `branch` already returns with no merge base, so the surface reports a sentence.
- **`gs` takes it only once something has been dispatched.** A cycle is walked blind, and
  cycling in a repository that has never submitted must not land on an error.

A file untracked at dispatch is in no snapshot at all, and arrives through the same
synthesis the branch and worktree scopes already apply.

## Tests

`diff_spec` takes the resolution, on a fixture of its own that is dispatched from and then
edited: the snapshot as `before`, the sentence an empty archive answers with, both cycle
rules, and the file list derived from `git diff --name-only <snapshot>` rather than
hardcoded. The claim that in-flight work stays out is guarded by asserting there was any —
dispatched from a clean tree it would pass with the snapshot replaced by `HEAD`.

`since_batch_spec` is new, and every case in it is about code that does not mention the
scope: syntax, navigation, collapse, reviewed marks, both layouts, and an entry captured
inside it compared field for field against the one the *same line* produces in `worktree`.
An entry recording which scope caught it would differ; nothing weaker would notice.

`make all` is green — 1021 cases.

Closes #72