### PR TITLE
refactor(view): declare the review's keys in a module of their own

### DIFF
--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -24,6 +24,7 @@ change there is felt through.
 | `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes | stateful (git) |
 | `hl.lua` | The highlight groups, all `default = true` links into whatever colorscheme is active | stateful (editor) |
 | `init.lua` | The public surface a host reaches: `setup`, the user commands, `annotate(type)` | stateful (setup) |
+| `keymaps.lua` | Every key the review view binds — the diff's and the tree's — onto a buffer handed in, driving actions handed in | stateful (editor) |
 | `panel.lua` | The file tree: build, chain compaction, folding, per-directory tallies | pure |
 | `payload.lua` | The queue rendered as the message an agent receives; `@ref`s resolved at submit time | pure |
 | `queue.lua` | The queue itself — module-level, not per-view, so reopening a view scatters nothing | stateful (memory) |
@@ -31,14 +32,14 @@ change there is felt through.
 | `state.lua` | Persisted review progress, and the blob-hash check that makes persisting safe | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
-| `view.lua` | The review view: buffers, windows, keymaps, navigation, both layouts, the queue float | stateful (windows) |
+| `view.lua` | The review view: buffers, windows, navigation, both layouts, the queue float | stateful (windows) |
 
 ## How they stack
 
 - **Require nothing**: `diff`, `drafts`, `panel`, `queue`, `types`.
 - **Above them**, in that order: `git`, `payload`, `render`; then `state`, `config`; then
-  `archive`, `delivery`, `syntax`; then `composer`, `hl`.
-- **The hubs**: `view` requires twelve of the modules above, `annotate` nine. A change that
+  `archive`, `delivery`, `keymaps`, `syntax`; then `composer`, `hl`.
+- **The hubs**: `view` requires thirteen of the modules above, `annotate` nine. A change that
   is not local to a leaf almost certainly reaches one of them.
 - **On top**: `capture`, then `init`.
 
@@ -56,10 +57,17 @@ the `since-batch` scope. Function-local on both sides, as above. The alternative
 the snapshot in from outside, which would put the one scope that needs it into every caller
 of `resolve_scope` — and scope resolution is exactly what must stay one function.
 
+`keymaps` would be a third. Its keys run the view's exported actions, and it takes them as
+an argument — `view` hands itself in — rather than requiring `view` for them. That is
+deliberate: it is what leaves the module a function of its arguments and the configured
+annotation types, with no view state read anywhere in it.
+
 ## Where reading pays
 
 - **Settled**, one to three commits each: `panel`, `drafts`, `diff`, `git`, `syntax`,
-  `render`, `hl`, `archive`. Read one when you need it, not to orient yourself.
+  `render`, `hl`, `archive`, `keymaps`. Read one when you need it, not to orient yourself.
+  `keymaps` is the one to open when the question is what a key does or where to add one —
+  it is a table, not a search through the surface that happens to bind it.
 - **Carries the churn**: `view` and `annotate` by a wide margin, then `config`, `composer`
   and `state`.
 

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -1,0 +1,211 @@
+---Every key the review view binds, in one place: the diff's, and the file tree's.
+---
+---Nothing here reads the view. The buffer to bind onto is handed in, and so are the actions
+---the keys run, which leaves this module a function of its arguments and the configured
+---annotation types. Taking the actions as an argument rather than requiring `view` for them
+---is also what keeps this module out of the cycle that module already sits in.
+---
+---The buffer has to be a parameter rather than something looked up. Both a before pane's
+---buffer and the tree's are `bufhidden = "wipe"`, so toggling the layout back to unified and
+---dismissing the tree each destroy every mapping bound to them, and what comes back is a
+---*new* buffer that has to be given the whole set again.
+local config = require("codereview.config")
+
+local M = {}
+
+---@param buf integer
+---@param maps table<string, function|table>
+local function bind(buf, maps)
+  for lhs, rhs in pairs(maps) do
+    local fn, desc, mode = rhs, "", "n"
+    if type(rhs) == "table" then
+      fn, desc, mode = rhs[1], rhs[2] or "", rhs[3] or "n"
+    end
+    vim.keymap.set(mode, lhs, fn, { buffer = buf, nowait = true, silent = true, desc = desc })
+  end
+end
+
+---Bind the diff's keys. Every pane gets the same set: which pane a reviewer happens to be
+---in decides what a key acts on, never whether it works.
+---@param buf integer
+---@param view table The review view, whose exported actions these keys run.
+function M.diff(buf, view)
+  -- Annotation keys are prefixed with `a` rather than bound bare. Bare `b`/`f`/`s`/`n`
+  -- would shadow back-word, find-char and next-search inside the buffer; `a` (append) is
+  -- dead in a nomodifiable buffer, so it costs a keystroke and no motion.
+  --
+  -- Required here rather than at file scope: `annotate` requires `view`, and `view`
+  -- requires this module, so a require up there would route their cycle through it.
+  local annotate = require("codereview.annotate")
+  for _, t in ipairs(config.get().types) do
+    vim.keymap.set({ "n", "x" }, "a" .. t.key, function()
+      annotate.annotate(t.name)
+    end, { buffer = buf, nowait = true, silent = true, desc = "Annotate: " .. t.name })
+  end
+  vim.keymap.set({ "n", "x" }, "aa", annotate.annotate_pick, {
+    buffer = buf,
+    nowait = true,
+    silent = true,
+    desc = "Annotate: pick type",
+  })
+
+  bind(buf, {
+    ["x"] = { annotate.drop, "Drop the annotation here" },
+    ["]f"] = {
+      function()
+        view.jump("file", true)
+      end,
+      "Next file",
+    },
+    ["[f"] = {
+      function()
+        view.jump("file", false)
+      end,
+      "Previous file",
+    },
+    ["]h"] = {
+      function()
+        view.jump("hunk", true)
+      end,
+      "Next hunk",
+    },
+    ["[h"] = {
+      function()
+        view.jump("hunk", false)
+      end,
+      "Previous hunk",
+    },
+    ["]F"] = {
+      function()
+        view.jump_unreviewed(true)
+      end,
+      "Next unreviewed file",
+    },
+    ["[F"] = {
+      function()
+        view.jump_unreviewed(false)
+      end,
+      "Previous unreviewed file",
+    },
+    ["]a"] = {
+      function()
+        view.jump_annotation(true)
+      end,
+      "Next annotation",
+    },
+    ["[a"] = {
+      function()
+        view.jump_annotation(false)
+      end,
+      "Previous annotation",
+    },
+    ["<C-p>"] = { view.pick_file, "Jump to a file" },
+    ["<Tab>"] = { view.toggle_focus, "Focus the file tree" },
+    ["R"] = { view.toggle_reviewed, "Toggle reviewed" },
+    ["za"] = { view.toggle_expand, "Toggle expansion" },
+    ["gs"] = {
+      function()
+        view.set_scope(nil)
+      end,
+      "Cycle scope",
+    },
+    ["gr"] = { view.refresh, "Reload the diff" },
+    ["gp"] = { view.toggle_panel, "Show or hide the file tree" },
+    -- From the `g` family the other view-level commands come from, and clear of `gt`/`gT`,
+    -- which are how `<CR>`'s new tab is returned from.
+    ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
+    ["<CR>"] = { view.open_file, "Open the real file here" },
+    ["Q"] = { view.review_queue, "Review the queue" },
+    -- `gy`, not `Y`: yank is not dead in this buffer the way append is, and pulling a code
+    -- line out of the diff is something reviewers do. From the same `g` family as the
+    -- commands above, where it shadows nothing.
+    ["gy"] = { view.copy, "Copy the batch to the clipboard" },
+    ["<C-t>"] = { view.pick_target, "Choose the delivery target" },
+    ["<C-s>"] = { view.submit, "Submit the batch" },
+    ["q"] = { view.close, "Close the review" },
+  })
+
+  -- Only once the adapter is injected. Every adapter is nil by default, and a key that
+  -- silently does nothing is worse than no key at all -- it also keeps `gd` free for
+  -- whatever a host that wired no diff tool would rather have there. From the same `g`
+  -- family as the commands above, and clear of `gt`/`gT`.
+  if config.get().open_diff then
+    bind(buf, { ["gd"] = { view.open_diff, "Read this file in the host's diff tool" } })
+  end
+end
+
+---Bind the file tree's keys.
+---@param buf integer
+---@param view table The review view, whose exported actions these keys run.
+function M.panel(buf, view)
+  bind(buf, {
+    ["<CR>"] = { view.panel_select, "Open the file / fold the directory" },
+    ["o"] = { view.panel_select, "Open the file / fold the directory" },
+    ["za"] = {
+      function()
+        view.panel_fold(nil)
+      end,
+      "Toggle the directory",
+    },
+    ["l"] = {
+      function()
+        view.panel_fold(false)
+      end,
+      "Expand the directory",
+    },
+    ["zo"] = {
+      function()
+        view.panel_fold(false)
+      end,
+      "Expand the directory",
+    },
+    ["h"] = {
+      function()
+        view.panel_fold(true)
+      end,
+      "Collapse the directory / go to the parent",
+    },
+    ["zc"] = {
+      function()
+        view.panel_fold(true)
+      end,
+      "Collapse the directory",
+    },
+    ["zM"] = {
+      function()
+        view.panel_fold_all(true)
+      end,
+      "Collapse every directory",
+    },
+    ["zR"] = {
+      function()
+        view.panel_fold_all(false)
+      end,
+      "Expand every directory",
+    },
+    ["]f"] = {
+      function()
+        view.panel_jump_file(true)
+      end,
+      "Next file in the tree",
+    },
+    ["[f"] = {
+      function()
+        view.panel_jump_file(false)
+      end,
+      "Previous file in the tree",
+    },
+    ["<C-p>"] = { view.pick_file, "Jump to a file" },
+    ["<Tab>"] = { view.toggle_focus, "Focus the diff" },
+    ["gp"] = { view.toggle_panel, "Hide the file tree" },
+    ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
+    ["R"] = { view.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
+    ["q"] = { view.close, "Close the review" },
+  })
+
+  if config.get().open_diff then
+    bind(buf, { ["gd"] = { view.panel_open_diff, "Read this file in the host's diff tool" } })
+  end
+end
+
+return M

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1,7 +1,9 @@
----The review surface: buffers, windows, keymaps, navigation.
+---The review surface: buffers, windows, navigation.
 ---
 ---One view exists at a time, in its own tab page. Everything it draws comes from
----`render.lua`; everything it knows about position comes from that render's anchor map.
+---`render.lua`; everything it knows about position comes from that render's anchor map;
+---and the keys that drive the actions exported here are declared in `keymaps.lua`, which
+---is handed this module rather than requiring it.
 ---
 ---In the split layout the view keeps its existing buffer and window as the **after** pane
 ---and gains a before pane beside it. The after-image is the primary one everywhere else --
@@ -14,6 +16,7 @@ local render = require("codereview.render")
 local panel = require("codereview.panel")
 local hl = require("codereview.hl")
 local delivery = require("codereview.delivery")
+local keymaps = require("codereview.keymaps")
 
 local M = {}
 
@@ -1606,194 +1609,6 @@ end
 --- Setup -----------------------------------------------------------------------
 
 ---@param buf integer
----@param maps table<string, function|table>
-local function bind(buf, maps)
-  for lhs, rhs in pairs(maps) do
-    local fn, desc, mode = rhs, "", "n"
-    if type(rhs) == "table" then
-      fn, desc, mode = rhs[1], rhs[2] or "", rhs[3] or "n"
-    end
-    vim.keymap.set(mode, lhs, fn, { buffer = buf, nowait = true, silent = true, desc = desc })
-  end
-end
-
----Bind the diff's keys. Every pane gets the same set: which pane a reviewer happens to be
----in decides what a key acts on, never whether it works.
----@param buf integer
-local function setup_main_keymaps(buf)
-  -- Annotation keys are prefixed with `a` rather than bound bare. Bare `b`/`f`/`s`/`n`
-  -- would shadow back-word, find-char and next-search inside the buffer; `a` (append) is
-  -- dead in a nomodifiable buffer, so it costs a keystroke and no motion.
-  local annotate = require("codereview.annotate")
-  for _, t in ipairs(config.get().types) do
-    vim.keymap.set({ "n", "x" }, "a" .. t.key, function()
-      annotate.annotate(t.name)
-    end, { buffer = buf, nowait = true, silent = true, desc = "Annotate: " .. t.name })
-  end
-  vim.keymap.set({ "n", "x" }, "aa", annotate.annotate_pick, {
-    buffer = buf,
-    nowait = true,
-    silent = true,
-    desc = "Annotate: pick type",
-  })
-
-  bind(buf, {
-    ["x"] = { annotate.drop, "Drop the annotation here" },
-    ["]f"] = {
-      function()
-        M.jump("file", true)
-      end,
-      "Next file",
-    },
-    ["[f"] = {
-      function()
-        M.jump("file", false)
-      end,
-      "Previous file",
-    },
-    ["]h"] = {
-      function()
-        M.jump("hunk", true)
-      end,
-      "Next hunk",
-    },
-    ["[h"] = {
-      function()
-        M.jump("hunk", false)
-      end,
-      "Previous hunk",
-    },
-    ["]F"] = {
-      function()
-        M.jump_unreviewed(true)
-      end,
-      "Next unreviewed file",
-    },
-    ["[F"] = {
-      function()
-        M.jump_unreviewed(false)
-      end,
-      "Previous unreviewed file",
-    },
-    ["]a"] = {
-      function()
-        M.jump_annotation(true)
-      end,
-      "Next annotation",
-    },
-    ["[a"] = {
-      function()
-        M.jump_annotation(false)
-      end,
-      "Previous annotation",
-    },
-    ["<C-p>"] = { M.pick_file, "Jump to a file" },
-    ["<Tab>"] = { M.toggle_focus, "Focus the file tree" },
-    ["R"] = { M.toggle_reviewed, "Toggle reviewed" },
-    ["za"] = { M.toggle_expand, "Toggle expansion" },
-    ["gs"] = {
-      function()
-        M.set_scope(nil)
-      end,
-      "Cycle scope",
-    },
-    ["gr"] = { M.refresh, "Reload the diff" },
-    ["gp"] = { M.toggle_panel, "Show or hide the file tree" },
-    -- From the `g` family the other view-level commands come from, and clear of `gt`/`gT`,
-    -- which are how `<CR>`'s new tab is returned from.
-    ["gl"] = { M.toggle_layout, "Switch between the unified and split layouts" },
-    ["<CR>"] = { M.open_file, "Open the real file here" },
-    ["Q"] = { M.review_queue, "Review the queue" },
-    -- `gy`, not `Y`: yank is not dead in this buffer the way append is, and pulling a code
-    -- line out of the diff is something reviewers do. From the same `g` family as the
-    -- commands above, where it shadows nothing.
-    ["gy"] = { M.copy, "Copy the batch to the clipboard" },
-    ["<C-t>"] = { M.pick_target, "Choose the delivery target" },
-    ["<C-s>"] = { M.submit, "Submit the batch" },
-    ["q"] = { M.close, "Close the review" },
-  })
-
-  -- Only once the adapter is injected. Every adapter is nil by default, and a key that
-  -- silently does nothing is worse than no key at all -- it also keeps `gd` free for
-  -- whatever a host that wired no diff tool would rather have there. From the same `g`
-  -- family as the commands above, and clear of `gt`/`gT`.
-  if config.get().open_diff then
-    bind(buf, { ["gd"] = { M.open_diff, "Read this file in the host's diff tool" } })
-  end
-end
-
-local function setup_panel_keymaps()
-  bind(V.panel_buf, {
-    ["<CR>"] = { M.panel_select, "Open the file / fold the directory" },
-    ["o"] = { M.panel_select, "Open the file / fold the directory" },
-    ["za"] = {
-      function()
-        M.panel_fold(nil)
-      end,
-      "Toggle the directory",
-    },
-    ["l"] = {
-      function()
-        M.panel_fold(false)
-      end,
-      "Expand the directory",
-    },
-    ["zo"] = {
-      function()
-        M.panel_fold(false)
-      end,
-      "Expand the directory",
-    },
-    ["h"] = {
-      function()
-        M.panel_fold(true)
-      end,
-      "Collapse the directory / go to the parent",
-    },
-    ["zc"] = {
-      function()
-        M.panel_fold(true)
-      end,
-      "Collapse the directory",
-    },
-    ["zM"] = {
-      function()
-        M.panel_fold_all(true)
-      end,
-      "Collapse every directory",
-    },
-    ["zR"] = {
-      function()
-        M.panel_fold_all(false)
-      end,
-      "Expand every directory",
-    },
-    ["]f"] = {
-      function()
-        M.panel_jump_file(true)
-      end,
-      "Next file in the tree",
-    },
-    ["[f"] = {
-      function()
-        M.panel_jump_file(false)
-      end,
-      "Previous file in the tree",
-    },
-    ["<C-p>"] = { M.pick_file, "Jump to a file" },
-    ["<Tab>"] = { M.toggle_focus, "Focus the diff" },
-    ["gp"] = { M.toggle_panel, "Hide the file tree" },
-    ["gl"] = { M.toggle_layout, "Switch between the unified and split layouts" },
-    ["R"] = { M.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
-    ["q"] = { M.close, "Close the review" },
-  })
-
-  if config.get().open_diff then
-    bind(V.panel_buf, { ["gd"] = { M.panel_open_diff, "Read this file in the host's diff tool" } })
-  end
-end
-
----@param buf integer
 ---@param name string
 local function scratch(buf, name)
   vim.bo[buf].buftype = "nofile"
@@ -1814,7 +1629,7 @@ end
 ---pane that comes back with no keymaps at all.
 ---@param buf integer
 local function attach_pane(buf)
-  setup_main_keymaps(buf)
+  keymaps.diff(buf, M)
 
   -- The review buffer is nomodifiable, so insert mode is never meaningful in it. It can
   -- still be arrived at while already inserting: a composer opened with `startinsert` and
@@ -1955,7 +1770,7 @@ local function show_panel()
   vim.api.nvim_win_set_width(pwin, cfg.panel.width)
   vim.wo[pwin].winfixwidth = true
   V.panel_buf, V.panel_win = pbuf, pwin
-  setup_panel_keymaps()
+  keymaps.panel(pbuf, M)
   vim.api.nvim_set_current_win(V.win)
 end
 


### PR DESCRIPTION
The keymap tables leave `view.lua` for `lua/codereview/keymaps.lua` — the diff's keys, the
tree's keys, and the helper that binds them. 188 lines out of the largest and highest-churn
file in the repository, in one contiguous deletion; `view.lua` goes 2,187 → 2,002 lines.

This is the first of the two parts #70 found genuinely detached from the view's mutable
state. The split along the section comments is still rejected, for the reason recorded
there: every other section mutates that state, and four files reaching into one shared
state is four reads where there was one.

## What changed

- `keymaps.diff(buf, view)` and `keymaps.panel(buf, view)` replace the module-local
  `setup_main_keymaps` / `setup_panel_keymaps`.
- The two view-state reads were both the panel's buffer handle. `show_panel` now passes the
  buffer it just built, which is what the diff's own binding already did. The new module
  contains no reference to the view state at all.
- The actions the keys run are handed in rather than required. Requiring `view` for them
  would route the `view` ↔ `annotate` cycle through a third module; passing them leaves
  `keymaps` a function of its arguments and the configured annotation types.
- `lua/codereview/CLAUDE.md` gains its row, and the layering, the cycles note and the
  "where reading pays" list are brought back into step.

## What did not change

No public entry point moves — a host configuration needs no change. Every key does exactly
what it did: `gd` still appears only when `open_diff` is wired, the annotation keys are
still derived from the configured types, and a pane rebuilt by a layout toggle and a tree
dismissed and summoned each still receive the full set in their new buffer.

## Verification

`make all` — 29 specs, 1,058 cases green, matching trunk, with **no spec edited**. The diff
touches three files, none of them under `tests/`.

`panel_spec` was run first and on its own, being the one whose failure would mean the most:
it asserts the tree returns in a different buffer carrying the same mappings and drives one
through the keys, which is the silent failure this change could have caused. 47 cases green.

Closes #80