### PR TITLE
feat(render): keep an archived entry on the diff, dimmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,24 @@ resubmit one would be claiming the plugin can revise what an agent already recei
 raise a point again, annotate again — that is an ordinary capture, and it joins the next
 batch.
 
+### What you already reported stays on the diff
+
+A dispatched batch does not leave the review view. Its entries keep the anchors they were
+bound to and are drawn dimmed beneath the code they were about, projected exactly as live
+annotations are. A reviewer who keeps going while the agent works is otherwise looking at a
+diff with no memory of what it already sent, and reports the same finding twice.
+
+They draw in **every scope**, not only `since-batch` — knowing what has already been said is
+worth as much wherever you are. An anchor carrying both a queued and an archived entry draws
+both, the queued one first: what is still to send outranks what has already gone. `x` there
+drops the queued one and never the archived one; nothing on the diff can revise a batch that
+already went, for the same reason the last-batch float is read-only.
+
+Their two highlight groups are their own — `CodeReviewArchived` for the marker and
+`CodeReviewArchivedNote` for the prose — and are `default = true` links like everything else
+here, so a colorscheme can say how dim "already sent" looks. `archived = false` turns them
+off wholesale, and the diff then renders exactly as it did before the archive existed.
+
 ### The payload
 
 Grouped by type, in the configured order, most actionable first, with anything untyped
@@ -519,6 +537,7 @@ opts = {
   max_syntax_bytes = 256 * 1024,   -- skip syntax above this size
   layout = "unified",              -- "unified" or "split"; validated at setup
   spans = true,                    -- emphasise what changed inside a changed line
+  archived = true,                 -- draw already-dispatched entries on the diff, dimmed
   panel = { enabled = true, width = 34, position = "left" },
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
             collapsed = "▸", expanded = "▾", change_bar = "▌" },

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -141,6 +141,17 @@ Marks are *found* rather than filtered — `render.build` appends each as it dra
 belongs to, so a pane's marks are in row order and a band is a slice of them; filtering
 would be a walk of the whole review on every scroll, which is the cost this removes.
 
+**A nested closure inside `note_virt` costs a third of `render.build`.** That function runs
+once per annotatable row — ninety thousand times on a 300-file review, and almost always to
+answer "nothing is attached here" — so anything that makes the *empty* answer more expensive
+is paid ninety thousand times. Folding the per-entry work into an inner `local function` so
+that queued and archived entries could share it read better and measured 17 ms → 23 ms on 60
+files, before either kind of entry existed in the fixture: the early return happens first, so
+the closure is never even created, and it is still the difference. Hoisted to a sibling of
+`note_virt`, taking the accumulator as an argument, it is back under the original. Measure
+this one with repeated `render.build` calls rather than `make perf`, whose repaint line is a
+single sample and hid the regression inside its own spread.
+
 **Intra-line spans are computed when the diff is parsed, never when it is drawn.** On a
 12,000-line diff they cost about as much again as a whole repaint. Paid once per git read
 that lengthens opening by roughly a third; paid per repaint it would be a ~50% regression on
@@ -229,6 +240,30 @@ meant to avoid. Matching on the stamp is load-bearing, and it resolves to one se
 dispatches inside the same second read back as one batch. That is beyond any human dispatch
 cadence and well within a loop's, which is why `archive_float_spec` clears both stores
 between blocks rather than trusting the clock.
+
+**The projection onto the diff is memoised on a write count, not rebuilt per repaint.** An
+archived entry is drawn from a table keyed by anchor, exactly as a queued one is — but the
+queue is in memory and an archive is a file, and a repaint runs on every resize, expansion,
+reviewed toggle and scope change. Decoding the state document there would put the cost of
+the whole archive back onto the operation extmark bounding exists to keep cheap, and it
+would scale with what is *stored* rather than with what is *drawn*, which is the property
+this feature had to hold. So `state.archive_writes` counts what can change an archive and
+`archive.by_key` compares against it: the ordinary repaint pays two comparisons, and a
+dispatch is what makes it read. Recomputing at the two moments the view knows about instead
+— opening, and its own submit — looks equivalent and is not: an **immediate send** archives
+a batch of one without emptying anything and without a repaint of its own, so the view would
+go on drawing an archive it had already been overtaken by.
+
+**Only the repository's own archive is projected.** An entry with no repository-relative path
+is in the store that needs no root, and its key is built from an absolute path or from
+nothing at all — so it can never name an anchor in this repository's diff. Reading that store
+per view would be a second file read that could only ever return nothing.
+
+**A queued and an archived entry on one anchor ride in the same virtual-line block.** Not two
+extmarks on one row: the split layout holds the opposite pane's place by *counting* virtual
+lines, so two blocks would need that mirroring to learn about the second — and getting it
+wrong knocks the panes out of alignment for every row below, which reads as the two images
+showing different code. One block, live entries first, keeps the count exactly what it was.
 
 **An archived entry's `stale` flag must not be drawn.** It is persisted with the entry, so
 it is there to read, and it means "this file had moved since the annotation was captured" —

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -14,7 +14,7 @@ change there is felt through.
 | Module | Owns | |
 | --- | --- | --- |
 | `annotate.lua` | The review path: cursor to entry, the deleted-line and hunk inlining rules, drop, grouping | stateful (queue, view) |
-| `archive.lua` | The archive read back: which batch went last, and the read-only float listing it | stateful (float) |
+| `archive.lua` | The archive read back: which batch went last, the read-only float listing it, and the projection of archived entries onto the diff's anchors | stateful (float) |
 | `capture.lua` | The capture path: the same entry from an ordinary buffer, no review view involved | stateful (queue, buffer) |
 | `composer.lua` | The shipped composer and its `@` reference picker — the default `compose` adapter, not a lesser one | stateful (float) |
 | `config.lua` | `setup()`, the defaults, and the injected adapters: `send`, `pick_target`, `pick_file`, `compose`, `open_diff` | stateful (options) |

--- a/lua/codereview/archive.lua
+++ b/lua/codereview/archive.lua
@@ -10,6 +10,11 @@
 ---cannot. Re-raising a point means annotating again, which is an ordinary capture and
 ---already has a path.
 ---
+---The other way it is read back is onto the diff itself: `by_key` projects archived entries
+---onto their **anchors** so the review view can draw them dimmed beneath the code they were
+---about. Same record, same read-only claim -- what differs is that one surface is asked for
+---and the other is simply there while you keep reviewing.
+---
 ---A module of its own because a buffer, a window and keys do not have to live on the review
 ---view to exist -- and because a **batch is not a window**: this opens with no review open,
 ---exactly as the queue float does, so what was asked for can be checked from anywhere.
@@ -68,6 +73,60 @@ function M.last(root)
     return loose
   end
   return owned
+end
+
+--- The archive on the diff ------------------------------------------------------
+
+---The projection last handed out, and what it was built from.
+---@type { root: string|nil, writes: integer, by_key: table<string, CRAnnotation[]> }
+local projected = { root = nil, writes = -1, by_key = {} }
+
+---Every archived entry that has an anchor, grouped by it.
+---
+---What the review view draws beneath the code, exactly as `queue.by_key` is what it draws
+---above: a reviewer who keeps working while an agent does is otherwise looking at a diff
+---with no memory of what it already sent, and reports the same finding twice. No key is
+---computed here -- an entry has carried its anchor since it was captured, which is what
+---makes an archived entry land where the live one stood rather than somewhere near it.
+---
+---**The repository's archive alone.** An entry with no repository-relative path is in the
+---store that needs no root, and its key is built from an absolute path or from nothing at
+---all, so it can never name an anchor in this repository's diff. Reading that store would
+---be a second file read that could only ever return nothing.
+---
+---**Memoised on `state.archive_writes`**, because a repaint runs on every resize,
+---expansion, reviewed toggle and scope change, and rebuilding this from a file read on each
+---of those is the cost bounding extmark emission exists to remove. Only a write moves that
+---number, so the ordinary repaint pays two comparisons.
+---
+---Newest batch first, and within a batch the order the entries went in. Every reader of an
+---archive wants the newest, and reading down from the code is then reading back in time.
+---@param root string|nil nil outside a repository, which has no archive to draw
+---@return table<string, CRAnnotation[]>
+function M.by_key(root)
+  local writes = state.archive_writes()
+  if projected.root == root and projected.writes == writes then
+    return projected.by_key
+  end
+
+  local out = {}
+  for _, batch in ipairs(state.archive(root)) do
+    for _, entry in ipairs(batch.entries or {}) do
+      -- A **bare note** is about no file and its key names no anchor. It cannot reach this
+      -- store, but nothing here should depend on that being true of every future kind.
+      if entry.key then
+        local bucket = out[entry.key]
+        if not bucket then
+          bucket = {}
+          out[entry.key] = bucket
+        end
+        bucket[#bucket + 1] = entry
+      end
+    end
+  end
+
+  projected = { root = root, writes = writes, by_key = out }
+  return out
 end
 
 --- Rendering the batch as rows -------------------------------------------------

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -27,6 +27,16 @@ M.defaults = {
   ---comparable review tool does. It lengthens opening a large review by roughly a third and
   ---a repaint by nothing at all, because the work is done once per git read.
   spans = true, ---@type boolean
+  ---Draw **archived** entries on the diff, dimmed, beneath the code they were about. A
+  ---reviewer who keeps working while an agent does is otherwise looking at a review view
+  ---with no memory of what it already sent, and reports the same finding twice. Every
+  ---scope, not only `since-batch`: what has already been said is worth knowing wherever
+  ---you are.
+  ---
+  ---On by default, and coarse on purpose -- off is the whole history off, and renders the
+  ---diff exactly as it did before the archive existed. There is no keymap beside it yet;
+  ---one can be added if the switch proves too blunt.
+  archived = true, ---@type boolean
   panel = {
     enabled = true,
     width = 34,
@@ -137,15 +147,17 @@ local function validate_layout(layout)
   end
 end
 
----Reject a `spans` value that is not a boolean.
+---Reject a switch that is not a boolean.
 ---
----In the same voice as a bad layout, and for the same reason: `spans = "off"` is truthy,
----so a mistyped switch would silently leave the feature on with nothing on screen saying
----why.
----@param spans any
-local function validate_spans(spans)
-  if type(spans) ~= "boolean" then
-    error(("codereview.setup: `spans` must be a boolean — got %s"):format(vim.inspect(spans)), 0)
+---In the same voice as a bad layout, and for the same reason: `spans = "off"` is truthy, so
+---a mistyped switch would silently leave the feature on with nothing on screen saying why.
+---Named rather than one function per switch, because the reason is the same one every time
+---and two copies of it would be two chances to word it differently.
+---@param name string
+---@param value any
+local function validate_boolean(name, value)
+  if type(value) ~= "boolean" then
+    error(("codereview.setup: `%s` must be a boolean — got %s"):format(name, vim.inspect(value)), 0)
   end
 end
 
@@ -153,7 +165,8 @@ end
 function M.setup(opts)
   M.options = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults), opts or {})
   validate_layout(M.options.layout)
-  validate_spans(M.options.spans)
+  validate_boolean("spans", M.options.spans)
+  validate_boolean("archived", M.options.archived)
   M.options.types = resolve_types(M.options)
   return M.options
 end

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -25,6 +25,15 @@ local LINKS = {
   CodeReviewNoteCount = "Comment",
   CodeReviewNote = "Comment",
   CodeReviewStale = "DiagnosticWarn",
+
+  -- An archived entry drawn on the diff, beneath the code it was about. One step dimmer
+  -- than the live counterpart of each chunk it replaces -- the marker where a queued entry
+  -- carries its annotation type's severity, the prose where it carries `CodeReviewNote` --
+  -- so what has already gone reads as recessive at a glance rather than as a different
+  -- kind of remark. `NonText` is what every colorscheme tunes for the dimmest thing on
+  -- screen, which is exactly what this is.
+  CodeReviewArchived = "Comment",
+  CodeReviewArchivedNote = "NonText",
   CodeReviewTitle = "Title",
   CodeReviewPanelSel = "CursorLine",
   CodeReviewPanelDir = "Directory",

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -209,8 +209,11 @@ end
 ---throughout: context lines are attributed to it, line keys prefer it, an entry's line
 ---numbers prefer it, and opening a file resolves through it. In the unified layout the
 ---second return value is nil, which is what every existing caller already ignores.
+---`notes` is the queue projected onto anchors; `archived` is the archive projected onto the
+---same ones, and is optional -- absent, nil and empty are one case, and the render is then
+---exactly what it was before an archive existed.
 ---@param files CRFile[]
----@param opts { width: integer, before_width: integer|nil, layout: string|nil, icons: table, expanded: table<string, boolean>, reviewed: table<string, string>, notes: table<string, table[]>, types: CRType[] }
+---@param opts { width: integer, before_width: integer|nil, layout: string|nil, icons: table, expanded: table<string, boolean>, reviewed: table<string, string>, notes: table<string, table[]>, archived: table<string, table[]>|nil, types: CRType[] }
 ---@return CRRender after, CRRender|nil before
 function M.build(files, opts)
   local icons = opts.icons
@@ -260,48 +263,84 @@ function M.build(files, opts)
     return r
   end
 
+  ---Append one annotation's virtual lines to `virt`.
+  ---
+  ---A sibling of `note_virt` rather than a loop inside it, deliberately. `note_virt` runs
+  ---once per annotatable row -- ninety thousand times on a large review, almost always to
+  ---answer "nothing here" -- and a nested closure inside it costs that answer measurably
+  ---more: it took `render.build` on 60 files from 17 ms to 23 ms, on the operation every
+  ---resize, expansion, reviewed toggle and scope change pays for.
+  ---@param virt table[]
+  ---@param item table
+  ---@param wrap_to integer|nil
+  ---@param archived boolean Drawn out of the archive rather than out of the queue
+  local function entry_virt(virt, item, wrap_to, archived)
+    local type_def = require("codereview.types").get(opts.types, item.type)
+    local icon = type_def and type_def.icon or "•"
+    -- An archived entry keeps its type's icon, because what kind of finding it was is still
+    -- worth knowing, and gives up that type's colour: severity is an instruction to act,
+    -- and this one has already been acted on.
+    local group = archived and "CodeReviewArchived" or (type_def and type_def.hl or "CodeReviewNote")
+    local text_group = archived and "CodeReviewArchivedNote" or "CodeReviewNote"
+    local prefix = ("   %s "):format(icon)
+    -- Queued entries only. An archived one carries the flag too, because it is persisted
+    -- with the entry, but there it means "this file had moved by the time the batch went" --
+    -- a fact about a queue that no longer exists. Drawn against the code now it reads as a
+    -- claim about the code now, which nothing has checked.
+    local stale = (not archived and item.stale) and "⚠ stale  " or nil
+
+    local body
+    if wrap_to then
+      -- The marker only prefixes the first line, but wrapping the whole note to the
+      -- narrower budget is what makes "nothing is clipped" true by construction rather
+      -- than true of every line except one.
+      local avail = wrap_to - vim.fn.strdisplaywidth(prefix) - (stale and vim.fn.strdisplaywidth(stale) or 0)
+      body = wrap(item.note, math.max(8, avail))
+    else
+      body = vim.split(item.note, "\n", { plain = true })
+    end
+
+    -- A multi-line note becomes multiple virtual lines; the continuation lines are
+    -- indented to the icon so the block reads as one comment.
+    for n, text in ipairs(body) do
+      if n == 1 then
+        local chunks = { { prefix, group } }
+        if stale then
+          chunks[#chunks + 1] = { stale, "CodeReviewStale" }
+        end
+        chunks[#chunks + 1] = { text, text_group }
+        virt[#virt + 1] = chunks
+      else
+        virt[#virt + 1] = { { (" "):rep(#prefix), text_group }, { text, text_group } }
+      end
+    end
+  end
+
   ---The virtual lines an annotated row draws, or nil when nothing is attached to it.
+  ---
+  ---Queued entries first, archived ones beneath them: what is still to send outranks what
+  ---has already gone. Both go into one list and therefore one extmark, so the split
+  ---layout's mirroring -- which holds the opposite pane's place by counting virtual lines --
+  ---keeps working on a count it did not have to learn anything new about.
+  ---
+  ---An anchor carrying nothing at all is the overwhelmingly common case and costs two
+  ---lookups, which is what makes a file the archive says nothing about cost nothing extra to
+  ---render however long that archive is.
   ---@param key string
   ---@param wrap_to integer|nil Pane width to wrap the note to; nil leaves it unwrapped
   ---@return table[]|nil
   local function note_virt(key, wrap_to)
-    local items = opts.notes and opts.notes[key]
-    if not items or #items == 0 then
+    local live = opts.notes and opts.notes[key]
+    local gone = opts.archived and opts.archived[key]
+    if (not live or #live == 0) and (not gone or #gone == 0) then
       return nil
     end
     local virt = {}
-    for _, item in ipairs(items) do
-      local type_def = require("codereview.types").get(opts.types, item.type)
-      local icon = type_def and type_def.icon or "•"
-      local group = type_def and type_def.hl or "CodeReviewNote"
-      local prefix = ("   %s "):format(icon)
-      local stale = item.stale and "⚠ stale  " or nil
-
-      local body
-      if wrap_to then
-        -- The marker only prefixes the first line, but wrapping the whole note to the
-        -- narrower budget is what makes "nothing is clipped" true by construction rather
-        -- than true of every line except one.
-        local avail = wrap_to - vim.fn.strdisplaywidth(prefix) - (stale and vim.fn.strdisplaywidth(stale) or 0)
-        body = wrap(item.note, math.max(8, avail))
-      else
-        body = vim.split(item.note, "\n", { plain = true })
-      end
-
-      -- A multi-line note becomes multiple virtual lines; the continuation lines are
-      -- indented to the icon so the block reads as one comment.
-      for n, text in ipairs(body) do
-        if n == 1 then
-          local chunks = { { prefix, group } }
-          if stale then
-            chunks[#chunks + 1] = { stale, "CodeReviewStale" }
-          end
-          chunks[#chunks + 1] = { text, "CodeReviewNote" }
-          virt[#virt + 1] = chunks
-        else
-          virt[#virt + 1] = { { (" "):rep(#prefix), "CodeReviewNote" }, { text, "CodeReviewNote" } }
-        end
-      end
+    for _, item in ipairs(live or {}) do
+      entry_virt(virt, item, wrap_to, false)
+    end
+    for _, item in ipairs(gone or {}) do
+      entry_virt(virt, item, wrap_to, true)
     end
     return virt
   end

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -35,6 +35,27 @@ local VERSION = 1
 ---directory.
 M.ARCHIVE_LIMIT = 20
 
+---How many times an archive has changed this session.
+---
+---What a projection of the archive onto a diff's anchors can be rebuilt from without a file
+---read. That projection is handed to every repaint, and a repaint runs on every resize,
+---expansion, reviewed toggle and scope change -- so decoding the document there would put
+---the cost of the whole archive back onto the operation bounding extmark emission exists to
+---keep cheap, and it would scale with what is stored rather than with what is drawn.
+---
+---Moved by everything that can change one: a dispatch, which is the only thing that writes
+---an archive, and forgetting a store. Declared here rather than beside them because a Lua
+---local is only in scope below itself, and one of those sits above the archive's own
+---section. Not persisted and meaningless across processes -- what it answers is "has it
+---changed since you last looked", which has no answer before you have looked, and a session
+---reads the archive once anyway.
+local archive_writes = 0
+
+---@return integer
+function M.archive_writes()
+  return archive_writes
+end
+
 ---@param root string
 ---@return string
 function M.path(root)
@@ -201,6 +222,7 @@ function M.clear_global()
   if vim.fn.filereadable(file) == 1 then
     vim.fn.delete(file)
   end
+  archive_writes = archive_writes + 1
 end
 
 --- The archive ------------------------------------------------------------------
@@ -242,6 +264,10 @@ function M.archive_batch(items, target, root)
   local owned, loose = partition(items)
   -- One stamp for the batch, taken once: the two stores are recording the same dispatch.
   local at = os.time()
+  -- Once for the dispatch rather than once per store, and before the writes rather than
+  -- after them: what this says is "an archive is not what you last read", and a partial
+  -- write is already not what you last read.
+  archive_writes = archive_writes + 1
 
   if #loose > 0 then
     local doc = read_global()
@@ -542,6 +568,9 @@ function M.clear(root)
   if vim.fn.filereadable(file) == 1 then
     vim.fn.delete(file)
   end
+  -- The archive went with it, so anything holding a projection of it is holding entries
+  -- that no longer exist -- and would go on drawing them until the next dispatch.
+  archive_writes = archive_writes + 1
 end
 
 return M

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -27,7 +27,8 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@field per_scope table<string, { reviewed: table<string,string>, expanded: table<string,boolean> }>
 ---@field reviewed table<string, string>   Path -> blob at the time it was marked
 ---@field expanded table<string, boolean>
----@field notes table<string, table[]>     Line key -> annotations
+---@field notes table<string, table[]>     Line key -> queued annotations
+---@field archived table<string, table[]>  Line key -> archived entries; empty when off
 ---@field buf integer                     The after pane
 ---@field win integer                     The after pane
 ---@field before_buf integer|nil          nil in the unified layout
@@ -401,6 +402,12 @@ function M.paint(keep_file)
   -- The queue is the source of truth for annotations; the view only ever displays a
   -- projection of it, so there is no second copy to keep in sync.
   V.notes = require("codereview.queue").by_key()
+  -- And the archive is the source of truth for what has already gone, projected the same
+  -- way onto the same anchors. Asked for on every paint rather than cached here, because
+  -- the answer changes on a dispatch this view need not have made -- an **immediate send**
+  -- archives a batch of one without emptying anything -- and the read behind it is a
+  -- comparison until something has written.
+  V.archived = cfg.archived and require("codereview.archive").by_key(V.root) or {}
   -- Both panes from one walk: their row counts and their anchors agree by construction
   -- rather than because two calls happened to be handed the same arguments.
   V.render, V.before_render = render.build(V.files, {
@@ -411,6 +418,7 @@ function M.paint(keep_file)
     expanded = V.expanded,
     reviewed = V.reviewed,
     notes = V.notes,
+    archived = V.archived,
     types = cfg.types,
   })
 
@@ -2142,6 +2150,7 @@ function M.open(spec)
     reviewed = {},
     expanded = {},
     notes = {},
+    archived = {},
     syntax_cache = {},
     collapsed = {},
     buf = buf,

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # timing report at two siz
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 975 cases in ~6 seconds.
+The whole suite is about 1,080 cases in ~6 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -21,7 +21,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | Path | What |
 | --- | --- |
 | `minimal_init.lua` | The only runtimepath is this plugin plus plenary. Also redirects `XDG_STATE_HOME` and neutralises git config. |
-| `helpers.lua` | Fixture builders, notification capture, extmark filters, anchor lookups. |
+| `helpers.lua` | Fixture builders, notification capture, extmark filters, highlight-group sets, anchor lookups. |
 | `fixtures/*.sh` | Build a fixture repository from scratch at a given path. Take a target path; safe to run by hand. |
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
@@ -37,8 +37,8 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | --- | --- |
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
-| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling |
-| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring with no windows; then the binding, annotation parity against the unified layout, and the two intersections nobody else owns |
+| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, and archived entries on the diff: where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them |
+| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, and the two intersections nobody else owns |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
@@ -46,7 +46,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
-| `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, and a document written before the archive existed |
+| `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
 | `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, and the four things it refuses |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
@@ -146,6 +146,24 @@ so the out-of-core language path is still checked locally without ever failing C
   `archive_spec` therefore dispatches in `archive_child.lua`, restarts, and queues one
   through the ordinary capture path. It also asserts that the archive really does hold id
   1, or the case is satisfied by an archive with nothing low enough to collide with.
+- **A dispatch no longer leaves the diff empty.** "No virtual lines are left" was the natural
+  proxy for "the queue emptied and the view repainted", and it stopped being true the moment
+  archived entries were drawn: the same remarks are still on screen, dimmed, which is the
+  whole feature. `payload_spec` and `delivery_spec` now assert the view's projection of the
+  *queue* is empty and that the rows below the code carry the archive's groups rather than an
+  annotation type's — `helpers.virt_groups` is what reads them.
+- **"With the flag off the diff renders exactly as today" needs the render from before
+  anything was archived.** Asserting that no archived group appears passes with the flag
+  ignored entirely and the projection merely empty, which is not the claim. `render_spec`
+  keeps a deep copy of `V.render.marks` taken before the first `archive_batch` and compares
+  the flag-off render against it, mark for mark. The same copy is what "a file carrying no
+  archived entries costs nothing extra" is asserted against, filtered to the other files —
+  and that comparison is guarded as non-empty, because an anchor lookup that stopped
+  resolving would empty both sides at once.
+- **The projection is memoised on a write count, so reaching past the accessors goes stale.**
+  `archive.by_key` rebuilds only when `state.archive_writes` has moved, which `archive_batch`,
+  `clear` and `clear_global` are what move. Deleting a state file directly — or writing one by
+  hand — leaves a view drawing entries that no longer exist until the next dispatch.
 - **`git stash create` on a clean tree returns nothing**, which is a case rather than an
   edge to assume away: the snapshot falls back to `HEAD`. `archive_spec` builds a second
   fixture and resets it hard, because the shared one is dirty by design and can never

--- a/tests/codereview/archive_spec.lua
+++ b/tests/codereview/archive_spec.lua
@@ -176,6 +176,93 @@ describe("an annotation queued after the restart", function()
   end)
 end)
 
+-- Where the id collision becomes visible, and the only place it can be asserted: both
+-- entries are on one anchor, drawn one above the other, and the counter that has to keep
+-- them apart did not survive the process that dispatched the first.
+--
+-- The block above pinned the seeding against the record. This pins it against what a
+-- reviewer sees and acts on -- which is what the seeding is for, and what nothing before
+-- archived entries were drawn could have exercised.
+describe("an anchor carrying both a queued and an archived entry", function()
+  local view = require("codereview.view")
+  local annotate = require("codereview.annotate")
+
+  local archived_entry = state.archive(root)[1].entries[1]
+  local queued_entry = assert(queue.all()[1], "the block above queued nothing")
+
+  it("is one anchor, reached by two sessions", function()
+    assert.same(archived_entry.key, queued_entry.key)
+  end)
+
+  -- Without the seed both are id 1, and every claim below about which of them `x` acted on
+  -- is a claim about two things the plugin cannot tell apart.
+  it("gives the two of them different ids", function()
+    assert.is_true(
+      archived_entry.id ~= queued_entry.id,
+      ("both entries carry id %s"):format(vim.inspect(queued_entry.id))
+    )
+  end)
+
+  codereview.open("branch")
+  local V = assert(view.current())
+  local header = V.render.file_rows[assert(h.file_index(V, "src/main.lua"))]
+
+  ---The virtual lines the diff draws on the file header.
+  ---@return table[]
+  local function drawn()
+    for _, m in ipairs(h.virt_marks(V)) do
+      if m[2] == header - 1 then
+        return m[4].virt_lines
+      end
+    end
+    return {}
+  end
+
+  ---@param line table[]
+  ---@return string
+  local function text_of(line)
+    local out = {}
+    for _, chunk in ipairs(line) do
+      out[#out + 1] = chunk[1]
+    end
+    return table.concat(out)
+  end
+
+  it("draws both, what is still to send above what has already gone", function()
+    local virt = drawn()
+    assert.same(2, #virt, vim.inspect(virt))
+    assert.is_truthy(text_of(virt[1]):find("from this session", 1, true), text_of(virt[1]))
+    assert.is_truthy(text_of(virt[2]):find("dispatched by an earlier session", 1, true), text_of(virt[2]))
+  end)
+
+  vim.api.nvim_win_set_cursor(V.win, { header, 0 })
+  local msgs, restore = h.capture_notify()
+  annotate.drop()
+  restore()
+
+  it("drops the queued entry", function()
+    assert.same(0, queue.count())
+    assert.is_true(h.notified(msgs, "Dropped bug note"), vim.inspect(msgs))
+  end)
+
+  -- The archive is not the queue's other half, and nothing that acts on the queue may reach
+  -- into it: an archived entry says something already happened, and no key revises that.
+  it("leaves the archived entry in the archive", function()
+    assert.same(1, #state.archive(root)[1].entries)
+    assert.same(archived_entry.id, state.archive(root)[1].entries[1].id)
+  end)
+
+  it("leaves the archived entry on the diff", function()
+    local virt = drawn()
+    assert.same(1, #virt, vim.inspect(virt))
+    assert.is_truthy(text_of(virt[1]):find("dispatched by an earlier session", 1, true), text_of(virt[1]))
+  end)
+
+  -- Every block below submits, and a view open over them would repaint against an archive
+  -- they are deliberately overflowing.
+  codereview.close()
+end)
+
 describe("the snapshot a dispatch minted", function()
   local snapshot = assert(state.archive(root)[1].snapshot, "the batch was archived without one")
 

--- a/tests/codereview/delivery_spec.lua
+++ b/tests/codereview/delivery_spec.lua
@@ -226,9 +226,16 @@ describe("a batch submitted from a review view", function()
     assert.is_truthy(header:find("reviewed)", 1, true), header)
   end)
 
+  -- What went is still on the diff, dimmed, which is the archive's whole point -- so the
+  -- repaint is observable as the queue's own projection being empty while the rows below
+  -- the code are drawn in the archive's groups rather than a type's.
   it("empties the queue and repaints what is left", function()
     assert.same(0, queue.count())
-    assert.same(0, #h.virt_marks(assert(require("codereview.view").current())))
+    local V = assert(require("codereview.view").current())
+    assert.same({}, V.notes)
+    local groups = h.virt_groups(V)
+    assert.is_true(groups.CodeReviewArchived or false, vim.inspect(vim.tbl_keys(groups)))
+    assert.is_nil(groups.CodeReviewBug, vim.inspect(vim.tbl_keys(groups)))
   end)
 end)
 

--- a/tests/codereview/payload_spec.lua
+++ b/tests/codereview/payload_spec.lua
@@ -249,8 +249,13 @@ describe("submitting to a routed target", function()
     assert.same(0, queue.count())
   end)
 
-  it("repaints the view with no notes left", function()
-    assert.same(0, #h.virt_marks(V))
+  -- A dispatched batch does not leave the diff, it goes dim: the same remarks are drawn
+  -- again out of the archive. So "nothing left" is a claim about the *queue's* projection,
+  -- which only a repaint refreshes, and about which groups the rows still carry.
+  it("repaints the view with nothing queued left on it", function()
+    assert.same({}, V.notes)
+    local groups = h.virt_groups(V)
+    assert.is_true(groups.CodeReviewArchived or false, vim.inspect(vim.tbl_keys(groups)))
   end)
 end)
 

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -3,11 +3,16 @@
 local h = require("tests.helpers")
 
 h.ui(110, 40)
-h.cd_fixture("mkfixture")
+local fixture = h.cd_fixture("mkfixture")
+local root = assert(vim.uv.fs_realpath(fixture))
 
 require("codereview").setup({})
 local view = require("codereview.view")
 local render = require("codereview.render")
+local archive = require("codereview.archive")
+local config = require("codereview.config")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
 
 describe("the anchor map", function()
   view.open("branch")
@@ -158,6 +163,168 @@ describe("scope cycling", function()
     local V = view.current()
     assert.is_truthy(vim.wo[V.win].winbar:find("branch vs master", 1, true))
   end)
+end)
+
+-- Archived entries on the diff: what has already been reported, drawn beneath the code it
+-- was about so a reviewer who keeps going while an agent works does not report it twice.
+--
+-- Everything here is asserted through extmark metadata and highlight *groups*. The colours
+-- a colorscheme resolves those to are deliberately not tested, and never have been.
+describe("archived entries", function()
+  local V = view.current()
+  local path = "src/main.lua"
+  local fi = assert(h.file_index(V, path))
+  local header = V.render.file_rows[fi]
+  local line_row = assert(h.line_row(V, path))
+  local anchor = V.render.anchors[line_row]
+  local ln = V.files[anchor.file].hunks[anchor.hunk].lines[anchor.line]
+  local line_key = render.line_key(path, ln)
+  local file_key = render.file_key(path)
+
+  ---The virtual lines the buffer's extmark on `row` carries, or nil.
+  ---
+  ---Read out of the buffer rather than out of the render, because what a reviewer sees is
+  ---what was emitted -- and emission is bounded by the viewport. `src/main.lua` is the
+  ---first file in this fixture, so its rows are inside the first band whatever the bound is.
+  ---@param row integer 1-indexed
+  ---@return table[]|nil
+  local function virt_at(row)
+    for _, m in ipairs(h.virt_marks(V)) do
+      if m[2] == row - 1 then
+        return m[4].virt_lines
+      end
+    end
+  end
+
+  ---The text of one virtual line, chunks joined.
+  ---@param line table[]
+  ---@return string
+  local function text_of(line)
+    local out = {}
+    for _, chunk in ipairs(line) do
+      out[#out + 1] = chunk[1]
+    end
+    return table.concat(out)
+  end
+
+  ---Every mark in a render that belongs to a row of some *other* file.
+  ---@param marks table[]
+  ---@return table[]
+  local function marks_elsewhere(marks)
+    return vim.tbl_filter(function(m)
+      local a = V.render.anchors[m.row + 1]
+      return a ~= nil and a.file ~= fi
+    end, marks)
+  end
+
+  -- Taken before anything is archived, so "the flag off renders exactly as it does today"
+  -- is a comparison against what today is rather than a claim about it.
+  local pristine = vim.deepcopy(V.render.marks)
+
+  it("costs a review with an empty archive nothing to open", function()
+    assert.same({}, archive.by_key(root))
+    assert.same(0, #h.virt_marks(V))
+  end)
+
+  state.archive_batch({
+    { id = 1, type = "bug", kind = "file", path = path, key = file_key, note = "whole file, already sent" },
+    {
+      id = 2,
+      type = "nitpick",
+      kind = "line",
+      path = path,
+      key = line_key,
+      first = ln.new or ln.old,
+      note = "this line, already sent",
+    },
+  }, "agent", root)
+  view.paint()
+
+  it("hangs one about a whole file off that file's header, as a live one does", function()
+    local virt = assert(virt_at(header), "nothing was drawn on the file header")
+    assert.same(1, #virt)
+    assert.is_truthy(text_of(virt[1]):find("whole file, already sent", 1, true))
+  end)
+
+  it("draws one about a line at that line's own anchor", function()
+    local virt = assert(virt_at(line_row), "nothing was drawn on the line")
+    assert.is_truthy(text_of(virt[1]):find("this line, already sent", 1, true))
+  end)
+
+  it("draws them in groups of their own, not in the annotation type's", function()
+    local groups = h.virt_groups(V)
+    assert.is_true(groups.CodeReviewArchived or false, vim.inspect(vim.tbl_keys(groups)))
+    assert.is_true(groups.CodeReviewArchivedNote or false, vim.inspect(vim.tbl_keys(groups)))
+    -- The entries archived above are a bug and a nitpick; drawn live, their markers would
+    -- carry those types' groups, which is what these replace.
+    assert.is_nil(groups.CodeReviewBug, vim.inspect(vim.tbl_keys(groups)))
+    assert.is_nil(groups.CodeReviewNitpick, vim.inspect(vim.tbl_keys(groups)))
+  end)
+
+  -- Every group here is a `default = true` link into whatever colorscheme is active, which
+  -- is the rule every other group in `hl.lua` follows and the only reason overriding one
+  -- works. Asserted as a link to a defined group, never as a resolved colour.
+  it("links those groups into the colorscheme rather than defining colours", function()
+    for _, group in ipairs({ "CodeReviewArchived", "CodeReviewArchivedNote" }) do
+      local def = vim.api.nvim_get_hl(0, { name = group })
+      assert.is_truthy(def.link, ("%s is not a link: %s"):format(group, vim.inspect(def)))
+      assert.is_truthy(vim.api.nvim_get_hl(0, { name = def.link }), ("%s links nowhere"):format(group))
+    end
+  end)
+
+  -- The cost this slice was blocked on #78 for. A repaint has to grow with what is drawn,
+  -- not with what is stored, and a file the archive says nothing about is where that shows.
+  it("leaves a file carrying no archived entries exactly as it was", function()
+    local elsewhere = marks_elsewhere(pristine)
+    -- Or the comparison below holds over nothing, which is the way a set comparison goes
+    -- quiet: an anchor lookup that stopped resolving would empty both sides at once.
+    assert.is_true(#elsewhere > 0, "no marks belong to any other file")
+    assert.same(elsewhere, marks_elsewhere(V.render.marks))
+  end)
+
+  -- What is still to send outranks what has already gone, so a reviewer reading down from
+  -- the code meets the live remark first.
+  queue.add({
+    id = 99,
+    type = "bug",
+    kind = "file",
+    path = path,
+    abs_path = vim.fs.joinpath(root, path),
+    key = file_key,
+    note = "still to send",
+  })
+  view.paint()
+
+  it("draws a queued and an archived entry on one anchor, queued first", function()
+    local virt = assert(virt_at(header))
+    assert.same(2, #virt)
+    assert.is_truthy(text_of(virt[1]):find("still to send", 1, true))
+    assert.is_truthy(text_of(virt[2]):find("whole file, already sent", 1, true))
+  end)
+
+  it("keeps the live entry in its own type's group beside the archived one", function()
+    local groups = h.virt_groups(V)
+    assert.is_true(groups.CodeReviewBug or false, vim.inspect(vim.tbl_keys(groups)))
+    assert.is_true(groups.CodeReviewArchived or false, vim.inspect(vim.tbl_keys(groups)))
+  end)
+
+  -- Not merely "nothing archived is drawn": with the flag off the render has to be the one
+  -- this repository produced before an archive existed, mark for mark.
+  queue.clear()
+  config.get().archived = false
+  view.paint()
+
+  it("renders exactly as it does today when the flag is off", function()
+    assert.same(pristine, V.render.marks)
+  end)
+
+  it("draws nothing from the archive at all when the flag is off", function()
+    assert.same({}, V.archived)
+    assert.same(0, #h.virt_marks(V))
+  end)
+
+  config.get().archived = true
+  view.paint()
 end)
 
 describe("line keys", function()

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -367,6 +367,95 @@ describe("where a note is drawn", function()
   end)
 end)
 
+-- Archived entries take the same anchors live ones do, so they need no rule of their own
+-- about which pane draws them: the key is already sided, and that side is the pane. They
+-- also ride inside the *same* virtual-line block as the live entries on that anchor, which
+-- is what keeps the mirroring that holds the opposite pane's place working on a count that
+-- never had to learn they exist.
+describe("where an archived entry is drawn", function()
+  local path = "src/main.lua"
+  local del_key = render.line_key(path, { side = "del", old = 2 })
+  local add_key = render.line_key(path, { side = "add", new = 2 })
+
+  ---The row a pane draws one side of `src/main.lua`'s line 2 on.
+  ---@param rendered CRRender
+  ---@param field "old"|"new"
+  ---@return integer
+  local function row_of_line(rendered, field)
+    for r = 1, #rendered.lines do
+      local a = rendered.anchors[r]
+      if a.kind == "line" and files[a.file].path == path and files[a.file].hunks[a.hunk].lines[a.line][field] == 2 then
+        return r
+      end
+    end
+    error("no row for " .. path .. " line 2 " .. field)
+  end
+
+  it("draws one on a deleted line in the before pane, and holds the after pane's place", function()
+    local after, before = build({ archived = { [del_key] = { { note = "already sent", type = "bug" } } } })
+    local row = row_of_line(before, "old")
+    local bvirt, avirt = virt_at(before, row), virt_at(after, row)
+    assert.is_truthy(bvirt[1][#bvirt[1]][1]:find("already sent", 1, true))
+    assert.same(#bvirt, #avirt)
+    assert.same("", avirt[1][1][1])
+  end)
+
+  it("hangs one about a whole file off the after pane's header", function()
+    local after, before =
+      build({ archived = { [render.file_key(path)] = { { note = "all of it, sent", type = "bug" } } } })
+    local row = after.file_rows[index_of(path)]
+    assert.is_truthy(virt_at(after, row)[1][#virt_at(after, row)[1]][1]:find("all of it, sent", 1, true))
+    assert.same(#virt_at(after, row), #virt_at(before, row))
+  end)
+
+  it("draws a queued entry above an archived one on the same anchor, in both panes", function()
+    local after, before = build({
+      notes = { [del_key] = { { note = "still to send", type = "bug" } } },
+      archived = { [del_key] = { { note = "already sent", type = "bug" } } },
+    })
+    local row = row_of_line(before, "old")
+    local bvirt, avirt = virt_at(before, row), virt_at(after, row)
+    assert.same(2, #bvirt)
+    assert.is_truthy(bvirt[1][#bvirt[1]][1]:find("still to send", 1, true))
+    assert.is_truthy(bvirt[2][#bvirt[2]][1]:find("already sent", 1, true))
+    -- Both entries cost the after pane the same height they cost the before pane, or every
+    -- row below this one reads against different code in the two panes.
+    assert.same(#bvirt, #avirt)
+  end)
+
+  it("gives it groups of its own beside a live entry's type", function()
+    local after = build({
+      notes = { [add_key] = { { note = "still to send", type = "bug" } } },
+      archived = { [add_key] = { { note = "already sent", type = "bug" } } },
+    })
+    local groups = {}
+    for _, m in ipairs(after.marks) do
+      for _, line in ipairs(m.opts.virt_lines or {}) do
+        for _, chunk in ipairs(line) do
+          groups[chunk[2]] = true
+        end
+      end
+    end
+    assert.is_true(groups.CodeReviewBug or false, vim.inspect(vim.tbl_keys(groups)))
+    assert.is_true(groups.CodeReviewArchived or false, vim.inspect(vim.tbl_keys(groups)))
+    assert.is_true(groups.CodeReviewArchivedNote or false, vim.inspect(vim.tbl_keys(groups)))
+  end)
+
+  -- The flag is persisted with the entry, so it is there to read, and it says the file had
+  -- moved by the time the batch went -- a fact about a queue that no longer exists. Drawn
+  -- against the code now it reads as a claim about the code now, which nothing has checked.
+  it("never draws an archived entry's stale flag", function()
+    local after = build({ archived = { [add_key] = { { note = "old", type = "bug", stale = true } } } })
+    for _, m in ipairs(after.marks) do
+      for _, line in ipairs(m.opts.virt_lines or {}) do
+        for _, chunk in ipairs(line) do
+          assert.is_not.same("CodeReviewStale", chunk[2])
+        end
+      end
+    end
+  end)
+end)
+
 describe("note text in a narrow pane", function()
   local long = "a remark long enough that it cannot possibly fit inside a single narrow "
     .. "column, which is exactly the case a virtual line silently truncates because it "

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -163,6 +163,25 @@ function M.virt_marks(view)
   end, M.extmarks(view))
 end
 
+---The highlight groups the virtual lines on a view's diff are drawn in, as a set.
+---
+---What tells a queued annotation from an archived one without reading a colour: an entry
+---drawn out of the queue carries its annotation type's group, and one drawn out of the
+---archive carries the archive's own.
+---@param view CRView
+---@return table<string, boolean>
+function M.virt_groups(view)
+  local groups = {}
+  for _, m in ipairs(M.virt_marks(view)) do
+    for _, line in ipairs(m[4].virt_lines) do
+      for _, chunk in ipairs(line) do
+        groups[chunk[2]] = true
+      end
+    end
+  end
+  return groups
+end
+
 ---Extmarks emitted by the treesitter replay.
 ---@param view CRView
 ---@return table[]


### PR DESCRIPTION
A reviewer who keeps working while the agent works is looking at a **review view** with no
memory of what it already sent, so the same finding gets annotated twice. Archived **entries**
now stay on the diff, projected onto their **anchors** exactly as live ones are, and drawn
dimmed beneath the code they were about.

They draw in **every scope**, not only `since-batch` — what has already been said is worth
knowing wherever you are. An anchor carrying both a queued and an archived entry draws both,
the queued one first: what is still to send outranks what has gone. `archived = false` turns
them off wholesale, and the diff then renders exactly as it did before the archive existed.

## How it is put together

- **`archive.by_key`** projects the repository's archive onto anchor keys, the same shape
  `queue.by_key` produces. No key is computed — an entry has carried its anchor since it was
  captured, which is what makes an archived entry land where the live one stood.
- **`render.build` takes a second table**, and `note_virt` emits live entries then archived
  ones into **one** virtual-line block. One block rather than two is what keeps the split
  layout's mirroring — which holds the opposite pane's place by *counting* virtual lines —
  working on a count that never had to learn they exist.
- **Two highlight groups of their own**, `CodeReviewArchived` and `CodeReviewArchivedNote`,
  both `default = true` links, one step dimmer than the live counterpart of each chunk they
  replace. An archived entry's `stale` flag is deliberately not drawn: it describes a queue
  that no longer exists.

## Cost, which is what #78 had to land first for

The acceptance criterion is that repaint scales with the entries *drawn*, not with the size
of the archive. Two things hold it:

- The projection is memoised on `state.archive_writes`, a count only a dispatch (or a
  cleared store) moves. A repaint pays two comparisons; recomputing at the moments the view
  knows about instead would miss an **immediate send**, which archives a batch of one with no
  repaint of its own.
- An anchor with nothing on it costs two table lookups. `render_spec` pins that a file the
  archive says nothing about renders mark for mark as it did before.

One measured surprise, now in `docs/design-notes.md`: folding the per-entry work into a
nested closure inside `note_virt` — which reads better, and whose early return means the
closure is never created — took `render.build` on 60 files from 17 ms to 23 ms. That
function runs once per annotatable row. Hoisted to a sibling taking the accumulator as an
argument, it is back under the original. `make perf`'s repaint line is a single sample and
hid it; repeated `render.build` calls did not.

## The id collision

This is where it becomes visible, so this is where it is asserted. `archive_spec` already
dispatches in a child and restarts; it now opens a review on the anchor that holds both the
archived entry (id 1) and the one queued after the restart, and pins that their ids differ,
that `x` drops the queued one, and that the archived one survives in the archive and on the
diff. Removing `queue.seed` reds two cases.

## Verification

`make all` — 29 specs, 1079 cases, green (trunk was 1058). Removing the projection reds 9
cases across `render_spec`, `archive_spec`, `delivery_spec` and `payload_spec`.

`payload_spec` and `delivery_spec` each had a case using "no virtual lines left" as the proxy
for "the queue emptied and the view repainted". That proxy is no longer true by design — the
same remarks are still on screen, dimmed — so both now assert the view's projection of the
*queue* is empty and that the rows carry the archive's groups rather than an annotation
type's.

Closes #73