### PR TITLE
perf(view): a repaint paints the viewport, not the whole document

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -115,6 +115,32 @@ It is also why `syntax_spec` asserts the map against the render on screen, and a
 the marks still cover their own tokens after a repaint that moved rows, rather than merely
 asserting that a map exists.
 
+**Extmark emission is bounded by the viewport, and the render is not.** A 300-file review
+produces 271,000 marks, and writing all of them into a buffer is 141 ms of a 384 ms
+repaint — paid on every resize, expansion, reviewed toggle, scope change and queued
+annotation, which are the operations that have to feel immediate. Only the rows near the
+window are emitted; the rest arrive when a reviewer scrolls to them, through the
+autocommand that already tops up highlighting. `render.build` still returns the complete
+`marks` array for both panes: that is the seam that makes this cheap, because the split,
+the spans and the anchor totality are all asserted against returned data rather than
+against a buffer, and bounding what is *written* leaves every one of those assertions
+valid. It is also why `bounded_spec` has a case asserting the render still produces the
+marks the buffer never receives — "bounded" must never be satisfiable by the render having
+stopped producing them.
+
+**The bound is the harvest's own, and rows are tracked in bands.** One margin decides how
+far past the window both the emission and the parse reach; two figures would drift, and a
+harvest reaching further than the emission is highlighting on a row with no diff background
+under it, so `syntax.viewport` is what the view asks rather than arithmetic of its own.
+What has been emitted is remembered in bands of that same margin, quantised so the record
+stays a handful of lookups rather than a set the size of the review, and so a band is
+either wholly emitted or wholly not — which is what lets both panes share one record and
+stay comparable row for row. The record is dropped where the namespace is cleared, exactly
+as `syntax_painted` is: what a band means is decided by the render it was emitted from.
+Marks are *found* rather than filtered — `render.build` appends each as it draws the row it
+belongs to, so a pane's marks are in row order and a band is a slice of them; filtering
+would be a walk of the whole review on every scroll, which is the cost this removes.
+
 **Intra-line spans are computed when the diff is parsed, never when it is drawn.** On a
 12,000-line diff they cost about as much again as a whole repaint. Paid once per git read
 that lengthens opening by roughly a third; paid per repaint it would be a ~50% regression on

--- a/lua/codereview/syntax.lua
+++ b/lua/codereview/syntax.lua
@@ -181,15 +181,24 @@ local function apply_side(view, ns, buf, file, side, map, ref, lang)
   end
 end
 
--- Rows of slack above and below the window. Generous enough that ordinary scrolling
--- never waits on a parse, small enough that opening a 60-file review parses two files
--- instead of sixty.
-local VIEWPORT_MARGIN = 120
+---Rows of slack above and below the window. Generous enough that ordinary scrolling never
+---waits on a parse, small enough that opening a 60-file review parses two files instead of
+---sixty.
+---
+---Exported because the diff's own extmarks are bounded by this same figure, and a second
+---one would drift: the two bounds decide together what a row on screen ends up carrying,
+---so a harvest reaching further than the emission is highlighting on a row with no diff
+---background under it.
+M.VIEWPORT_MARGIN = 120
 
----Rows currently worth highlighting.
+---Rows currently worth painting: the window's own, plus the margin above and below.
+---
+---Exported for the same reason the margin is, and preferred to it: the view bounds its own
+---emission against this, so the two answers agree by construction rather than by two call
+---sites doing the same arithmetic.
 ---@param view CRView
 ---@return integer lo, integer hi
-local function viewport(view)
+function M.viewport(view)
   if not vim.api.nvim_win_is_valid(view.win) then
     return 1, #view.render.lines
   end
@@ -201,7 +210,7 @@ local function viewport(view)
   if not ok or type(span) ~= "table" or not span[1] or not span[2] then
     return 1, #view.render.lines
   end
-  return math.max(1, span[1] - VIEWPORT_MARGIN), math.min(#view.render.lines, span[2] + VIEWPORT_MARGIN)
+  return math.max(1, span[1] - M.VIEWPORT_MARGIN), math.min(#view.render.lines, span[2] + M.VIEWPORT_MARGIN)
 end
 
 ---@alias CRFileRows { before: table<integer, { row: integer, col: integer }>, after: table<integer, { row: integer, col: integer }>, first: integer, last: integer }
@@ -278,7 +287,7 @@ function M.apply(view, ns)
   -- and the first pass after one pays for it.
   view.syntax_rows = view.syntax_rows or invert(view)
 
-  local lo, hi = viewport(view)
+  local lo, hi = M.viewport(view)
   local split = view.before_render ~= nil
 
   for fi, maps in pairs(view.syntax_rows) do

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -40,6 +40,7 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@field render CRRender|nil             The after pane's render
 ---@field before_render CRRender|nil      nil in the unified layout
 ---@field panel_render CRPanelRender|nil
+---@field painted_bands table<integer, boolean>|nil  Row bands whose marks have been emitted
 
 ---@type CRView|nil
 local V = nil
@@ -301,19 +302,92 @@ local function update_before_winbar()
   vim.wo[V.before_win].winbar = bar:gsub("%%", "%%%%")
 end
 
----Write one pane's render into its buffer.
+---Write one pane's render into its buffer: the lines, and nothing else.
+---
+---Which of the render's marks reach the buffer is `paint_bands`' decision, taken against
+---the window rather than against the diff. The namespace is cleared here, so this is also
+---where everything a previous paint emitted stops existing.
 ---@param buf integer
 ---@param rendered CRRender
 local function write_pane(buf, rendered)
   vim.bo[buf].modifiable = true
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, rendered.lines)
   vim.bo[buf].modifiable = false
-
   vim.api.nvim_buf_clear_namespace(buf, NS, 0, -1)
-  for _, m in ipairs(rendered.marks) do
+end
+
+---First index in `marks` whose row is at or after `row`.
+---
+---`render.build` appends each mark as it draws the row it belongs to, so a pane's marks are
+---in non-decreasing row order and a run of rows is a slice of that array. Found rather than
+---filtered, because a filter is a walk of the whole review -- the cost this bounding exists
+---to remove, and one that would then be paid again on every scroll into new rows.
+---`bounded_spec` pins the ordering this relies on, for both panes.
+---@param marks table[]
+---@param row integer 0-indexed, as an extmark's row is
+---@return integer
+local function lower_bound(marks, row)
+  local lo, hi = 1, #marks + 1
+  while lo < hi do
+    local mid = math.floor((lo + hi) / 2)
+    if marks[mid].row < row then
+      lo = mid + 1
+    else
+      hi = mid
+    end
+  end
+  return lo
+end
+
+---Emit every mark one pane's render put on rows `first`..`last`, 1-indexed and inclusive.
+---@param buf integer
+---@param rendered CRRender
+---@param first integer
+---@param last integer
+local function emit_rows(buf, rendered, first, last)
+  local marks = rendered.marks
+  for i = lower_bound(marks, first - 1), #marks do
+    local m = marks[i]
+    if m.row > last - 1 then
+      return
+    end
     -- An end_col past the end of a line is a hard error; a mis-measured header should
     -- lose its colour, not abort the whole repaint.
     pcall(vim.api.nvim_buf_set_extmark, buf, NS, m.row, m.col, m.opts)
+  end
+end
+
+---Emit the marks for the rows near the window, in every pane there is.
+---
+---Bounded by the viewport, not by the diff, for the reason the harvest already is and
+---against the same bounds: a 300-file review renders 271,000 marks, and writing all of them
+---is a sixth of a second on every resize, expansion, reviewed toggle and scope change.
+---
+---Rows are tracked in bands so that scrolling back re-emits nothing, and quantising is what
+---keeps that tracking a handful of lookups instead of a set the size of the review. The
+---grain is the harvest's margin: one figure decides both how far ahead the view paints and
+---how coarsely it remembers, and a band is either wholly emitted or wholly not.
+---
+---Cheap when there is nothing new -- which is what lets it hang off `CursorMoved`.
+local function paint_bands()
+  if not V.render then
+    return
+  end
+  local syntax = require("codereview.syntax")
+  local band = syntax.VIEWPORT_MARGIN
+  local lo, hi = syntax.viewport(V)
+  V.painted_bands = V.painted_bands or {}
+  for b = math.floor((lo - 1) / band), math.floor((hi - 1) / band) do
+    if not V.painted_bands[b] then
+      V.painted_bands[b] = true
+      -- Both panes draw the same rows, so one set of bands answers for both: a band is
+      -- emitted into both or into neither, which is what keeps the two images comparable
+      -- row for row wherever a reviewer has scrolled.
+      emit_rows(V.buf, V.render, b * band + 1, (b + 1) * band)
+      if V.before_render then
+        emit_rows(V.before_buf, V.before_render, b * band + 1, (b + 1) * band)
+      end
+    end
   end
 end
 
@@ -344,6 +418,10 @@ function M.paint(keep_file)
   if V.before_render then
     write_pane(V.before_buf, V.before_render)
   end
+  -- The namespaces above were just cleared, so nothing this records still exists. Dropped
+  -- here rather than in `paint_bands` for the reason `syntax_painted` is dropped by the
+  -- paint: what a band means is decided by the render it was emitted from.
+  V.painted_bands = {}
 
   paint_panel()
   update_winbar()
@@ -352,6 +430,11 @@ function M.paint(keep_file)
   if keep_file and V.render.file_rows[keep_file] then
     place(V.render.file_rows[keep_file])
   end
+
+  -- After `place`, not before it: parking the cursor on a file is what decides which rows
+  -- are near the window, and a repaint has to leave the rows it lands on painted rather
+  -- than waiting for the reviewer to move.
+  paint_bands()
 
   -- The namespace was just cleared and the renders above are new, so nothing a previous
   -- paint derived from them still describes what is on screen -- but the parsed captures
@@ -1749,9 +1832,12 @@ local function attach_pane(buf)
     end,
   })
 
-  -- Highlighting is bounded by the viewport, so scrolling into an un-parsed file is what
-  -- triggers its parse. Cheap on every other scroll: already-painted files are skipped
-  -- and already-parsed ones repaint from cache.
+  -- Both the diff's own marks and its highlighting are bounded by the viewport, so
+  -- scrolling into rows nothing has been emitted onto is what emits them, and scrolling
+  -- into an un-parsed file is what triggers its parse. One trigger for the two of them:
+  -- they share a margin, so they come due at the same moment. Cheap on every other scroll --
+  -- a band already emitted is a lookup, an already-painted file is skipped, and an
+  -- already-parsed one repaints from cache.
   vim.api.nvim_create_autocmd({ "WinScrolled", "CursorMoved" }, {
     group = V.augroup,
     buffer = buf,
@@ -1759,6 +1845,7 @@ local function attach_pane(buf)
       if not M.current() then
         return
       end
+      paint_bands()
       if config.get().syntax then
         require("codereview.syntax").apply(V, NS)
       end

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # timing report at two siz
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 910 cases in ~6 seconds.
+The whole suite is about 975 cases in ~6 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -42,6 +42,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
+| `bounded_spec` | Emission bounded by the viewport: what a paint writes and what it leaves out, the bound it shares with the harvest, what a scroll adds and what scrolling back does not, both panes at once — on a diff taller than the window, guarded |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
@@ -82,11 +83,14 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec`, `focus_spec` and `queue_jump_panel_spec`.
-- **`mkbig.sh`** — files of a given size, half of every file rewritten, for `perf.lua` only.
-  It takes counts as well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and
-  200), which is what lets the report measure two sizes without a second script: it builds a
-  60-file, 12k-line repository and a 300-file, 60k-line one, per run, in a temporary
-  directory. Neither is committed.
+- **`mkbig.sh`** — files of a given size, half of every file rewritten. It takes counts as
+  well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and 200), so a caller
+  asks for the height it needs rather than for a second script. `perf.lua` builds a 60-file,
+  12k-line repository and a 300-file, 60k-line one per run; `bounded_spec` builds a 6-file
+  one, about 1,800 rendered rows, which is the only fixture in the suite taller than a
+  window and the margin around it. Nothing built from it is committed. It costs about a
+  third of a second, which is why it is no longer kept out of `make test` — what is slow is
+  opening a review on it at the sizes the report uses, not building it.
 
 The sources are Lua and Markdown rather than TypeScript because Neovim core ships both
 parsers **and** their `highlights` queries. `syntax_spec` therefore exercises the real
@@ -186,6 +190,16 @@ so the out-of-core language path is still checked locally without ever failing C
   old map claimed. `syntax_spec` collapses a file *above* the one it checks, guards that the
   rows below really did move, and only then asserts that every syntax mark still covers its
   own token. Same trap as "a filter test needs a fixture only that filter can reject".
+- **A bounded paint is invisible on a diff that fits on screen.** Only the rows near the
+  window are written into a pane's buffer, so every extmark assertion elsewhere in the suite
+  runs on a fixture small enough to sit inside that band and passes whether or not anything
+  is bounded — the same trap as "centring is unobservable in a window taller than its
+  buffer". `bounded_spec` is the one spec that builds `mkbig`, and its first case guards
+  that the render really is taller than one paint can reach. Two of its cases judge against
+  figures the implementation cannot move — how many of the render's marks reached the buffer
+  at all, and whether the last file's marks did — because the rest derive their expectations
+  from `syntax.viewport`, and a case that asks the bound where the bound is goes quiet when
+  the bound goes away.
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.

--- a/tests/codereview/bounded_spec.lua
+++ b/tests/codereview/bounded_spec.lua
@@ -1,0 +1,297 @@
+-- Emission bounded by the viewport: what a paint writes into a pane's buffer, what a
+-- scroll adds to it, and what scrolling back does not.
+--
+-- Every claim here needs a diff genuinely taller than the window and the margin around it.
+-- A bounding assertion made on a diff that fits on screen passes with the bounding deleted,
+-- which is the failure `tests/README.md` already records twice -- "centring is unobservable
+-- in a window taller than its buffer", and "a filter test needs a fixture only that filter
+-- can reject". So this is the one spec that builds `mkbig`, small enough to build in a
+-- fraction of a second and still eight times taller than everything one paint can reach,
+-- and its first case guards that it really is. Without that guard the whole file silently
+-- stops measuring the moment a fixture or a default window size moves.
+--
+-- What is asserted is the shape of the work -- which marks reached which buffer -- and
+-- never how long any of it took. Timing lives in `perf.lua`, which is a report, not a gate.
+local h = require("tests.helpers")
+
+local syntax = require("codereview.syntax")
+local render = require("codereview.render")
+
+h.ui(110, 40)
+h.cd_fixture("mkbig", "6", "200")
+
+-- A synchronous stub composer, so an annotation is queued and drawn inside the call.
+require("codereview").setup({
+  compose = function(_, on_accept, _)
+    on_accept(nil, "note about this line")
+  end,
+})
+
+local view = require("codereview.view")
+local annotate = require("codereview.annotate")
+
+view.open("branch")
+local V = view.current()
+
+local BAND = syntax.VIEWPORT_MARGIN
+
+---The diff's own marks in a buffer: what the render put there, and nothing the treesitter
+---replay did. The two share a namespace, and only these are bounded by a band -- a file
+---near the window is parsed and painted *whole*, so a syntax mark can legitimately sit on a
+---row this bounding has not reached.
+---@param buf integer
+---@return table[]
+local function emitted(buf)
+  return vim.tbl_filter(function(m)
+    return m[4].priority ~= render.PRIORITY.syntax
+  end, vim.api.nvim_buf_get_extmarks(buf, h.NS, 0, -1, { details = true }))
+end
+
+---How many marks a buffer carries on each 1-indexed row.
+---@param buf integer
+---@return table<integer, integer>
+local function in_buffer(buf)
+  local out = {}
+  for _, m in ipairs(emitted(buf)) do
+    out[m[2] + 1] = (out[m[2] + 1] or 0) + 1
+  end
+  return out
+end
+
+---How many marks a render gives each 1-indexed row.
+---@param rendered CRRender
+---@return table<integer, integer>
+local function in_render(rendered)
+  local out = {}
+  for _, m in ipairs(rendered.marks) do
+    out[m.row + 1] = (out[m.row + 1] or 0) + 1
+  end
+  return out
+end
+
+---The rows the window is showing.
+---@return integer first, integer last
+local function on_screen()
+  -- Read through a table: `nvim_win_call` propagates only the first return value.
+  local span = vim.api.nvim_win_call(V.win, function()
+    return { vim.fn.line("w0"), vim.fn.line("w$") }
+  end)
+  return span[1], span[2]
+end
+
+---The last row of the last band a paint at this scroll position reaches.
+---@return integer
+local function reach()
+  local _, hi = syntax.viewport(V)
+  return (math.floor((hi - 1) / BAND) + 1) * BAND
+end
+
+---Put the window on `row` and fire the trigger a reviewer's scroll would.
+---
+---Neither `nvim_win_set_cursor` nor a `normal!` motion raises `CursorMoved` under a
+---headless Neovim -- see "Things that bite" -- so a case that only moved the window would
+---be asserting against a top-up that never ran.
+---@param row integer
+local function scroll_to(row)
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  vim.api.nvim_win_call(V.win, function()
+    vim.cmd("normal! zz")
+  end)
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+end
+
+---A pane carries every mark its render gave the rows up to `through`, and none above them.
+---@param buf integer
+---@param rendered CRRender
+---@param through integer
+local function complete_through(buf, rendered, through)
+  local buf_rows, render_rows = in_buffer(buf), in_render(rendered)
+  for row = 1, #rendered.lines do
+    if row <= through then
+      assert.same(render_rows[row], buf_rows[row], ("row %d, inside the painted bands"):format(row))
+    else
+      assert.is_nil(buf_rows[row], ("row %d is past them and carries marks"):format(row))
+    end
+  end
+end
+
+---A pane's marks come out in row order, which is what makes a band a slice of them rather
+---than a filter over all of them.
+---@param rendered CRRender
+local function in_row_order(rendered)
+  local previous = -1
+  for i, m in ipairs(rendered.marks) do
+    assert.is_true(m.row >= previous, ("mark %d is on row %d, after row %d"):format(i, m.row + 1, previous + 1))
+    previous = m.row
+  end
+end
+
+describe("a paint of a diff taller than the window", function()
+  -- The guard the rest of the file rests on. Everything below is satisfied by a diff that
+  -- fits on screen, whether or not anything is bounded.
+  it("renders more rows than one paint can reach", function()
+    assert.is_true(
+      #V.render.lines > reach() * 2,
+      ("%d rows is not enough taller than the %d a paint reaches"):format(#V.render.lines, reach())
+    )
+  end)
+
+  it("hands its marks over in row order", function()
+    in_row_order(V.render)
+  end)
+
+  it("writes the rows near the window and stops", function()
+    complete_through(V.buf, V.render, reach())
+  end)
+
+  it("leaves the buffer holding a fraction of what the render produced", function()
+    assert.is_true(
+      #emitted(V.buf) * 3 < #V.render.marks,
+      ("%d of %d marks is not bounded"):format(#emitted(V.buf), #V.render.marks)
+    )
+  end)
+
+  -- The guard against the cheapest wrong way to pass every case above: a render that
+  -- stopped producing the marks nobody can see. `split_spec`, `spans_spec` and
+  -- `render_spec` all assert against returned data, and this is what keeps that seam honest.
+  it("still produces the marks the buffer never receives", function()
+    local last_file = assert(V.render.file_rows[#V.files])
+    local produced = 0
+    for _, m in ipairs(V.render.marks) do
+      produced = produced + (m.row + 1 >= last_file and 1 or 0)
+    end
+    local written = 0
+    for _, m in ipairs(emitted(V.buf)) do
+      written = written + (m[2] + 1 >= last_file and 1 or 0)
+    end
+    assert.is_true(produced > 0, "the render gave the last file no marks at all")
+    assert.same(0, written)
+  end)
+
+  -- The margin is the harvest's own. Two figures would drift, and a harvest reaching
+  -- further than the emission is highlighting on rows with no diff background under them.
+  it("stops at the bound the harvest is judged against", function()
+    local _, hi = syntax.viewport(V)
+    local top = 0
+    for _, m in ipairs(emitted(V.buf)) do
+      top = math.max(top, m[2] + 1)
+    end
+    assert.is_true(top >= hi, ("row %d is short of the harvest's bound at %d"):format(top, hi))
+    assert.is_true(top < hi + BAND, ("row %d is past the harvest's bound at %d"):format(top, hi))
+  end)
+
+  it("carries the diff background, change bar, line number and span emphasis on screen", function()
+    local first, last = on_screen()
+    local groups = {}
+    for _, m in ipairs(emitted(V.buf)) do
+      local row = m[2] + 1
+      if row >= first and row <= last then
+        groups[m[4].line_hl_group or m[4].hl_group or ""] = true
+      end
+    end
+    assert.is_true(groups.CodeReviewAdd, "no added line carries its background")
+    assert.is_true(groups.CodeReviewDel, "no deleted line carries its background")
+    assert.is_true(groups.CodeReviewAddBar, "no added line carries the change bar")
+    assert.is_true(groups.CodeReviewDelBar, "no deleted line carries the change bar")
+    assert.is_true(groups.CodeReviewLineNr, "no row carries its line number")
+    assert.is_true(groups.CodeReviewAddSpan, "nothing inside a changed line is emphasised")
+  end)
+end)
+
+describe("an annotation on a row on screen", function()
+  local row = select(1, on_screen()) + 4
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  annotate.annotate("bug")
+
+  it("draws its virtual lines", function()
+    local found = vim.tbl_filter(function(m)
+      return m[4].virt_lines ~= nil and m[2] + 1 == row
+    end, emitted(V.buf))
+    assert.same(1, #found)
+  end)
+
+  it("has not lifted the bound to do it", function()
+    complete_through(V.buf, V.render, reach())
+  end)
+end)
+
+describe("scrolling into rows nothing has been emitted onto", function()
+  local far = #V.render.lines
+  -- Read while the window is still at the top: what a paint reaches is a fact about where
+  -- the window is, so asking again after scrolling would be asking about the far end.
+  local from_the_top = reach()
+  local before
+
+  it("finds them empty first", function()
+    before = #emitted(V.buf)
+    local buf_rows = in_buffer(V.buf)
+    for row = from_the_top + 1, far do
+      assert.is_nil(buf_rows[row], ("row %d was already painted"):format(row))
+    end
+  end)
+
+  it("emits that region's marks", function()
+    scroll_to(far)
+    assert.is_true(#emitted(V.buf) > before, "scrolling to the end emitted nothing")
+    local first, last = on_screen()
+    local buf_rows, render_rows = in_buffer(V.buf), in_render(V.render)
+    for row = first, last do
+      assert.same(render_rows[row], buf_rows[row], ("row %d, on screen at the end"):format(row))
+    end
+  end)
+
+  -- The middle was never near the window, so a top-up that emitted everything up to where
+  -- the reviewer scrolled would pass the case above and fail this one.
+  it("emits only that region", function()
+    local buf_rows = in_buffer(V.buf)
+    local lo = syntax.viewport(V)
+    -- The last row below the bands the window has now reached.
+    local middle = math.floor((lo - 1) / BAND) * BAND
+    assert.is_true(middle > from_the_top, "the two painted regions meet, so there is no middle to check")
+    for row = from_the_top + 1, middle do
+      assert.is_nil(buf_rows[row], ("row %d was painted without ever being near the window"):format(row))
+    end
+  end)
+
+  it("re-emits nothing when the reviewer scrolls back", function()
+    local written = #emitted(V.buf)
+    scroll_to(1)
+    assert.same(written, #emitted(V.buf))
+  end)
+end)
+
+describe("the split layout", function()
+  view.toggle_layout()
+
+  it("holds two panes of the same height", function()
+    assert.is_not_nil(V.before_render)
+    assert.same(#V.render.lines, #V.before_render.lines)
+  end)
+
+  it("hands both panes' marks over in row order", function()
+    in_row_order(V.render)
+    in_row_order(V.before_render)
+  end)
+
+  -- Both panes bounded by the same bands, so the two images stay comparable row for row
+  -- wherever a reviewer has scrolled: a bound that moved per pane would leave one of them
+  -- drawing a change bar the other had not reached.
+  it("bounds both panes at the same rows", function()
+    complete_through(V.buf, V.render, reach())
+    complete_through(V.before_buf, V.before_render, reach())
+  end)
+
+  it("tops both up together when the reviewer scrolls", function()
+    scroll_to(#V.render.lines)
+    local first, last = on_screen()
+    local after_rows, before_rows = in_buffer(V.buf), in_buffer(V.before_buf)
+    local after_render, before_render_rows = in_render(V.render), in_render(V.before_render)
+    local seen = 0
+    for row = first, last do
+      assert.same(after_render[row], after_rows[row], ("after pane, row %d"):format(row))
+      assert.same(before_render_rows[row], before_rows[row], ("before pane, row %d"):format(row))
+      seen = seen + (before_rows[row] or 0)
+    end
+    assert.is_true(seen > 0, "the before pane drew nothing on screen, so it agrees vacuously")
+  end)
+end)

--- a/tests/fixtures/mkbig.sh
+++ b/tests/fixtures/mkbig.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Rebuild the large fixture repo used by tests/perf.lua.
+# Rebuild the large fixture repo used by tests/perf.lua and by bounded_spec.
 #
 # 60 files of 200 lines by default, with half of every file rewritten on the feature
 # branch: roughly 12k rendered rows once headers and context are counted. Sized to be the
@@ -9,7 +9,9 @@
 # Both counts are arguments because one size cannot show everything: every cost in the
 # review view is linear in the size of the diff, so `perf.lua` asks for this same shape at
 # 60 files and again at 300, where a keystroke and a repaint are large enough to read a
-# change from.
+# change from, and `bounded_spec` asks for 6 -- the smallest that renders a diff taller
+# than a window and the margin around it, which is the only size at which a bounded paint
+# can be told from an unbounded one.
 set -e
 # Hermetic: no user or system git config. Without this the fixture inherits things that
 # change what it is (commit.gpgsign, diff.renames, core.autocrlf, hooks) -- gpg signing in

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -8,21 +8,26 @@ local M = {}
 M.root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
 
 ---Build a fixture repository and return its path.
----@param script "mkfixture"|"mktree"
+---
+---Anything after the script name is passed to it after the path, which is how `mkbig` is
+---asked for a diff of a particular height: it takes a file count and a line count.
+---@param script "mkfixture"|"mktree"|"mkbig"
+---@param ... string
 ---@return string dir
-function M.fixture(script)
+function M.fixture(script, ...)
   local dir = vim.fn.tempname() .. "-" .. script
   local sh = vim.fs.joinpath(M.root, "tests", "fixtures", script .. ".sh")
-  local res = vim.system({ "bash", sh, dir }, { text = true }):wait(60000)
+  local res = vim.system(vim.list_extend({ "bash", sh, dir }, { ... }), { text = true }):wait(60000)
   assert(res.code == 0, ("%s failed (%d): %s"):format(script, res.code, res.stderr or ""))
   return dir
 end
 
 ---Build a fixture and make it the current directory.
----@param script "mkfixture"|"mktree"
+---@param script "mkfixture"|"mktree"|"mkbig"
+---@param ... string
 ---@return string dir
-function M.cd_fixture(script)
-  local dir = M.fixture(script)
+function M.cd_fixture(script, ...)
+  local dir = M.fixture(script, ...)
   vim.cmd("cd " .. vim.fn.fnameescape(dir))
   return dir
 end


### PR DESCRIPTION
Closes #78. Second and last half of #66; #77 landed the first.

## What changed

Writing a **pane** cleared its namespace and re-emitted every mark the render
produced — 271,000 of them on a 300-file review, 141 ms of a repaint that runs on
every resize, expansion, reviewed toggle, **scope** change and queued
**annotation**. Only the rows near the window are written now; the rest arrive
when a reviewer scrolls to them, through the autocommand that already tops up the
harvest.

- **The render is not touched.** `render.build` still returns the complete `marks`
  array for both panes. Only the writing of those marks into a buffer is bounded,
  which is what leaves the split, **span** and **anchor** assertions — all made
  against returned data — valid, and why a guard case asserts the render still
  produces the marks the buffer never receives.
- **The margin is the harvest's own.** `syntax.viewport` is exported and the view
  asks it rather than doing the arithmetic again: two figures would drift, and a
  harvest reaching further than the emission is highlighting on a row with no diff
  background under it.
- **Rows are tracked in bands** of that same margin, so scrolling back re-emits
  nothing, and both panes share one record — a band is emitted into both or into
  neither. The record is dropped where the namespace is cleared, exactly as
  `syntax_painted` is.
- Marks are **found** rather than filtered: `render.build` appends each as it draws
  the row it belongs to, so a band is a slice of the array. Filtering would be a
  walk of the whole review on every scroll, which is the cost this removes.

## The numbers

`make perf`, back to back on one machine:

| | before | after |
| --- | --- | --- |
| repaint, 300 files | 372 ms | **99 ms** |
| repaint, 60 files | 75 ms | 26 ms |
| cursor move | 0.0 ms | 0.0 ms |
| open, 300 files | 618 ms | 495 ms |

## Tests

New `bounded_spec`, the first spec to build `mkbig` — at six files, about 1,800
rendered rows into a 40-line window. A bounding assertion made on a diff that fits
on screen passes with the bounding deleted, so a guard case asserts the render
really is taller than one paint can reach.

Verified by mutation: emitting every row reds eleven of its seventeen cases, and
dropping the painted-band tracking reds exactly the one that owns it. The ten
existing buffer-extmark assertions elsewhere in the suite pass unedited.

`make all` green: 975 cases, 0 failures.