### PR TITLE
feat(archive): read the last dispatched batch back

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,23 @@ in the `+` register without submitting it. It is the same text `send` would have
 handed, target and all, and it costs the batch nothing: the queue is untouched, so reading
 what an agent will be told is not a decision to send it.
 
+### Read the last batch back after it goes
+
+A submit clears the queue, which is the moment "what did I actually ask for?" stops having
+an answer anywhere but the agent's transcript. `:CodeReviewLastBatch` gives it one: the
+annotations of the batch that went last, grouped by type exactly as the queue float and the
+payload group them, with the target it went to and when it went in the frame.
+
+It needs no review open — a batch is not a window, and what you asked for is worth checking
+from anywhere. A bare note is listed like anything else, even though it was kept in a
+different store than the annotations with a file behind them.
+
+It is **read-only**, and that is a statement about the record rather than a feature left
+out. An archived entry says something happened; a surface that let you drop, edit or
+resubmit one would be claiming the plugin can revise what an agent already received. To
+raise a point again, annotate again — that is an ordinary capture, and it joins the next
+batch.
+
 ### The payload
 
 Grouped by type, in the configured order, most actionable first, with anything untyped
@@ -476,6 +493,21 @@ under the cursor and not what a heading further up happened to say.
 
 `gy` leaves the float open, because it takes nothing out of the queue — everything it is
 listing is still there.
+
+### In the last-batch float
+
+`:CodeReviewLastBatch` lists an annotation the same way — the reserved gutter, the bar in
+its type's colour, the code it inlined and its note — so the two read as one family. What
+is missing is every key that would change something.
+
+| Key | Action |
+| --- | --- |
+| `q` / `<Esc>` | Close |
+| `x` `<C-s>` | Bound only to say why they do nothing here |
+
+Those two are bound rather than left off so that the queue float's muscle memory gets a
+sentence instead of `E21`. Nothing else is: the batch has gone, and there is nothing left
+to route, drop or send.
 
 ## Configuration
 
@@ -652,6 +684,10 @@ A dispatch writes it and nothing else does. An adapter that declined, one that r
 it exactly as they leave the queue — a payload sitting in a register is not something an
 agent received. An immediate send is a batch of one and is kept as one. The most recent
 **twenty** batches are kept per store, oldest dropped on write.
+
+`:CodeReviewLastBatch` reads the newest one back. A batch holding both kinds of annotation
+is written to both stores and rejoined by the moment it was dispatched, which is what stops
+a bare note being the one thing missing from what you read back.
 
 </details>
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -52,6 +52,22 @@ files without one fall back to flat diff colours.
         archived -- a register is not a consumer. Needs no review view open.
         Also bound to `gy` in the diff and in the queue float.
 
+                                                       *:CodeReviewLastBatch*
+:CodeReviewLastBatch
+        Read the last dispatched batch back: its annotations, grouped by type
+        exactly as the queue float and the payload group them, with the target
+        it went to and when it went in the frame. Needs no review view open --
+        a batch is not a window. A bare note is listed like anything else,
+        though it was kept in a different store. With nothing dispatched yet
+        it says so rather than opening onto nothing.
+
+        Read-only, and that is a claim about the record: an archived entry
+        says something happened, and a surface that let you drop, edit or
+        resubmit one would be claiming the plugin can revise what an agent
+        already received. To raise a point again, annotate again -- an
+        ordinary capture, which joins the next batch. See
+        |codereview-persistence-archive|.
+
                                                         *:CodeReviewAnnotate*
 :[range]CodeReviewAnnotate [{type}]
         Annotate the current buffer without a review open. {type} is one of
@@ -144,6 +160,14 @@ have nowhere to go: a bare note has no file at all, there may be no review
 view open, and a file may lie outside the current scope. Each says which, and
 leaves the float open -- the remedies are nothing, open a review, and change
 scope.
+
+In the last-batch float (|:CodeReviewLastBatch|): q and <Esc> close, and that
+is the whole of it. `x` and <C-s> are bound only to say why they do nothing,
+so the queue float's muscle memory gets a sentence rather than |E21| against a
+|nomodifiable| buffer. An annotation is drawn there exactly as the queue float
+draws one -- the reserved gutter, the bar in its type's colour, the code it
+inlined and its note -- so the two read as one family; what is missing is
+every key that would change something.
 
 Annotation keys are prefixed with `a` rather than bound bare. Bare `b`, `f`,
 `n` and `s` would shadow back-word, find-char and next-search inside the
@@ -820,6 +844,11 @@ note or a file outside any checkout to the no-repository store. The most
 recent **twenty** batches per store are kept, and the oldest is dropped on
 write.
 
+|:CodeReviewLastBatch| reads the newest one back. A batch that held both kinds
+of annotation is therefore two records, and they are rejoined by the moment
+they were dispatched -- both halves are stamped from one clock reading. That
+is what stops a bare note being the one thing missing from what you read back.
+
 ==============================================================================
 12. LUA API                                                 *codereview-api*
 
@@ -843,6 +872,9 @@ require("codereview").copy()                             *codereview.copy()*
         Copy the batch to the `+` register without submitting it -- the same
         payload |codereview-opt-send| would have been handed. The queue is
         untouched and nothing is archived. See |:CodeReviewCopy|.
+require("codereview").last_batch()                 *codereview.last_batch()*
+        Read the last dispatched batch back, read-only and with no review view
+        involved. See |:CodeReviewLastBatch|.
 require("codereview").count()                           *codereview.count()*
         Number of queued annotations -- useful in a statusline.
 require("codereview").is_open()                       *codereview.is_open()*

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -204,6 +204,26 @@ that has never dispatched must not have a scope in its cycle that can only repor
 One rule reads as two until you notice that one of them is a question and the other is a
 key held down.
 
+**One dispatch is two records, and reading it back means rejoining them.** A batch is split
+across the two stores on the rule that already routes the queue — an entry with a
+repository-relative path to that repository's document, a bare note or a file outside a
+checkout to the store that needs no root — and the two halves are stamped from a single
+`os.time()` call. That stamp is the *only* thing tying them together. Anything reading a
+batch back through one accessor alone therefore drops exactly the entries with nowhere else
+to live, silently and in the direction that looks fine: the file annotations are all there,
+and a bare note becomes the one thing that vanishes — which is the failure the split was
+meant to avoid. Matching on the stamp is load-bearing, and it resolves to one second: two
+dispatches inside the same second read back as one batch. That is beyond any human dispatch
+cadence and well within a loop's, which is why `archive_float_spec` clears both stores
+between blocks rather than trusting the clock.
+
+**An archived entry's `stale` flag must not be drawn.** It is persisted with the entry, so
+it is there to read, and it means "this file had moved since the annotation was captured" —
+a fact about a queue that no longer exists. Printed on a surface listing what already went,
+it reads as a claim about the code *now*, which nothing has checked. Whether an archived
+entry's file has moved since its batch was dispatched is a different question, judged
+against a different blob, and it has a word of its own.
+
 **`git stash create` mints a commit and does nothing else.** No ref moves, the index is not
 touched and the working tree is not reverted, which is the only reason it is safe to run
 behind a submit. Two consequences worth knowing before reading a snapshot back: a clean

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -204,6 +204,19 @@ that has never dispatched must not have a scope in its cycle that can only repor
 One rule reads as two until you notice that one of them is a question and the other is a
 key held down.
 
+**Two things ask which batch went last, and they must never get different answers.** The
+`since-batch` scope diffs the working tree against the newest batch's snapshot; the surface
+that reads a batch back lists the newest batch's entries. A reviewer reads one beside the
+other — that is the whole point of keeping a batch — so a disagreement would put the
+response to one dispatch on screen with the annotations of another next to it, and nothing
+anywhere would say so. Both go through `state.last_batch`, which exists for that reason and
+not for brevity: the two arrived independently, each reaching for the head of the archive,
+and two copies of `[1]` are what that drift looks like before it happens. It lives on
+`state` rather than on either caller because `git` already requires `state` and does not
+require `archive` — routing it through the surface would turn the two-module cycle into a
+three-module one. Re-inlining either call is the regression, and the case that catches it is
+in `archive_float_spec`, because neither slice's own spec archives more than one batch.
+
 **One dispatch is two records, and reading it back means rejoining them.** A batch is split
 across the two stores on the rule that already routes the queue — an entry with a
 repository-relative path to that repository's document, a bare note or a file outside a

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -14,6 +14,7 @@ change there is felt through.
 | Module | Owns | |
 | --- | --- | --- |
 | `annotate.lua` | The review path: cursor to entry, the deleted-line and hunk inlining rules, drop, grouping | stateful (queue, view) |
+| `archive.lua` | The archive read back: which batch went last, and the read-only float listing it | stateful (float) |
 | `capture.lua` | The capture path: the same entry from an ordinary buffer, no review view involved | stateful (queue, buffer) |
 | `composer.lua` | The shipped composer and its `@` reference picker — the default `compose` adapter, not a lesser one | stateful (float) |
 | `config.lua` | `setup()`, the defaults, and the injected adapters: `send`, `pick_target`, `pick_file`, `compose`, `open_diff` | stateful (options) |
@@ -36,7 +37,7 @@ change there is felt through.
 
 - **Require nothing**: `diff`, `drafts`, `panel`, `queue`, `types`.
 - **Above them**, in that order: `git`, `payload`, `render`; then `state`, `config`; then
-  `delivery`, `syntax`; then `composer`, `hl`.
+  `archive`, `delivery`, `syntax`; then `composer`, `hl`.
 - **The hubs**: `view` requires twelve of the modules above, `annotate` nine. A change that
   is not local to a leaf almost certainly reaches one of them.
 - **On top**: `capture`, then `init`.
@@ -58,7 +59,7 @@ of `resolve_scope` — and scope resolution is exactly what must stay one functi
 ## Where reading pays
 
 - **Settled**, one to three commits each: `panel`, `drafts`, `diff`, `git`, `syntax`,
-  `render`, `hl`. Read one when you need it, not to orient yourself.
+  `render`, `hl`, `archive`. Read one when you need it, not to orient yourself.
 - **Carries the churn**: `view` and `annotate` by a wide margin, then `config`, `composer`
   and `state`.
 

--- a/lua/codereview/archive.lua
+++ b/lua/codereview/archive.lua
@@ -1,0 +1,314 @@
+---The archive read back: the batch that went last, as a surface of its own.
+---
+---What a reviewer asked for should be a fact the plugin holds, not something to scroll an
+---agent's transcript for. This is where that fact is read: the **entries** of the newest
+---archived **batch**, the **target** it went to, and when it went.
+---
+---**Read-only, and that is a claim about the record rather than a feature left unwritten.**
+---An archived entry says something happened. A surface that let you drop, edit or resubmit
+---one would be claiming the plugin can revise what an agent already received, which it
+---cannot. Re-raising a point means annotating again, which is an ordinary capture and
+---already has a path.
+---
+---A module of its own because a buffer, a window and keys do not have to live on the review
+---view to exist -- and because a **batch is not a window**: this opens with no review open,
+---exactly as the queue float does, so what was asked for can be checked from anywhere.
+local config = require("codereview.config")
+local render = require("codereview.render")
+local state = require("codereview.state")
+local types = require("codereview.types")
+
+local M = {}
+
+---@param msg string
+local function info(msg)
+  vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
+
+--- Which batch went last -------------------------------------------------------
+
+---The batch that went last, wherever its entries were kept.
+---
+---**One dispatch can be two records.** `state.archive_batch` splits a batch on the rule
+---that already routes the queue -- an entry with a repository-relative path to that
+---repository's document, a bare note or a file outside a checkout to the store that needs
+---no root -- and stamps both halves from a single `os.time()`. Read back through one
+---accessor alone, a batch that held both is missing exactly the entries with nowhere else
+---to be listed, and a bare note becomes the one thing that vanishes.
+---
+---So: the newest record across the two, and the other store's newest with it when the two
+---carry the same stamp and the same target, which is what one dispatch looks like on disk.
+---Both stores are read through the accessors that already exist; nothing here reaches past
+---them for a newest batch of its own.
+---@param root string|nil nil outside a repository, where only the store that needs none applies
+---@return CRBatch|nil
+function M.last(root)
+  -- Each store keeps its batches newest first, so the head of each is the only candidate.
+  local owned = state.archive(root)[1]
+  local loose = state.global_archive()[1]
+
+  if owned and loose and owned.at == loose.at and owned.target == loose.target then
+    local entries = {}
+    vim.list_extend(entries, owned.entries or {})
+    vim.list_extend(entries, loose.entries or {})
+    -- Back into the order they were written in, which is the order they reached the agent:
+    -- ids are issued as annotations are queued and are unique across the two stores, so the
+    -- split that put these in different documents is undone by sorting on one field.
+    table.sort(entries, function(a, b)
+      return (a.id or 0) < (b.id or 0)
+    end)
+    return { at = owned.at, target = owned.target, snapshot = owned.snapshot, entries = entries }
+  end
+
+  if not owned or (loose and loose.at > owned.at) then
+    return loose
+  end
+  return owned
+end
+
+--- Rendering the batch as rows -------------------------------------------------
+
+---Extmarks belonging to this float, in a namespace of its own so clearing them cannot
+---disturb the queue float's, the diff's or the tree's.
+local NS = vim.api.nvim_create_namespace("codereview_archive")
+
+---One column to the left of every bar, reserved exactly as the queue float reserves it.
+---The two surfaces list the same shape of thing and should read as one family; a gutter
+---here and none there would be a dialect, not a distinction.
+local GUTTER = " "
+
+---Where an archived entry was, and the tag that rides on the right of its first row.
+---
+---**Staleness is deliberately absent**, where the queue float prints it. A queued entry's
+---`⚠ stale` says its line numbers may have moved since it was captured, which is worth
+---acting on before it goes. The same flag on an entry that has already gone is a fact about
+---a queue that no longer exists, and printing it here would read as a claim about the code
+---now. Whether an archived entry's file has moved since its batch went is a different
+---question, with a word of its own, and not this surface's to answer.
+---@param entry CRAnnotation
+---@return string where, string|nil tag
+local function locate(entry)
+  -- A bare note is about no file, so there is no location to print; every branch below
+  -- reads a path this one does not have.
+  if entry.kind == "note" then
+    return "(no file)", nil
+  end
+  -- Captured outside a checkout there is no repository-relative path, and the absolute one
+  -- is the only name the file has.
+  local where = entry.path or entry.abs_path
+  if entry.kind == "file" then
+    return where, entry.tag or "whole file"
+  end
+  local range = entry.first == entry.last and tostring(entry.first) or ("%d-%d"):format(entry.first, entry.last)
+  return ("%s:%s"):format(where, range), entry.tag
+end
+
+---Turn an archived batch's entries into the float's rows.
+---
+---The queue float's shape, minus the machinery it grew for acting on an entry. An entry is
+---a run of rows carrying a bar in its annotation type's group -- its location, the code it
+---inlined, and every line of its note -- and the blank row *between* two entries carries
+---none, so a boundary holds whatever a note contains. What is not here is the row-to-entry
+---map: that exists so `x` can resolve the cursor exactly, and nothing here acts on an entry.
+---
+---Its highlight columns are byte offsets, not display columns: the bar glyph is multibyte,
+---and so is anything a host configures in its place.
+---@param entries CRAnnotation[]
+---@param opts { types: CRType[], bar: string, width: integer }
+---@return { lines: string[], marks: table[] }
+local function build(entries, opts)
+  local lines, marks = {}, {}
+  local bar = opts.bar
+  local bar_col, bar_end = #GUTTER, #GUTTER + #bar
+  -- Padded to the widest number in the batch, so entry 10 does not shift the column every
+  -- row below it is drawn in.
+  local digits = #tostring(#entries)
+  local indent = GUTTER .. bar .. (" "):rep(digits + 2)
+  local body = math.max(8, opts.width - vim.fn.strdisplaywidth(indent))
+
+  ---@param row integer 1-indexed
+  ---@param col integer 0-indexed byte
+  local function mark(row, col, o)
+    marks[#marks + 1] = { row = row - 1, col = col, opts = o }
+  end
+
+  ---A row carrying an entry's bar and nothing else by default.
+  ---@return integer row
+  local function bar_row(group, text)
+    lines[#lines + 1] = text
+    mark(#lines, bar_col, { end_col = bar_end, hl_group = group })
+    return #lines
+  end
+
+  local index = 0
+  -- The same helper the payload rendered this batch through when it went, and the same one
+  -- the queue float lists what is still to send through. A third implementation would be a
+  -- third thing that agrees today; the two that existed before this one already drifted.
+  for gi, group in ipairs(types.group(entries, opts.types)) do
+    if gi > 1 then
+      lines[#lines + 1] = ""
+    end
+    local label = ("## %s"):format(group.type.label)
+    local heading = label
+    if group.type.directive and group.type.directive ~= "" then
+      heading = heading .. (" — %s"):format(group.type.directive)
+    end
+    lines[#lines + 1] = heading
+    mark(#lines, 0, { end_col = #label, hl_group = "CodeReviewTitle" })
+    if #heading > #label then
+      mark(#lines, #label, { end_col = #heading, hl_group = "CodeReviewNote" })
+    end
+
+    -- A configured type always carries one; `types.UNTYPED` is not a configured type and
+    -- has none, and falls back to what the diff draws an unresolvable type's note in.
+    local bar_hl = group.type.hl or "CodeReviewNote"
+
+    for ei, entry in ipairs(group.items) do
+      index = index + 1
+      -- Between entries and nowhere else: this row belongs to neither of them, which is
+      -- exactly what makes the boundary visible.
+      if ei > 1 then
+        lines[#lines + 1] = ""
+      end
+
+      local where, tag = locate(entry)
+      local room = body - (tag and vim.fn.strdisplaywidth(tag) + 2 or 0)
+      where = render.truncate(where, math.max(8, room))
+      local head = GUTTER .. bar .. ("%" .. digits .. "d"):format(index) .. "  " .. where
+      if tag then
+        head = head .. (" "):rep(math.max(1, room - vim.fn.strdisplaywidth(where) + 2)) .. tag
+      end
+
+      local row = bar_row(bar_hl, head)
+      mark(row, bar_end, { end_col = bar_end + digits, hl_group = "CodeReviewQueueIndex" })
+      mark(row, #indent, { end_col = #indent + #where, hl_group = "CodeReviewFileHeader" })
+      if tag then
+        -- From the right: the pad before it is display width and the column an extmark
+        -- wants is bytes, so the only offset that can be counted on is the end.
+        mark(row, #head - #tag, { end_col = #head, hl_group = "CodeReviewQueueState" })
+      end
+
+      -- The code an entry carried travels inside its bar, exactly as it did in the payload.
+      -- `+`/`-` already say which side a line is, so they keep the diff's own colours.
+      if entry.inline and entry.lines then
+        for _, code in ipairs(entry.lines) do
+          local text = indent .. render.truncate(code, body)
+          local r = bar_row(bar_hl, text)
+          local sign = code:sub(1, 1)
+          if sign == "+" or sign == "-" then
+            mark(r, #indent, { end_col = #text, hl_group = sign == "+" and "CodeReviewAdd" or "CodeReviewDel" })
+          end
+        end
+      end
+
+      -- Kept as the reviewer wrote it and wrapped by display width, through the renderer's
+      -- own helper rather than a copy of it: splitting by byte passes every ASCII assertion
+      -- and corrupts the first CJK or emoji note.
+      for _, text in ipairs(render.wrap(entry.note, body)) do
+        -- A blank line inside a note is a bar and nothing after it, which is what keeps the
+        -- entry unbroken across one.
+        bar_row(bar_hl, text == "" and (GUTTER .. bar) or (indent .. text))
+      end
+    end
+  end
+
+  return { lines = lines, marks = marks }
+end
+
+--- The float -------------------------------------------------------------------
+
+---Say why a key that acts on the queue does nothing here.
+---
+---The keys that drop and submit are bound to this rather than left unbound, because a
+---reviewer arrives with the queue float's muscle memory and `x` on a `nomodifiable` buffer
+---answers `E21` -- which says the buffer cannot be changed, not why this one must not be.
+local function read_only()
+  info("This batch has already gone — annotate again to raise a point a second time")
+end
+
+---Read the last dispatched batch back.
+---
+---Keyed on the repository the queue itself is keyed on, which is the working directory's.
+---A review view is not consulted and does not have to be open: a batch has already gone,
+---so nothing about which window is current could change which one went last.
+function M.open()
+  local batch = M.last(state.ambient_root())
+  local entries = batch and batch.entries or {}
+  if #entries == 0 then
+    -- Said rather than opened onto nothing. An empty archive is an ordinary state -- every
+    -- repository is in it until the first submit -- and a float with no rows would leave a
+    -- reviewer wondering which of the two had gone wrong.
+    info("Nothing has been dispatched yet — there is no batch to read back")
+    return
+  end
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].bufhidden = "wipe"
+
+  local width = math.min(100, math.max(50, math.floor(vim.o.columns * 0.8)))
+  local height = math.min(28, math.max(10, math.floor(vim.o.lines * 0.7)))
+  local n = #entries
+  local cfg = config.get()
+  -- The label as delivery worded it at the moment of dispatch, stored rather than resolved
+  -- again: the target itself is a live destination this session may no longer have, and the
+  -- record is of where the batch went, not of where one would go now.
+  local name = batch.target or ""
+
+  local cfg_win = {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2 - 1),
+    col = math.floor((vim.o.columns - width) / 2),
+    style = "minimal",
+    border = "rounded",
+    -- What went and when, where the queue float carries what is still to go. Absolute
+    -- rather than "12 minutes ago": telling this morning's batch from yesterday's is the
+    -- whole reason the moment is recorded, and a stamp says it without rounding.
+    title = (" Last batch · %d annotation%s · %s "):format(
+      n,
+      n == 1 and "" or "s",
+      os.date("%Y-%m-%d %H:%M", batch.at)
+    ),
+    title_pos = "center",
+    -- Where it went, and the one thing this surface will not do, said before a key is
+    -- pressed rather than only in answer to one.
+    footer = (" → %s · read-only · q close "):format(#name > 24 and (name:sub(1, 23) .. "…") or name),
+    footer_pos = "center",
+  }
+
+  local win = vim.api.nvim_open_win(buf, true, cfg_win)
+  -- The rows wrap themselves, to a width they know, so a bar keeps running down the left of
+  -- every one of them. Letting the window wrap instead would fold a long line back to
+  -- column zero, where there is no bar and no gutter, and the entry would appear to end.
+  vim.wo[win].wrap = false
+
+  local painted = build(entries, {
+    types = cfg.types,
+    -- The change-bar vocabulary the diff and the queue float already speak, including when
+    -- a host has configured a glyph of its own.
+    bar = cfg.icons.change_bar,
+    width = vim.api.nvim_win_get_width(win),
+  })
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, painted.lines)
+  -- Not merely a consequence of a scratch buffer: this is the record of a batch that has
+  -- gone, and nothing typed into it could mean anything.
+  vim.bo[buf].modifiable = false
+  for _, m in ipairs(painted.marks) do
+    pcall(vim.api.nvim_buf_set_extmark, buf, NS, m.row, m.col, m.opts)
+  end
+
+  local function close()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+  end
+
+  vim.keymap.set("n", "x", read_only, { buffer = buf, desc = "An archived entry cannot be dropped" })
+  vim.keymap.set("n", "<C-s>", read_only, { buffer = buf, desc = "An archived batch cannot be resubmitted" })
+  vim.keymap.set("n", "q", close, { buffer = buf, desc = "Close" })
+  vim.keymap.set("n", "<Esc>", close, { buffer = buf, desc = "Close" })
+end
+
+return M

--- a/lua/codereview/archive.lua
+++ b/lua/codereview/archive.lua
@@ -38,13 +38,17 @@ end
 ---
 ---So: the newest record across the two, and the other store's newest with it when the two
 ---carry the same stamp and the same target, which is what one dispatch looks like on disk.
----Both stores are read through the accessors that already exist; nothing here reaches past
----them for a newest batch of its own.
+---
+---The repository's half comes through `state.last_batch`, which is also what the
+---`since-batch` scope resolves against -- one query, so the diff that scope draws and the
+---entries listed here can never describe two different dispatches. The other half is read
+---inline because it has exactly one reader: no scope resolves against a record with no
+---repository behind it, since a **snapshot** can only belong to the half that has one.
 ---@param root string|nil nil outside a repository, where only the store that needs none applies
 ---@return CRBatch|nil
 function M.last(root)
   -- Each store keeps its batches newest first, so the head of each is the only candidate.
-  local owned = state.archive(root)[1]
+  local owned = state.last_batch(root)
   local loose = state.global_archive()[1]
 
   if owned and loose and owned.at == loose.at and owned.target == loose.target then

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -138,7 +138,7 @@ M.SCOPES = { "branch", "staged", "unstaged", "worktree", "since-batch" }
 function M.cycle(root)
   local names = {}
   for _, name in ipairs(M.SCOPES) do
-    if name ~= "since-batch" or #require("codereview.state").archive(root) > 0 then
+    if name ~= "since-batch" or require("codereview.state").last_batch(root) then
       names[#names + 1] = name
     end
   end
@@ -171,8 +171,10 @@ function M.resolve_scope(spec, root)
     -- Resolved here rather than anywhere of its own, and to a *real ref*: the diff parser,
     -- the blob hashing and the whole-file fetch the highlighter needs all read content out
     -- of `before`, and none of them can read a marker. Which is why the archive keeps a
-    -- commit object -- read back here through the accessor every other consumer uses.
-    local batch = require("codereview.state").archive(root)[1]
+    -- commit object -- read back here through the one query that answers which batch went
+    -- last, shared with the surface that lists that batch's entries so the diff on screen
+    -- and the annotations beside it can never describe two different dispatches.
+    local batch = require("codereview.state").last_batch(root)
     if not batch then
       return nil, "nothing has been dispatched from this repository yet"
     end

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -29,9 +29,12 @@ local LINKS = {
   CodeReviewPanelSel = "CursorLine",
   CodeReviewPanelDir = "Directory",
 
-  -- The queue float's own chrome. The bar running down an entry is that annotation type's
-  -- group rather than one of these, so what is left is the number the entry is listed
-  -- under and the state that rides on the right of its first row.
+  -- The chrome of the floats that list entries as rows -- the queue float, and the archive
+  -- float that reads the last dispatched batch back. Named for the queue because that is
+  -- where they started, and shared rather than duplicated because the two surfaces list the
+  -- same shape of thing and a reviewer overriding one means both. The bar running down an
+  -- entry is that annotation type's group rather than one of these, so what is left is the
+  -- number the entry is listed under and the state that rides on the right of its first row.
   CodeReviewQueueIndex = "LineNr",
   CodeReviewQueueState = "Comment",
 

--- a/lua/codereview/init.lua
+++ b/lua/codereview/init.lua
@@ -33,6 +33,13 @@ function M.setup(opts)
     desc = "Copy the queued batch to the + register, without submitting it",
   })
 
+  -- Takes no arguments and needs no review open, for the reason the copy above does not:
+  -- the batch it reads back has already gone, so nothing about the current window could
+  -- change which one went last.
+  vim.api.nvim_create_user_command("CodeReviewLastBatch", M.last_batch, {
+    desc = "Read the last dispatched batch back: its annotations, where it went and when",
+  })
+
   vim.api.nvim_create_user_command("CodeReviewAnnotate", function(cmd)
     -- `cmd.range` counts the addresses given, not the lines covered. Reading line1/line2
     -- unconditionally would turn a bare `:CodeReviewAnnotate` into a one-line capture of
@@ -96,6 +103,15 @@ end
 ---is, so what is copied describes the open review when there is one.
 function M.copy()
   require("codereview.view").copy()
+end
+
+---Read the last dispatched batch back: its annotations, where it went and when.
+---
+---Read-only. An archived entry records something that happened, so nothing in it can be
+---dropped, edited or resubmitted -- re-raising a point means annotating again. Opens with
+---no review view, as the queue float does: a batch is not a window.
+function M.last_batch()
+  require("codereview.archive").open()
 end
 
 ---@return integer

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -277,6 +277,29 @@ function M.archive(root)
   return root and M.load(root).archive or {}
 end
 
+---The batch a repository dispatched last, or nil when it has never dispatched one.
+---
+---One query rather than a `[1]` at each caller, and here rather than on either caller
+---because both of them are already above this module. Two things ask it, and they ask it
+---about the same dispatch: the `since-batch` scope, which diffs the working tree against
+---that batch's **snapshot**, and the surface that lists that batch's **entries**. A
+---reviewer reads one beside the other, so a disagreement about which batch is newest would
+---put the response to one dispatch on screen with the annotations of another beside it,
+---and nothing would say so. Two copies of `[1]` are what that drift looks like before it
+---happens -- the same reason the payload renderer and the queue float group through one
+---helper rather than two that agreed at the time.
+---
+---The repository's record only, which is what makes it the right answer for a caller that
+---needs a snapshot: a snapshot can only ever belong to the half with a repository behind
+---it. A batch that also held a **bare note** is recorded in the store that needs no root as
+---well, and `archive.last` is what rejoins the two for a surface that has to list every
+---entry.
+---@param root string|nil
+---@return CRBatch|nil
+function M.last_batch(root)
+  return M.archive(root)[1]
+end
+
 ---The highest id any archived entry carries, across every archive given.
 ---
 ---Which is what the queue's counter has to resume past. See `queue.seed`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, and a document written before the archive existed |
+| `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, and the four things it refuses |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
@@ -163,6 +164,17 @@ so the out-of-core language path is still checked locally without ever failing C
   capture case compares the entry captured in `since-batch` against the one the *same line*
   produces in `worktree`, field for field bar the id: an entry that recorded which scope
   caught it would differ, and nothing weaker than a comparison would notice.
+- **The two halves of one dispatch are rejoined by a stamp with one-second resolution.** A
+  batch holding a bare note is written to both stores and matched back up by the `os.time()`
+  both were stamped from, so a spec that submits in a loop can leave one batch's loose
+  entries within reach of the next batch's stamp — and the surface then lists entries from
+  two dispatches as one. `archive_float_spec` clears *both* stores between blocks
+  (`state.clear` and `state.clear_global`) rather than trusting the clock to separate them.
+- **A rejoin test needs the loose entry queued first.** Concatenating one store after the
+  other happens to produce the right order whenever the repository entries were queued
+  first, so a fixture in that order passes with the ordering deleted. `archive_float_spec`
+  queues the bare note before the file annotation, gives both the *same* annotation type so
+  the grouping cannot hide the order, and guards that their ids really are in that order.
 - **A send adapter that raises takes the whole `describe` with it.** Plenary runs a
   describe body immediately, so an adapter that propagates its error aborts the block
   instead of failing one case — the `it`s below it never run. `delivery_spec` asserts on

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,6 +170,13 @@ so the out-of-core language path is still checked locally without ever failing C
   entries within reach of the next batch's stamp — and the surface then lists entries from
   two dispatches as one. `archive_float_spec` clears *both* stores between blocks
   (`state.clear` and `state.clear_global`) rather than trusting the clock to separate them.
+- **Neither the scope's spec nor the float's archives more than one batch.** `since-batch`
+  and the last-batch float both resolve "which batch went last", and with a single batch
+  archived the head and the tail of the archive are the same record — so an accessor that
+  returned the *oldest* leaves `since_batch_spec` and `diff_spec` entirely green. The case
+  that catches it is in `archive_float_spec`: two dispatches, a file edited between them so
+  the two snapshots are genuinely different shas, and the batch the scope resolved against
+  looked up *by its snapshot* rather than by taking the head a third time.
 - **A rejoin test needs the loose entry queued first.** Concatenating one store after the
   other happens to produce the right order whenever the repository entries were queued
   first, so a fixture in that order passes with the ordering deleted. `archive_float_spec`

--- a/tests/codereview/archive_float_spec.lua
+++ b/tests/codereview/archive_float_spec.lua
@@ -1,0 +1,603 @@
+-- The surface that reads the last dispatched batch back.
+--
+-- Not `archive_spec`, which owns the record itself: what reached the disk, what a restart
+-- finds, the bound and the id a new annotation takes. This owns the float over it -- which
+-- batch it decides went last, how it lists one, and the four things it must refuse.
+--
+-- One process on purpose, which is the opposite of `archive_spec`'s reason and not a
+-- contradiction of it: nothing here is a claim about persistence, and every batch below is
+-- written by a real dispatch and read back through the accessors, not out of memory.
+--
+-- Both stores are emptied between blocks. The two halves of one dispatch are rejoined by
+-- their shared stamp, and `os.time()` has one-second resolution, so a spec that submits in
+-- a loop can otherwise leave a previous batch's bare note in reach of the next one's stamp.
+-- Clearing is what keeps every case below a statement about the batch it dispatched.
+--
+-- Rows, window chrome and highlight *groups*, never colours.
+local h = require("tests.helpers")
+
+h.ui(100, 30)
+local fixture = h.cd_fixture("mkfixture")
+
+---What the send adapter was handed. An adapter that returns nothing dispatches, which is
+---the one condition that both empties the queue and records the batch.
+local sent = {}
+
+local codereview = require("codereview")
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "a note")
+  end,
+  pick_target = function(cb)
+    cb({ short = "agent", cwd = fixture })
+  end,
+  send = function(text, target)
+    sent[#sent + 1] = { text = text, target = target }
+  end,
+})
+
+local archive = require("codereview.archive")
+local config = require("codereview.config")
+local delivery = require("codereview.delivery")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+-- Resolved, because the archive is keyed on the root git answers with and git answers with
+-- symlinks resolved. On macOS the fixture lives under a `/var` symlink, so the unresolved
+-- form would read a document nothing ever wrote.
+local root = assert(vim.uv.fs_realpath(fixture))
+local main = vim.fs.joinpath(root, "src/main.lua")
+
+local NS = vim.api.nvim_create_namespace("codereview_archive")
+
+---The reserved gutter and the bar, as the float draws them. Multibyte on purpose: every
+---column an extmark is placed at below is a *byte* offset.
+local GUTTER = " "
+local BAR = config.get().icons.change_bar
+
+---Forget every batch, in both stores, so a block says only what it dispatched itself.
+local function fresh()
+  queue.clear()
+  state.clear(root)
+  state.clear_global()
+end
+
+---@param over table Fields to set on the entry
+---@return CRAnnotation
+local function queued(over)
+  return queue.add(vim.tbl_extend("force", {
+    type = "bug",
+    kind = "line",
+    path = "src/main.lua",
+    abs_path = main,
+    key = "src/main.lua:n:1",
+    first = 1,
+    last = 1,
+    note = "a note",
+  }, over))
+end
+
+---An annotation with no file behind it, which is what routes to the store needing no root.
+---Added by hand because `tbl_extend` cannot express "and no path", which is the whole point.
+---@param note string
+---@param type_name string|nil
+local function bare_note(note, type_name)
+  return queue.add({ type = type_name, kind = "note", key = "note:" .. note, note = note })
+end
+
+---Dispatch whatever is queued, without the notifications reaching the runner.
+local function dispatch()
+  local _, restore = h.capture_notify()
+  codereview.submit()
+  restore()
+end
+
+---@return integer win, integer buf
+local function open_float()
+  codereview.last_batch()
+  local win = vim.api.nvim_get_current_win()
+  return win, vim.api.nvim_win_get_buf(win)
+end
+
+---@param buf integer
+---@return string[]
+local function lines(buf)
+  return vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+end
+
+---A row of an entry's note, as either float draws it: the gutter, the bar, and an indent
+---as wide as the batch's numbering. Every batch below has fewer than ten entries, so that
+---column is one digit and the indent is three.
+---@param text string
+---@return string
+local function note_row(text)
+  return GUTTER .. BAR .. "   " .. text
+end
+
+---Every extmark starting on a row, as { col, end_col, hl }.
+---@param buf integer
+---@param row integer 1-indexed
+local function marks_on(buf, row)
+  local out = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, NS, { row - 1, 0 }, { row - 1, -1 }, { details = true })) do
+    out[#out + 1] = { col = m[3], end_col = m[4].end_col, hl = m[4].hl_group }
+  end
+  return out
+end
+
+---The group the bar on a row is drawn in, or nil when the row carries no bar.
+---
+---Identified by the byte span the bar occupies rather than by "the first mark", so a row
+---that merely happens to be highlighted somewhere cannot pass for one carrying a bar.
+---@param buf integer
+---@param row integer
+---@return string|nil
+local function bar_group(buf, row)
+  local text = lines(buf)[row]
+  if not text or text:sub(#GUTTER + 1, #GUTTER + #BAR) ~= BAR then
+    return nil
+  end
+  for _, m in ipairs(marks_on(buf, row)) do
+    if m.col == #GUTTER and m.end_col == #GUTTER + #BAR then
+      return m.hl
+    end
+  end
+end
+
+---@param buf integer
+---@param row integer
+---@param group string
+---@return { col: integer, end_col: integer, hl: string }|nil
+local function mark_of(buf, row, group)
+  for _, m in ipairs(marks_on(buf, row)) do
+    if m.hl == group then
+      return m
+    end
+  end
+end
+
+---Rows carrying an entry's bar, from the row its number is drawn on downwards.
+---@param buf integer
+---@param index integer
+---@return integer first, integer last
+local function extent(buf, index)
+  local first
+  for row, text in ipairs(lines(buf)) do
+    if text:match("^%s*" .. vim.pesc(BAR) .. "%s*" .. index .. "  ") then
+      first = row
+      break
+    end
+  end
+  assert(first, ("entry %d is not listed in the float"):format(index))
+  local last = first
+  while bar_group(buf, last + 1) do
+    last = last + 1
+  end
+  return first, last
+end
+
+---A window's title or footer, as one string.
+---@param win integer
+---@param field "title"|"footer"
+---@return string
+local function chrome(win, field)
+  local value = vim.api.nvim_win_get_config(win)[field]
+  return value and tostring(value[1][1]) or ""
+end
+
+--- Nothing dispatched yet -------------------------------------------------------
+
+describe("with an empty archive", function()
+  fresh()
+  local before = vim.api.nvim_get_current_win()
+  local msgs, restore = h.capture_notify()
+  codereview.last_batch()
+  restore()
+
+  it("says so rather than opening onto nothing", function()
+    assert.is_true(h.notified(msgs, "Nothing has been dispatched"), vim.inspect(msgs))
+  end)
+
+  it("opens no window at all", function()
+    assert.same(before, vim.api.nvim_get_current_win())
+  end)
+end)
+
+--- What the batch that went last is ---------------------------------------------
+
+describe("the batch a dispatch leaves behind", function()
+  fresh()
+  queued({ note = "the batch that went" })
+  queued({ type = "nitpick", note = "and this one with it" })
+  delivery.pick_target()
+  dispatch()
+
+  local win, buf = open_float()
+  local text = lines(buf)
+
+  it("was dispatched, so the queue is empty and the archive is not", function()
+    assert.same(0, queue.count())
+    assert.same(1, #state.archive(root))
+  end)
+
+  it("lists every entry of it, and only those", function()
+    assert.same(2, #state.archive(root)[1].entries)
+    assert.is_truthy(vim.tbl_contains(text, note_row("the batch that went")), table.concat(text, "\n"))
+    assert.is_truthy(vim.tbl_contains(text, note_row("and this one with it")), table.concat(text, "\n"))
+  end)
+
+  it("groups them by annotation type, through the grouping the payload shares", function()
+    assert.same("## Bugs — diagnose and fix these", text[1])
+    assert.is_truthy(
+      vim.tbl_contains(text, "## Nitpicks — low priority — batch these together"),
+      table.concat(text, "\n")
+    )
+  end)
+
+  it("draws each entry's bar in its own type's group", function()
+    assert.same("CodeReviewBug", bar_group(buf, extent(buf, 1)))
+    assert.same("CodeReviewNitpick", bar_group(buf, extent(buf, 2)))
+  end)
+
+  it("carries that bar on every row an entry owns, over a reserved gutter", function()
+    local first, last = extent(buf, 1)
+    for row = first, last do
+      assert.same("CodeReviewBug", bar_group(buf, row), ("row %d: %q"):format(row, text[row]))
+      assert.same(GUTTER, text[row]:sub(1, #GUTTER), ("row %d: %q"):format(row, text[row]))
+    end
+  end)
+
+  it("names the target the batch went to", function()
+    assert.same("agent", state.archive(root)[1].target)
+    assert.is_truthy(chrome(win, "footer"):find("agent", 1, true), chrome(win, "footer"))
+  end)
+
+  it("says when it was dispatched", function()
+    local at = state.archive(root)[1].at
+    assert.is_truthy(chrome(win, "title"):find(os.date("%Y-%m-%d %H:%M", at), 1, true), chrome(win, "title"))
+  end)
+
+  it("counts what it is listing", function()
+    assert.is_truthy(chrome(win, "title"):find("2 annotations", 1, true), chrome(win, "title"))
+  end)
+
+  it("says it is read-only before a key is pressed", function()
+    assert.is_truthy(chrome(win, "footer"):find("read-only", 1, true), chrome(win, "footer"))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- The location an entry carries ------------------------------------------------
+
+describe("how an entry says where it was", function()
+  fresh()
+  queued({ first = 20, last = 21, note = "a range", inline = true, lines = { "-was", "+is" } })
+  queued({ kind = "file", key = "src/routes.lua:f:0", path = "src/routes.lua", note = "a whole file" })
+  queued({ first = 14, last = 14, tag = "deleted", path = "src/routes.lua", key = "o:14", note = "a deleted line" })
+  dispatch()
+
+  local win, buf = open_float()
+  local text = lines(buf)
+
+  it("prints a range as the file and the lines it covered", function()
+    assert.is_truthy(text[extent(buf, 1)]:find("src/main.lua:20-21", 1, true), text[extent(buf, 1)])
+  end)
+
+  it("tags a whole-file entry as one", function()
+    local row = extent(buf, 2)
+    local tag = assert(mark_of(buf, row, "CodeReviewQueueState"), text[row])
+    assert.same("whole file", text[row]:sub(tag.col + 1, tag.end_col))
+  end)
+
+  it("keeps the tag an entry carried", function()
+    local row = extent(buf, 3)
+    local tag = assert(mark_of(buf, row, "CodeReviewQueueState"), text[row])
+    assert.same("deleted", text[row]:sub(tag.col + 1, tag.end_col))
+  end)
+
+  it("draws the code it inlined inside the same bar, in the diff's own colours", function()
+    local first, last = extent(buf, 1)
+    local rows = {}
+    for row = first, last do
+      if text[row]:find("was", 1, true) or text[row]:find("is", 1, true) then
+        rows[#rows + 1] = row
+      end
+    end
+    assert.same(2, #rows, table.concat(text, "\n"))
+    assert.is_truthy(mark_of(buf, rows[1], "CodeReviewDel"), text[rows[1]])
+    assert.is_truthy(mark_of(buf, rows[2], "CodeReviewAdd"), text[rows[2]])
+  end)
+
+  -- The queue float prints `⚠ stale` beside an entry whose file moved since capture. That
+  -- is worth acting on before a batch goes; on one that has already gone it would read as a
+  -- claim about the code now, which this surface has no way to make.
+  it("says nothing about staleness, which is a fact about a queue that no longer exists", function()
+    for row = 1, #text do
+      assert.is_nil(mark_of(buf, row, "CodeReviewStale"), ("row %d: %q"):format(row, text[row]))
+    end
+    assert.is_nil(table.concat(text, "\n"):find("stale", 1, true))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- A batch split across the two stores ------------------------------------------
+
+-- The case a single accessor cannot answer. A dispatch is recorded in two documents, split
+-- on the rule that already routes the queue, and a batch that held both is missing exactly
+-- the entries with nowhere else to be listed when only one of them is read -- so a bare note
+-- becomes the one thing that vanishes from what a reviewer reads back.
+describe("a batch holding a bare note as well as a file", function()
+  fresh()
+  -- The bare note first and of the *same* annotation type as the file entry, both on
+  -- purpose. The two go to different documents, so a rejoin that merely put one store after
+  -- the other would list them the wrong way round -- and a different type would hide that
+  -- behind the grouping instead of showing it.
+  local first = bare_note("first, and it has no file behind it", "bug")
+  local second = queued({ note = "second, and it does" })
+  bare_note("a third, carrying no type at all")
+  dispatch()
+
+  local win, buf = open_float()
+  local text = lines(buf)
+
+  it("is a batch the two stores really did split", function()
+    assert.same(1, #state.archive(root), vim.inspect(state.archive(root)))
+    assert.same(1, #state.archive(root)[1].entries)
+    assert.same(2, #state.global_archive()[1].entries)
+  end)
+
+  it("lists the bare notes like anything else", function()
+    assert.is_truthy(vim.tbl_contains(text, note_row("first, and it has no file behind it")), table.concat(text, "\n"))
+    assert.is_truthy(vim.tbl_contains(text, note_row("a third, carrying no type at all")), table.concat(text, "\n"))
+  end)
+
+  it("says a bare note is about no file, rather than printing a path it has not got", function()
+    assert.is_truthy(text[extent(buf, 1)]:find("(no file)", 1, true), text[extent(buf, 1)])
+  end)
+
+  it("counts the whole batch, not the half one store holds", function()
+    assert.is_truthy(chrome(win, "title"):find("3 annotations", 1, true), chrome(win, "title"))
+  end)
+
+  -- Otherwise the case below is vacuous: two entries the queue numbered the same way round
+  -- as the stores hold them would list identically either way.
+  it("queued the loose entry before the owned one", function()
+    assert.is_true(first.id < second.id, ("%d is not below %d"):format(first.id, second.id))
+  end)
+
+  it("puts the two halves back in the order they were queued in", function()
+    assert.is_truthy(text[extent(buf, 2)]:find("src/main.lua", 1, true), text[extent(buf, 2)])
+  end)
+
+  it("groups them by type, untyped last, exactly as anything else is grouped", function()
+    assert.same("## Bugs — diagnose and fix these", text[1])
+    assert.is_truthy(vim.tbl_contains(text, "## Untyped"), table.concat(text, "\n"))
+    assert.same("CodeReviewBug", bar_group(buf, extent(buf, 1)))
+    assert.same("CodeReviewNote", bar_group(buf, extent(buf, 3)))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- Which batch is the last one --------------------------------------------------
+
+describe("with more than one batch archived", function()
+  fresh()
+  queued({ note = "the older batch" })
+  dispatch()
+  queued({ note = "the newer batch" })
+  dispatch()
+
+  local win, buf = open_float()
+  local text = lines(buf)
+
+  it("has two to choose between", function()
+    assert.same(2, #state.archive(root))
+  end)
+
+  it("lists the newest, and only it", function()
+    assert.is_truthy(vim.tbl_contains(text, note_row("the newer batch")), table.concat(text, "\n"))
+    assert.is_false(vim.tbl_contains(text, note_row("the older batch")), table.concat(text, "\n"))
+  end)
+
+  it("counts one annotation, not both batches'", function()
+    assert.is_truthy(chrome(win, "title"):find("1 annotation ", 1, true), chrome(win, "title"))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- Read-only --------------------------------------------------------------------
+
+describe("what the float refuses to do", function()
+  fresh()
+  queued({ note = "already gone" })
+  dispatch()
+  -- Queued after the dispatch, so the queue holding something is what "left exactly as it
+  -- was" is asserted against -- an empty queue is satisfied by a surface that emptied it.
+  queued({ note = "still to send" })
+  queued({ type = "nitpick", note = "and this" })
+  local before_queue = vim.deepcopy(queue.all())
+  local before_archive = vim.deepcopy(state.archive(root))
+  local listed = #sent
+
+  local win, buf = open_float()
+
+  it("lists the batch that went, not the queue that has not", function()
+    local text = lines(buf)
+    assert.is_truthy(vim.tbl_contains(text, note_row("already gone")), table.concat(text, "\n"))
+    assert.is_false(vim.tbl_contains(text, note_row("still to send")), table.concat(text, "\n"))
+  end)
+
+  it("holds a buffer nothing can be typed into", function()
+    assert.is_false(vim.bo[buf].modifiable)
+  end)
+
+  -- The notification is asserted as well as the record, and it is what stops these two
+  -- passing on a key that is merely unbound: `x` against a `nomodifiable` buffer changes
+  -- nothing either, and would leave every assertion below it green while saying `E21`.
+  it("drops nothing on the key that drops from the queue float", function()
+    local msgs, restore = h.capture_notify()
+    h.feed("x")
+    restore()
+    assert.same(before_archive, state.archive(root))
+    assert.same(before_queue, queue.all())
+    assert.is_true(h.notified(msgs, "annotate again"), vim.inspect(msgs))
+  end)
+
+  it("resubmits nothing on the key that submits from the queue float", function()
+    local msgs, restore = h.capture_notify()
+    h.feed("<C-s>")
+    restore()
+    assert.same(listed, #sent)
+    assert.same(before_archive, state.archive(root))
+    assert.is_true(h.notified(msgs, "annotate again"), vim.inspect(msgs))
+  end)
+
+  it("is still open, having done neither", function()
+    assert.is_true(vim.api.nvim_win_is_valid(win))
+  end)
+
+  it("leaves the queue exactly as it was when it closes", function()
+    h.feed("q")
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+    assert.same(before_queue, queue.all())
+  end)
+end)
+
+--- What it leaves alone ----------------------------------------------------------
+
+describe("the queue float beside it", function()
+  fresh()
+  queued({ note = "already gone" })
+  dispatch()
+  queued({ note = "still to send" })
+
+  local win = select(1, open_float())
+  h.feed("q")
+
+  it("still lists what is left to send, and not what went", function()
+    view.review_queue()
+    local qwin = vim.api.nvim_get_current_win()
+    local text = lines(vim.api.nvim_win_get_buf(qwin))
+    assert.is_truthy(vim.tbl_contains(text, note_row("still to send")), table.concat(text, "\n"))
+    assert.is_false(vim.tbl_contains(text, note_row("already gone")), table.concat(text, "\n"))
+    vim.api.nvim_win_close(qwin, true)
+  end)
+
+  it("opened with no review view, and left none behind", function()
+    assert.is_false(codereview.is_open())
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+end)
+
+-- A batch is not a window: it can be read back from anywhere, including from inside a
+-- review, and reading it must leave that review exactly where it was.
+describe("opened with a review view on screen", function()
+  fresh()
+  queued({ note = "already gone" })
+  dispatch()
+
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local diff_win = review.win
+  local rows = #vim.api.nvim_buf_get_lines(review.buf, 0, -1, false)
+
+  local win = select(1, open_float())
+
+  it("opens over it rather than instead of it", function()
+    assert.is_true(vim.api.nvim_win_is_valid(diff_win))
+    assert.are_not.same(diff_win, win)
+  end)
+
+  it("leaves the diff behind it untouched", function()
+    h.feed("q")
+    assert.same(review, view.current())
+    assert.same(rows, #vim.api.nvim_buf_get_lines(review.buf, 0, -1, false))
+  end)
+
+  codereview.close()
+end)
+
+--- Wrapping ----------------------------------------------------------------------
+
+describe("a note wider than the float", function()
+  fresh()
+  -- No spaces, so the wrap has nowhere to break but mid-word -- which is where cutting by
+  -- byte or by character count goes wrong. Each of these occupies two display columns.
+  local cjk = ("字"):rep(120)
+  queued({ note = cjk })
+  dispatch()
+
+  local win, buf = open_float()
+  local width = vim.api.nvim_win_get_width(win)
+  local text = lines(buf)
+  local first, last = extent(buf, 1)
+  local body = {}
+  for row = first + 1, last do
+    body[#body + 1] = text[row]:sub(#GUTTER + #BAR + 1):gsub("^%s+", "")
+  end
+
+  it("wrapped it over several rows", function()
+    assert.is_true(#body > 1, table.concat(body, "\n"))
+  end)
+
+  it("keeps every row inside the float", function()
+    for row = 1, #text do
+      assert.is_true(
+        vim.fn.strdisplaywidth(text[row]) <= width,
+        ("row %d is %d columns wide in a %d-column float"):format(row, vim.fn.strdisplaywidth(text[row]), width)
+      )
+    end
+  end)
+
+  -- The assertion that fails when the wrap counts characters rather than columns: each of
+  -- these is two columns, so a row holding as many characters as it has columns to spend is
+  -- twice as wide as the float.
+  it("wrapped by display width rather than by character count", function()
+    for _, row in ipairs(body) do
+      assert.is_true(vim.fn.strdisplaywidth(row) > vim.fn.strchars(row), row)
+    end
+  end)
+
+  it("breaks between characters, not inside one", function()
+    assert.same(cjk, table.concat(body))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- Which batch `last` picks ------------------------------------------------------
+
+-- The rule underneath the float, asserted where the two stores can be arranged by hand
+-- rather than only through whichever dispatch a fixture happens to produce.
+describe("choosing between the two stores", function()
+  it("takes the newest of the pair when only one of them holds anything", function()
+    fresh()
+    bare_note("nothing but a thought")
+    dispatch()
+    local batch = assert(archive.last(root))
+    assert.same(1, #batch.entries)
+    assert.same("nothing but a thought", batch.entries[1].note)
+  end)
+
+  it("answers with nothing at all when neither holds anything", function()
+    fresh()
+    assert.is_nil(archive.last(root))
+  end)
+
+  -- Outside a repository there is no document to key against, so the store that needs no
+  -- root is the only one there is -- and a bare note dispatched from anywhere is still the
+  -- last batch, exactly as it is still part of the one queue.
+  it("reads the store that needs no root with no repository behind it", function()
+    fresh()
+    bare_note("dispatched from nowhere in particular")
+    dispatch()
+    local batch = assert(archive.last(nil))
+    assert.same("dispatched from nowhere in particular", batch.entries[1].note)
+  end)
+end)

--- a/tests/codereview/archive_float_spec.lua
+++ b/tests/codereview/archive_float_spec.lua
@@ -40,6 +40,7 @@ codereview.setup({
 local archive = require("codereview.archive")
 local config = require("codereview.config")
 local delivery = require("codereview.delivery")
+local git = require("codereview.git")
 local queue = require("codereview.queue")
 local state = require("codereview.state")
 local view = require("codereview.view")
@@ -600,4 +601,75 @@ describe("choosing between the two stores", function()
     local batch = assert(archive.last(nil))
     assert.same("dispatched from nowhere in particular", batch.entries[1].note)
   end)
+end)
+
+--- Where the scope and this float meet -------------------------------------------
+
+-- The case neither slice could have written, and the reason it is here.
+--
+-- `since-batch` diffs the working tree against the newest archived batch's **snapshot**;
+-- this float lists the newest archived batch's **entries**. A reviewer reads one beside the
+-- other -- that is the whole point of keeping a batch -- so if the two ever disagreed about
+-- which batch is newest, the diff on screen would be the response to one dispatch and the
+-- annotations beside it would belong to another, and nothing anywhere would say so.
+--
+-- Each side was green against a base that did not have the other, and each independently
+-- reached for the head of the archive. They now go through `state.last_batch`, and this is
+-- what makes that one query rather than two that happen to agree.
+--
+-- Two dispatches, because with one batch archived both answers are forced and agreeing
+-- costs nothing.
+describe("the scope and the float, on which batch is newest", function()
+  fresh()
+  queued({ note = "the older batch" })
+  dispatch()
+
+  -- Edited between the two dispatches, standing in for the agent's response. Without it both
+  -- `git stash create` calls mint a commit from the same tree in the same second and return
+  -- the *same* sha, so "the scope diffs against the newest batch's snapshot" is satisfied by
+  -- either batch and the case measures nothing.
+  local touched = vim.fs.joinpath(root, "src/main.lua")
+  vim.fn.writefile(vim.list_extend(vim.fn.readfile(touched), { "-- between the two batches" }), touched)
+
+  queued({ note = "the newer batch" })
+  dispatch()
+
+  local archived = state.archive(root)
+  local scope = assert(git.resolve_scope("since-batch", root))
+
+  ---The batch the scope actually resolved against, found by the snapshot it is diffing from
+  ---rather than by taking the head of the archive a third time -- which is the assumption
+  ---under test and cannot also be the way the test looks it up.
+  local diffed
+  for _, batch in ipairs(archived) do
+    if batch.snapshot == scope.before then
+      diffed = batch
+    end
+  end
+
+  local win, buf = open_float()
+  local text = lines(buf)
+
+  it("archived two batches with different snapshots, so agreeing is a choice", function()
+    assert.same(2, #archived)
+    assert.are_not.same(archived[1].snapshot, archived[2].snapshot)
+  end)
+
+  it("resolves the scope against one of them", function()
+    assert.is_truthy(diffed, ("%s is no archived batch's snapshot"):format(tostring(scope.before)))
+  end)
+
+  it("lists the entries of the very batch the scope is diffing against", function()
+    for _, entry in ipairs(diffed.entries) do
+      assert.is_truthy(vim.tbl_contains(text, note_row(entry.note)), table.concat(text, "\n"))
+    end
+    assert.is_false(vim.tbl_contains(text, note_row("the older batch")), table.concat(text, "\n"))
+  end)
+
+  it("counts what that batch held, and nothing from the other", function()
+    local n = #diffed.entries
+    assert.is_truthy(chrome(win, "title"):find(("%d annotation"):format(n), 1, true), chrome(win, "title"))
+  end)
+
+  vim.api.nvim_win_close(win, true)
 end)


### PR DESCRIPTION
A submit clears the queue, which is the moment *what did I actually ask for?* stops having
an answer anywhere but the agent's transcript. `:CodeReviewLastBatch` gives it one: the
annotations of the newest archived batch, the **target** it went to, and when it went.

Rebased onto `master` after #72 and #78 landed.

## What it does

- Lists the entries of the newest archived batch, grouped by **annotation type** through
  `types.group` — the same grouping the **payload** and the queue float already share.
- Names the target in the footer and the moment of **dispatch** in the title.
- Opens with no **review view**, as the queue float does: a batch is not a window.
- Reports an empty archive rather than opening onto nothing.
- Lists a **bare note** like anything else.

## Where it lives

A module of its own, `lua/codereview/archive.lua`, with a row in the module map. Outside it:
the command registration in `init.lua`, one comment in `hl.lua` saying the two floats share
its chrome groups, and the shared accessor below.

## Read-only

An archived entry records something that happened. A surface that let you drop, edit or
resubmit one would claim the plugin can revise what an agent already received, so nothing in
it does. Re-raising a point means annotating again, which is an ordinary capture.

`x` and `<C-s>` *are* bound — to a sentence saying why they do nothing. A reviewer arrives
with the queue float's muscle memory, and `E21` against a `nomodifiable` buffer answers a
different question than the one being asked.

## One query for which batch went last

#72's `since-batch` scope diffs the working tree against the newest batch's **snapshot**;
this float lists the newest batch's **entries**. Both had independently reached for the head
of the archive. A reviewer reads one beside the other, so a disagreement would put the
response to one dispatch on screen with the annotations of another beside it, and nothing
would say so.

Both now go through `state.last_batch(root)`, beside `state.archive` — on `state` rather than
on either caller because `git` already requires `state` and does not require `archive`, so
routing it through the surface would turn the two-module cycle into a three-module one. The
`git` ↔ `state` cycle is left exactly as #72 recorded it.

`archive.last` still rejoins the two stores on top of that query, because a batch that also
held a bare note is two records and a snapshot can only ever belong to the half with a
repository behind it.

## Mutation evidence

Three mutations, run on the rebased tree:

| Mutation | `archive_float_spec` | `since_batch_spec` | `diff_spec` |
| --- | --- | --- | --- |
| `last_batch` returns the **oldest** batch | **2 red** | green (26) | green (45) |
| `last_batch` returns **nil** | **25 red, 5 errors** | hangs | — |
| oldest, **and** `resolve_scope` re-inlined to `archive(root)[1]` | **2 red** | green | green |

The finding worth stating: **the scope's own specs stay green under a head/tail mutation**,
because `since_batch_spec` and `diff_spec` each archive exactly one batch — head and tail are
the same record, so the mutation is invisible to them. The coverage for "which batch" lives
entirely in the new join case, which is the point of it. Under the third mutation, where the
two consumers genuinely disagree, it fails on the cross-check: the entry the scope is diffing
against is missing from the float's rows.

Both facts are recorded in `design-notes.md` and `tests/README.md`.

## Verification

`make all` green, exit 0: **29 specs / 1058 cases**, 0 failures, 0 errors — trunk's 1011
plus 47.

`make perf` at 300 files: `cursor move 0.0 ms`, `repaint` within trunk's own spread. Measured
against a worktree of `ee87d70`, interleaved three times on the same machine: trunk 107 / 112
/ 103 ms, this branch 105 / 114 / 124 ms. This machine does not reproduce the 96 ms figure on
*either* side, so the gap is load, not this change — nothing here touches the paint path, and
`archive.lua` is never loaded during a review.

Closes #74