### PR TITLE
feat(state): say whether an archived entry's file has moved

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -176,10 +176,20 @@ _Avoid_: hook, callback, plugin, provider
 ### Staleness
 
 **Blob**:
-The hash of a file's contents at the moment an annotation was captured. The key staleness is
-judged against.
+The hash of a file's contents at a moment worth comparing against — when an annotation was
+captured, or when a batch was **dispatched**. The key both **stale** and **touched** are
+judged with.
 
 **Stale**:
 Said of an annotation whose file has changed since it was captured, so its line numbers may
 no longer mean what they did.
 _Avoid_: dirty, outdated, invalid
+
+**Touched**:
+Said of an archived annotation whose file has changed since its batch was **dispatched** —
+per file, never per **range**. Distinct from **stale**, which is the same comparison against
+a different blob and means something else entirely: stale says *my note may be wrong*,
+touched says *the agent has been here*. The two are reported separately and must never
+become one flag. Deliberately not _addressed_: the plugin knows the file moved, not that
+anyone read the note, agreed with it or acted on it.
+_Avoid_: addressed, handled, resolved, done

--- a/README.md
+++ b/README.md
@@ -397,6 +397,41 @@ Their two highlight groups are their own — `CodeReviewArchived` for the marker
 here, so a colorscheme can say how dim "already sent" looks. `archived = false` turns them
 off wholesale, and the diff then renders exactly as it did before the archive existed.
 
+### Where the agent has and has not been
+
+Each entry of the **last** batch says whether its file has changed since that batch was
+dispatched — `file changed` or `file unchanged` beside the note — and the winbar tallies the
+ones that have not:
+
+```
+ Code review · branch vs master · 2/7 reviewed · +40 -12 · 1 note · 2 untouched · → janus
+```
+
+`2 untouched` is the answer to *did it ignore something*, and it is exact on the case that
+matters: a file the agent never opened. The comparison is **per file**, against the snapshot
+the batch went out with — the same commit `since-batch` diffs against, so a file the tally
+calls touched is exactly a file that scope shows you.
+
+The word is *touched*, not *addressed*. The plugin knows the file moved. It does not know
+that anyone read your note, agreed with it, or acted on it, and it will not imply otherwise.
+It is also not **staleness**: that is the same kind of comparison against a different blob,
+it is about entries still in the queue, and it means *this note may now be wrong* rather than
+*something happened here*. The two are never merged, and an archived entry never shows a
+stale flag.
+
+Three things are left unjudged rather than guessed at — a file the current scope does not
+cover, a file that was untracked when the batch went (a snapshot does not record those), and
+a **bare note**, which is about no file at all. A file *deleted* since the dispatch counts as
+touched. Nothing judged means no segment at all rather than a zero to misread.
+
+That the scope decides who is judged is why the tally reads `0 untouched` inside
+`since-batch`: that scope shows you exactly the files that moved, so every entry it covers is
+touched by definition, and the ones you are looking for are the ones it is not showing.
+`branch` and `worktree` are where the number earns its keep.
+
+`CodeReviewTouched` and `CodeReviewUntouched` are the groups, and `archived = false` turns
+the tally off along with everything else.
+
 ### The payload
 
 Grouped by type, in the configured order, most actionable first, with anything untyped
@@ -537,7 +572,8 @@ opts = {
   max_syntax_bytes = 256 * 1024,   -- skip syntax above this size
   layout = "unified",              -- "unified" or "split"; validated at setup
   spans = true,                    -- emphasise what changed inside a changed line
-  archived = true,                 -- draw already-dispatched entries on the diff, dimmed
+  archived = true,                 -- draw already-dispatched entries on the diff, dimmed,
+                                   -- and tally the untouched ones on the winbar
   panel = { enabled = true, width = 34, position = "left" },
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
             collapsed = "▸", expanded = "▾", change_bar = "▌" },

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -454,6 +454,55 @@ abandoned.
 
 Wire |codereview-opt-compose| to replace this composer with your own.
 
+What you already reported                             *codereview-archived*
+
+A dispatched batch does not leave the review view. Its entries keep the
+anchors they were bound to and are drawn dimmed beneath the code they were
+about, in every scope rather than only |codereview-since-batch| -- a reviewer
+who keeps going while the agent works is otherwise looking at a diff with no
+memory of what it already sent, and reports the same finding twice.
+
+An anchor carrying both draws the queued entry first: what is still to send
+outranks what has gone. `x` there drops the queued one and never the archived
+one, for the same reason |:CodeReviewLastBatch| is read-only. `archived =
+false` turns the whole of this off, and the diff then renders exactly as it
+did before the archive existed.
+
+Touched and untouched                                  *codereview-touched*
+
+Each entry of the *last* batch says whether its file has changed since that
+batch was dispatched -- `file changed` or `file unchanged` beside the note --
+and the winbar tallies the ones that have not: >
+    Code review · branch vs master · 2/7 reviewed · +40 -12 · 2 untouched
+<
+`2 untouched` answers "did it ignore something", and it is exact on the case
+that matters: a file the agent never opened. The comparison is per file, made
+against the snapshot the batch went out with -- the same commit
+|codereview-since-batch| diffs against, so a file the tally calls touched is
+exactly a file that scope shows you. A file deleted since the dispatch counts
+as touched.
+
+The word is *touched*, not *addressed*. The plugin knows the file moved. It
+does not know that anyone read your note, agreed with it or acted on it.
+
+It is also not staleness (|codereview-persistence|): that is the same kind of
+comparison against a different blob, it is about entries still in the queue,
+and it means "this note may now be wrong" rather than "something happened
+here". The two are never merged, and an archived entry never draws a stale
+flag.
+
+Three things are left unjudged rather than guessed at, because absence is not
+evidence: a file the current scope does not cover, a file that was untracked
+when the batch went (a snapshot records none), and a bare note, which is about
+no file at all. Nothing judged means no segment on the winbar rather than a
+zero to misread.
+
+That the scope decides who is judged is why the tally reads `0 untouched`
+inside |codereview-since-batch|: that scope shows exactly the files that
+moved, so every entry it covers is touched by definition, and the ones you are
+looking for are the ones it is not showing. `branch` and `worktree` are where
+the number earns its keep.
+
 ==============================================================================
 7. CAPTURE                                              *codereview-capture*
 
@@ -701,6 +750,7 @@ Defaults: >
       max_syntax_bytes = 256 * 1024,
       layout = "unified",
       spans = true,
+      archived = true,
       panel = { enabled = true, width = 34, position = "left" },
       icons = {
         reviewed = "✓", annotated = "●", unreviewed = "○",
@@ -720,6 +770,11 @@ default. On a 12,000-line diff it lengthens opening a review by roughly a
 third and a repaint by nothing at all, because the work is done once per git
 read rather than every time the view is drawn.
 
+`archived` draws already-dispatched entries on the diff and tallies the
+untouched ones on the winbar (|codereview-archived|, |codereview-touched|).
+It is on by default and coarse on purpose: off is the whole history off --
+nothing drawn, nothing tallied and no `git` spent judging.
+
 ==============================================================================
 10. HIGHLIGHTS                                        *codereview-highlights*
 
@@ -735,8 +790,17 @@ defines, so overriding any of them works without the plugin fighting back: >
     CodeReviewFileHeader   -> Title
     CodeReviewFileReviewed -> Comment
     CodeReviewHunkHeader   -> Special
+    CodeReviewSep          -> WinSeparator
+    CodeReviewTitle        -> Title
     CodeReviewNote         -> Comment
+    CodeReviewNoteCount    -> Comment
     CodeReviewStale        -> DiagnosticWarn
+    CodeReviewArchived     -> Comment
+    CodeReviewArchivedNote -> NonText
+    CodeReviewTouched      -> NonText
+    CodeReviewUntouched    -> DiagnosticHint
+    CodeReviewQueueIndex   -> LineNr
+    CodeReviewQueueState   -> Comment
     CodeReviewPanelDir     -> Directory
     CodeReviewPanelSel     -> CursorLine
     CodeReviewBug          -> DiagnosticError

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -272,6 +272,53 @@ it reads as a claim about the code *now*, which nothing has checked. Whether an 
 entry's file has moved since its batch was dispatched is a different question, judged
 against a different blob, and it has a word of its own.
 
+**Touchedness and staleness share a primitive and must not share a rule.** Both are blob
+comparisons, and that is the whole of what they have in common. Staleness judges a *queued*
+entry against the blob it was **captured** with and means *my note may be wrong*;
+touchedness judges an *archived* entry against the working tree as it stood when its batch
+was **dispatched**, and means *the agent has been here*. One flag would say both and
+neither — an entry captured on Monday, edited by the reviewer on Tuesday and dispatched on
+Wednesday is stale and untouched at the same time. That is also why touchedness is judged
+against the **snapshot** rather than against the entry's own `blob`: reusing that field
+makes the comparison arithmetically identical to the staleness one, which is how two rules
+become one by accident instead of by decision, and it counts the reviewer's own edits
+between annotating and submitting as the agent's work. Separate functions on `state`,
+separate highlight groups, reported separately — a sentence for staleness, a winbar segment
+for touchedness — and an archived entry's persisted `stale` flag is not drawn at all.
+
+**It is judged per file, and against the snapshot the scope already diffs against.** Mapping
+an entry's line range through the diff since the snapshot was considered and settled against:
+considerably more machinery, and the case it improves stays fuzzy either way. *The agent
+never opened this file* is exact under the per-file rule, and it is the question a reviewer
+actually has after submitting. Reading the dispatch-time blobs out of the snapshot rather
+than stamping a second copy onto each entry is what keeps `since-batch` and the untouched
+tally describing one dispatch by construction: a file the tally calls touched is exactly a
+file that scope shows.
+
+**Three things are left unjudged rather than guessed at**, and each absence is silence rather
+than a verdict: a file the current scope does not cover (absence from a scope is not evidence
+that anything changed — the rule the reviewed-mark reconciliation already holds), a path the
+snapshot does not carry (a file untracked at dispatch, which `git stash create` never
+recorded), and a **bare note**, which is about no file and lives in the store that needs no
+root. Only the *newest* batch is judged: an older one went out against an older snapshot, and
+"has this moved since the last dispatch" is not a question about it.
+
+**The scope rule is why the tally reads `0 untouched` in `since-batch`, and that is not a
+bug to special-case away.** That scope shows exactly the files that moved since the snapshot,
+so every archived entry it covers is touched by definition and the ones a reviewer is looking
+for are the ones it is not showing. Suppressing the segment there would be a case in the view
+for one scope, which is the thing `since-batch` was built to avoid — it resolves like every
+other scope and nothing downstream knows its name. The number earns its keep in `branch` and
+`worktree`, where the whole review is on screen.
+
+**The tally is computed where the diff is read, never where the winbar is built.** That bar
+is rebuilt by every paint, and a paint runs on every resize — two `git` invocations there
+would be a resize handler shelling out. It is judged on opening, refreshing, changing scope
+and the view's own submit, and the number is read off the view. The view also records the
+`archive_writes` count it judged at: an **immediate send** archives a batch of one with no
+repaint of its own, so a paint that finds the count moved drops the verdicts and the segment
+with them, rather than reporting a number about a batch that has been overtaken.
+
 **`git stash create` mints a commit and does nothing else.** No ref moves, the index is not
 touched and the working tree is not reverted, which is the only reason it is safe to run
 behind a submit. Two consequences worth knowing before reading a snapshot back: a clean

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -30,7 +30,7 @@ change there is felt through.
 | `queue.lua` | The queue itself — module-level, not per-view, so reopening a view scatters nothing | stateful (memory) |
 | `queue_float.lua` | The float over the queue: an entry as a run of bar-marked rows, and the keys that drop, jump, copy and submit | stateful (float) |
 | `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk | pure |
-| `state.lua` | Persisted review progress, and the blob-hash check that makes persisting safe | stateful (disk) |
+| `state.lua` | Persisted review progress, and the blob comparisons over it — staleness, and touchedness kept in a function of its own | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
 | `view.lua` | The review view: buffers, windows, navigation, both layouts | stateful (windows) |

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -33,9 +33,13 @@ M.defaults = {
   ---scope, not only `since-batch`: what has already been said is worth knowing wherever
   ---you are.
   ---
-  ---On by default, and coarse on purpose -- off is the whole history off, and renders the
-  ---diff exactly as it did before the archive existed. There is no keymap beside it yet;
-  ---one can be added if the switch proves too blunt.
+  ---Each of them says whether its file has been **touched** since its batch went, and the
+  ---winbar tallies how many have not.
+  ---
+  ---On by default, and coarse on purpose -- off is the whole history off: nothing drawn,
+  ---nothing tallied, no git spent judging, and the diff renders exactly as it did before
+  ---the archive existed. There is no keymap beside it yet; one can be added if the switch
+  ---proves too blunt.
   archived = true, ---@type boolean
   panel = {
     enabled = true,

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -34,6 +34,15 @@ local LINKS = {
   -- screen, which is exactly what this is.
   CodeReviewArchived = "Comment",
   CodeReviewArchivedNote = "NonText",
+
+  -- Whether an archived entry's file has moved since its batch went. Deliberately *not*
+  -- `CodeReviewStale`'s group: the two answer different questions about different entries,
+  -- and one colour for both is the merge the rule itself refuses. The unremarkable answer
+  -- takes the dimmest group there is -- a file the agent changed is what reading an agent's
+  -- work expects -- and the one worth noticing takes the quietest diagnostic rather than a
+  -- warning, because a file nothing happened to is not yet a problem.
+  CodeReviewTouched = "NonText",
+  CodeReviewUntouched = "DiagnosticHint",
   CodeReviewTitle = "Title",
   CodeReviewPanelSel = "CursorLine",
   CodeReviewPanelDir = "Directory",

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -211,9 +211,11 @@ end
 ---second return value is nil, which is what every existing caller already ignores.
 ---`notes` is the queue projected onto anchors; `archived` is the archive projected onto the
 ---same ones, and is optional -- absent, nil and empty are one case, and the render is then
----exactly what it was before an archive existed.
+---exactly what it was before an archive existed. `touched` is what the reconciliation made
+---of those archived entries, keyed by entry id, and is optional for the same reason: an id
+---it says nothing about is an entry nothing has judged.
 ---@param files CRFile[]
----@param opts { width: integer, before_width: integer|nil, layout: string|nil, icons: table, expanded: table<string, boolean>, reviewed: table<string, string>, notes: table<string, table[]>, archived: table<string, table[]>|nil, types: CRType[] }
+---@param opts { width: integer, before_width: integer|nil, layout: string|nil, icons: table, expanded: table<string, boolean>, reviewed: table<string, string>, notes: table<string, table[]>, archived: table<string, table[]>|nil, touched: table<integer, boolean>|nil, types: CRType[] }
 ---@return CRRender after, CRRender|nil before
 function M.build(files, opts)
   local icons = opts.icons
@@ -283,18 +285,34 @@ function M.build(files, opts)
     local group = archived and "CodeReviewArchived" or (type_def and type_def.hl or "CodeReviewNote")
     local text_group = archived and "CodeReviewArchivedNote" or "CodeReviewNote"
     local prefix = ("   %s "):format(icon)
-    -- Queued entries only. An archived one carries the flag too, because it is persisted
-    -- with the entry, but there it means "this file had moved by the time the batch went" --
-    -- a fact about a queue that no longer exists. Drawn against the code now it reads as a
-    -- claim about the code now, which nothing has checked.
-    local stale = (not archived and item.stale) and "⚠ stale  " or nil
+
+    -- One slot before the prose, and the two things that can occupy it never share an
+    -- entry -- which is the rule, not an economy. A queued entry carries staleness: its
+    -- file moved since it was *captured*, so its line anchor may be wrong and that is worth
+    -- fixing before it goes. An archived entry carries touchedness: its file has or has not
+    -- moved since its batch was *dispatched*, which says where the agent has been. An
+    -- archived entry's `stale` flag is persisted with it and is deliberately not drawn --
+    -- it is a fact about a queue that no longer exists, and against the code now it would
+    -- read as a claim about the code now that nothing has checked.
+    local flag, flag_group
+    if archived then
+      local moved = opts.touched and item.id and opts.touched[item.id]
+      if moved ~= nil then
+        -- Said of the file, never of the note. The plugin knows the bytes moved; it does
+        -- not know that anyone read the remark, agreed with it or acted on it.
+        flag = moved and "file changed  " or "file unchanged  "
+        flag_group = moved and "CodeReviewTouched" or "CodeReviewUntouched"
+      end
+    elseif item.stale then
+      flag, flag_group = "⚠ stale  ", "CodeReviewStale"
+    end
 
     local body
     if wrap_to then
       -- The marker only prefixes the first line, but wrapping the whole note to the
       -- narrower budget is what makes "nothing is clipped" true by construction rather
       -- than true of every line except one.
-      local avail = wrap_to - vim.fn.strdisplaywidth(prefix) - (stale and vim.fn.strdisplaywidth(stale) or 0)
+      local avail = wrap_to - vim.fn.strdisplaywidth(prefix) - (flag and vim.fn.strdisplaywidth(flag) or 0)
       body = wrap(item.note, math.max(8, avail))
     else
       body = vim.split(item.note, "\n", { plain = true })
@@ -305,8 +323,8 @@ function M.build(files, opts)
     for n, text in ipairs(body) do
       if n == 1 then
         local chunks = { { prefix, group } }
-        if stale then
-          chunks[#chunks + 1] = { stale, "CodeReviewStale" }
+        if flag then
+          chunks[#chunks + 1] = { flag, flag_group }
         end
         chunks[#chunks + 1] = { text, text_group }
         virt[#virt + 1] = chunks

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -10,6 +10,12 @@
 ---    have not reviewed what is there now;
 ---  * an annotation whose blob moved is kept but flagged stale, because the prose is
 ---    still worth sending and only its line anchor is untrustworthy.
+---
+---A third comparison lives here and is deliberately not a third case of that one:
+---**touchedness** judges an *archived* entry against the working tree as it stood when its
+---batch was **dispatched**, and answers where an agent has been rather than whether a note
+---is still trustworthy. Same primitive, different blob, different entries, separate
+---function -- see `reconcile_archive`.
 local queue = require("codereview.queue")
 
 local M = {}
@@ -559,6 +565,100 @@ function M.reconcile(view)
   end
 
   return unmarked, staled + M.reconcile_queue(view.root)
+end
+
+---Judge the newest archived batch's files against the code its batch went out with.
+---
+---**Touchedness is not staleness, and the two must never become one flag.** Sharing the
+---blob comparison is the whole of what they share. Staleness judges a *queued* entry
+---against the blob it was **captured** with and means *my note may be wrong*; this judges
+---an *archived* entry against the working tree as it stood when its batch was
+---**dispatched** and means *the agent has been here*. One flag would say both and neither:
+---an entry captured on Monday, edited by the reviewer on Tuesday and dispatched on
+---Wednesday is stale and untouched at once, and each read off the other is wrong in the
+---direction that looks fine.
+---
+---**Judged against the snapshot, not against the entry's own blob.** That blob is the
+---capture blob, so a file the reviewer themselves edited between annotating it and
+---submitting would count as the agent's work -- and it would make this comparison
+---arithmetically identical to the staleness one, which is how two rules become one by
+---accident rather than by decision. The snapshot is what the archive already records the
+---dispatch as, so there is no second copy of that fact to drift from it, and it is what
+---`since-batch` diffs against: the tally and the diff a reviewer reads it beside therefore
+---describe one dispatch by construction.
+---
+---**Per file, not per anchor.** Mapping an entry's line range through the diff since the
+---snapshot is considerably more machinery and the case it improves stays fuzzy either way.
+---The signal worth having is *the agent never opened this file*, and that one is exact
+---under a per-file rule.
+---
+---Two batched calls, neither of which grows with the number of files -- `hash-object` for
+---the working tree and `cat-file --batch-check` for the snapshot, exactly as the two sides
+---of a diff are already hashed. One process per file was measurably more expensive than
+---every treesitter operation combined.
+---
+---Three things are left unjudged rather than guessed at:
+---  * a file the current scope does not cover, because absence from a scope is not evidence
+---    that anything changed -- the rule `reconcile` already holds;
+---  * a path the snapshot does not carry, which is a file untracked at dispatch: `git stash
+---    create` records none of those, so the snapshot has nothing to say about it;
+---  * a **bare note**, which is about no file at all. It lives in the store that needs no
+---    root and never reaches this one.
+---@param root string
+---@param files CRFile[] The scope on screen, which is what decides who is judged
+---@return table<integer, boolean> touched Keyed by entry id; an absent id was not judged
+---@return integer|nil untouched How many judged entries' files have not moved, or nil when
+---        nothing could be judged at all
+function M.reconcile_archive(root, files)
+  local batch = M.last_batch(root)
+  if not batch or not batch.snapshot then
+    return {}, nil
+  end
+
+  local in_scope = {}
+  for _, file in ipairs(files) do
+    in_scope[file.path] = true
+  end
+
+  -- Distinct paths: one batch routinely holds several entries about one file, and hashing
+  -- a path once per entry is exactly the per-file cost the batching exists to avoid.
+  local paths, seen = {}, {}
+  for _, entry in ipairs(batch.entries or {}) do
+    if entry.path and in_scope[entry.path] and not seen[entry.path] then
+      seen[entry.path] = true
+      paths[#paths + 1] = entry.path
+    end
+  end
+  if #paths == 0 then
+    return {}, nil
+  end
+
+  local git = require("codereview.git")
+  local now = git.hash_worktree(paths, root)
+  local specs = {}
+  for i, path in ipairs(paths) do
+    specs[i] = ("%s:%s"):format(batch.snapshot, path)
+  end
+  local sent = git.hash_refs(specs, root)
+
+  local moved = {}
+  for i, path in ipairs(paths) do
+    local was = sent[specs[i]]
+    if was then
+      -- A file deleted since the dispatch hashes to nothing, and nothing is as moved as a
+      -- rewrite: what the note was about is not there either way.
+      moved[path] = now[path] ~= was
+    end
+  end
+
+  local touched, untouched = {}, nil
+  for _, entry in ipairs(batch.entries or {}) do
+    if entry.id and entry.path and moved[entry.path] ~= nil then
+      touched[entry.id] = moved[entry.path]
+      untouched = (untouched or 0) + (moved[entry.path] and 0 or 1)
+    end
+  end
+  return touched, untouched
 end
 
 ---Forget everything saved for a repository.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -35,6 +35,9 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@field expanded table<string, boolean>
 ---@field notes table<string, table[]>     Line key -> queued annotations
 ---@field archived table<string, table[]>  Line key -> archived entries; empty when off
+---@field touched table<integer, boolean>  Archived entry id -> whether its file has moved
+---@field untouched integer|nil            How many of those have not; nil when none were judged
+---@field judged integer|nil               `state.archive_writes` the two above were judged at
 ---@field buf integer                     The after pane
 ---@field win integer                     The after pane
 ---@field before_buf integer|nil          nil in the unified layout
@@ -288,6 +291,12 @@ local function update_winbar()
   if notes > 0 then
     bar = bar .. (" · %d note%s"):format(notes, notes == 1 and "" or "s")
   end
+  -- Read rather than computed: this runs on every paint, and a paint runs on every resize.
+  -- The git behind the number is paid where the archive is judged, which is where the diff
+  -- is read -- see `judge_archive`.
+  if V.untouched then
+    bar = bar .. (" · %d untouched"):format(V.untouched)
+  end
   local to = delivery.target()
   if to and to.short then
     bar = bar .. (" · → %s"):format(to.short)
@@ -414,6 +423,15 @@ function M.paint(keep_file)
   -- archives a batch of one without emptying anything -- and the read behind it is a
   -- comparison until something has written.
   V.archived = cfg.archived and require("codereview.archive").by_key(V.root) or {}
+  -- What was judged against an archive that has since been overtaken describes something
+  -- else now: an **immediate send** archives a batch of one with no repaint of its own, so
+  -- the entries below may belong to a batch nothing has judged. Dropped rather than
+  -- recomputed, because judging is two git invocations and this runs on every resize --
+  -- saying nothing until the next reconcile is the honest answer, and the winbar's segment
+  -- goes with it.
+  if V.judged ~= require("codereview.state").archive_writes() then
+    V.touched, V.untouched = {}, nil
+  end
   -- Both panes from one walk: their row counts and their anchors agree by construction
   -- rather than because two calls happened to be handed the same arguments.
   V.render, V.before_render = render.build(V.files, {
@@ -425,6 +443,7 @@ function M.paint(keep_file)
     reviewed = V.reviewed,
     notes = V.notes,
     archived = V.archived,
+    touched = V.touched,
     types = cfg.types,
   })
 
@@ -758,12 +777,39 @@ function M.refresh()
   M.persist()
 end
 
+---Ask which of the last batch's files the agent has been in since it went.
+---
+---Kept apart from the reconciliation below, and reported through the winbar rather than a
+---sentence, because it says nothing a reviewer has to act on: *stale* means a note may now
+---be wrong, *untouched* only means a file has not moved. The computation is `state`'s,
+---beside the staleness rule it parallels rather than joins.
+---
+---Called where the diff is read -- opening, refreshing, changing scope, and this view's own
+---submit -- and never from a paint, which also runs on every resize.
+local function judge_archive()
+  -- Submitting reaches here with nothing open: a batch is not a window, and it can go out
+  -- of a session that never opened a review at all.
+  if not V then
+    return
+  end
+  if not config.get().archived then
+    -- One switch turns the archive off in the review view outright: nothing drawn, nothing
+    -- tallied, and no git spent deciding either.
+    V.touched, V.untouched, V.judged = {}, nil, nil
+    return
+  end
+  local state = require("codereview.state")
+  V.touched, V.untouched = state.reconcile_archive(V.root, V.files)
+  V.judged = state.archive_writes()
+end
+
 ---Re-check reviewed marks and annotations against the diff now on screen, reporting what
 ---the blob comparison invalidated.
 function M.reconcile()
   if not V then
     return
   end
+  judge_archive()
   local unmarked, staled = require("codereview.state").reconcile(V)
   local parts = {}
   if unmarked > 0 then
@@ -1159,6 +1205,11 @@ function M.submit()
   -- A batch that did not go is still queued and still drawn on the diff, so there is
   -- nothing to repaint -- and the reviewer has already been told why.
   if dispatched then
+    -- The batch that just went was snapshotted a moment ago, so every one of its entries is
+    -- untouched and the winbar should say so immediately. Judged here rather than left to
+    -- the next reconcile because a submit is the one moment a reviewer looks for that
+    -- number, and because the archive underneath it has certainly moved.
+    judge_archive()
     M.paint()
   end
 end
@@ -1651,6 +1702,7 @@ function M.open(spec)
     expanded = {},
     notes = {},
     archived = {},
+    touched = {},
     syntax_cache = {},
     collapsed = {},
     buf = buf,

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # timing report at two siz
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 1,080 cases in ~6 seconds.
+The whole suite is about 1,110 cases in ~6 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -48,6 +48,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
 | `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, and the four things it refuses |
+| `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally, the three things left unjudged, and that the queue's own staleness rule is untouched by any of it |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
@@ -73,7 +74,8 @@ interchangeable, and the assertions know which one they are looking at.
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
   `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `queue_float_spec`,
-  `split_spec`, `layout_spec`, `open_diff_spec`, `archive_spec` and `interactive_spec`. Its
+  `split_spec`, `layout_spec`, `open_diff_spec`, `archive_spec`, `touched_spec` and
+  `interactive_spec`. Its
   dirty working tree is what makes a snapshot worth minting, so `archive_spec` builds a
   second copy and resets it to get a clean one. It already covers everything the split layout has
   to render, including the files that exist on only one side and the additions between
@@ -164,6 +166,14 @@ so the out-of-core language path is still checked locally without ever failing C
   `archive.by_key` rebuilds only when `state.archive_writes` has moved, which `archive_batch`,
   `clear` and `clear_global` are what move. Deleting a state file directly — or writing one by
   hand — leaves a view drawing entries that no longer exist until the next dispatch.
+- **A touchedness test needs a file the agent changed *and* one it did not.** With every
+  file touched, every assertion passes with the blob comparison deleted — the same trap as
+  "a filter test needs a fixture only that filter can reject". `touched_spec` dispatches a
+  batch naming `src/main.lua` and `src/nonl.md`, edits only the first, and asserts against
+  git that exactly one of the two moved before asserting anything about either. Neither is
+  the renamed file: `git diff -M` names a rename by its *pre-image* path once the
+  post-image is gone, so deleting `src/newname.lua` takes it out of scope instead of
+  marking it touched, and the deletion case would then be measuring the scope rule.
 - **`git stash create` on a clean tree returns nothing**, which is a case rather than an
   edge to assume away: the snapshot falls back to `HEAD`. `archive_spec` builds a second
   fixture and resets it hard, because the shared one is dirty by design and can never

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # timing report at two siz
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 1,110 cases in ~6 seconds.
+The whole suite is about 1,115 cases in ~6 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -48,7 +48,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
 | `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, and the four things it refuses |
-| `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally, the three things left unjudged, and that the queue's own staleness rule is untouched by any of it |
+| `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally, the three things left unjudged, which of three candidate blobs it is judged against, and that the queue's own staleness rule is untouched by any of it |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
@@ -174,6 +174,18 @@ so the out-of-core language path is still checked locally without ever failing C
   the renamed file: `git diff -M` names a rename by its *pre-image* path once the
   post-image is gone, so deleting `src/newname.lua` takes it out of scope instead of
   marking it touched, and the deletion case would then be measuring the scope rule.
+- **Touchedness has three plausible reference points, and a clean fixture cannot tell them
+  apart.** The blob an entry was *captured* with, the blob its batch was *dispatched* with
+  and the blob at `HEAD` are one object for any file that is clean when the batch goes — so
+  a spec whose only write happens *after* the dispatch passes whichever of the three the
+  implementation reaches for, and nothing catches a refactor that swaps the dispatch blob
+  for the capture blob. That swap is the exact merge this feature exists to refuse, and it
+  reports a file the agent never opened as touched. `touched_spec`'s last block gives
+  `src/fresh.lua` three distinct contents — committed, edited before annotating, edited
+  again before submitting — leaves it alone afterwards, and guards that the three really are
+  three shas before asserting it is untouched. Both mutations (specs built from `HEAD`, and
+  `was` taken from the entry's own `blob`) must red four cases each, applied separately:
+  applied together they mask each other.
 - **`git stash create` on a clean tree returns nothing**, which is a case rather than an
   edge to assume away: the snapshot falls back to `HEAD`. `archive_spec` builds a second
   fixture and resets it hard, because the shared one is dirty by design and can never

--- a/tests/codereview/touched_spec.lua
+++ b/tests/codereview/touched_spec.lua
@@ -354,3 +354,82 @@ describe("the configuration flag", function()
     assert.is_truthy(vim.wo[V.win].winbar:find("0 untouched", 1, true), vim.wo[V.win].winbar)
   end)
 end)
+
+-- Which blob touchedness is judged against, and the only fixture that can tell.
+--
+-- Everything above is clean at HEAD when its batch goes, so the blob the entry was
+-- *captured* with, the blob the batch was *dispatched* with and the blob at HEAD are one
+-- object -- and any of the three passes every assertion above. That is precisely the choice
+-- this slice exists to get right: staleness judges a queued entry against its capture blob,
+-- touchedness judges an archived entry against the dispatch blob, and a refactor swapping
+-- one for the other has to red something.
+--
+-- So: a file the reviewer annotates, keeps working on, and only then submits -- the work in
+-- flight #67 says `since-batch` must exclude -- which the agent afterwards never opens. Only
+-- the snapshot reports it untouched. The capture blob and HEAD both report touched, which is
+-- the plugin claiming an agent has been in a file it has never seen.
+--
+-- A second dispatch, and last in the file for that reason: it becomes the newest batch, and
+-- everything above has already been judged against the one it displaces.
+describe("a file the reviewer edited between annotating and submitting", function()
+  local git = require("codereview.git")
+  local V = assert(view.current())
+  local IN_FLIGHT = "src/fresh.lua"
+  local abs = vim.fs.joinpath(root, IN_FLIGHT)
+
+  -- Three distinct contents, so the three reference points are three distinct blobs rather
+  -- than two that happen to differ. HEAD carries what the branch committed; the reviewer had
+  -- already moved on from it before annotating, and moves on again before submitting.
+  local at_head = assert(git.blob(IN_FLIGHT, "HEAD", root))
+  vim.fn.writefile({ "local function fresh() end", "-- mine, before I annotated it" }, abs)
+
+  local entry = queue_file(IN_FLIGHT, "annotated while I was still working on this")
+  entry.worktree = true
+  entry.blob = assert(git.blob(IN_FLIGHT, nil, root))
+
+  vim.fn.writefile({ "local function fresh() end", "-- mine, and still in flight when I sent" }, abs)
+
+  local _, done = h.capture_notify()
+  codereview.submit()
+  done()
+  view.refresh()
+
+  local snapshot = assert(state.archive(root)[1].snapshot, "the second batch archived no snapshot")
+  local at_dispatch = assert(git.blob(IN_FLIGHT, snapshot, root))
+
+  -- Without this the case stops measuring the first time the fixture moves: two reference
+  -- points that name one blob agree about everything, and the assertion below would then
+  -- hold whichever of them the implementation reached for.
+  it("has three genuinely different blobs to be judged against", function()
+    assert.are_not.same(at_head, entry.blob, "HEAD and the capture blob are the same object")
+    assert.are_not.same(entry.blob, at_dispatch, "the capture blob and the snapshot are the same object")
+    assert.are_not.same(at_head, at_dispatch, "HEAD and the snapshot are the same object")
+  end)
+
+  it("was left exactly as it was dispatched, which is what makes it untouched", function()
+    assert.same(at_dispatch, git.blob(IN_FLIGHT, nil, root))
+  end)
+
+  it("is untouched, because the agent never opened it", function()
+    assert.is_truthy(only_line_on(IN_FLIGHT):find("file unchanged", 1, true), only_line_on(IN_FLIGHT))
+  end)
+
+  it("counts as untouched on the winbar", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("1 untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+
+  -- The reviewer's own edits are not the agent's work, and the entry carries the blob that
+  -- would say they were.
+  it("does not read the reviewer's own work as the agent's", function()
+    local touched = state.reconcile_archive(root, V.files)
+    assert.is_false(touched[entry.id], "an in-flight edit was counted as the agent's")
+  end)
+
+  -- Only the newest batch is judged: an older one went out against an older snapshot, and
+  -- "has this moved since the last dispatch" is not a question about it.
+  it("leaves the batch it displaced unjudged", function()
+    local touched = state.reconcile_archive(root, V.files)
+    assert.is_nil(touched[dispatched_ids["the agent will edit this file"]])
+    assert.same({ [entry.id] = false }, touched)
+  end)
+end)

--- a/tests/codereview/touched_spec.lua
+++ b/tests/codereview/touched_spec.lua
@@ -1,0 +1,356 @@
+-- Whether an archived entry's file has been touched since its batch was dispatched, and
+-- the tally of the ones that have not.
+--
+-- The fixture carries a file the agent changed *and* one it did not, deliberately: with
+-- everything touched, every assertion here passes with the blob comparison deleted. Same
+-- trap as "a filter test needs a fixture only that filter can reject".
+--
+-- Everything is asserted through what a reviewer can see -- the winbar, the text of a
+-- virtual line, the highlight *group* it is drawn in -- or through what the reconciliation
+-- returns. Never a colour, and never the JSON behind the archive.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+local root = assert(vim.uv.fs_realpath(fixture))
+
+local codereview = require("codereview")
+local queue = require("codereview.queue")
+local render = require("codereview.render")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+-- The two files this whole spec turns on. Both are modified on the feature branch, so both
+-- are in the branch scope from the start, and neither is the renamed one: `git diff -M`
+-- names a rename by its *pre-image* path once the post-image is gone, so deleting
+-- `src/newname.lua` would take it out of scope instead of marking it touched.
+local CHANGED = "src/main.lua"
+local UNCHANGED = "src/nonl.md"
+
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, "composed")
+  end,
+  -- Reports nothing, which is a dispatch: the one condition that empties the queue and
+  -- writes the archive.
+  send = function() end,
+})
+
+---Queue one whole-file annotation, as the review path would have left it.
+---@param path string
+---@param note string
+---@param stale boolean|nil
+---@return CRAnnotation
+local function queue_file(path, note, stale)
+  return queue.add({
+    type = "bug",
+    kind = "file",
+    path = path,
+    abs_path = vim.fs.joinpath(root, path),
+    key = render.file_key(path),
+    note = note,
+    stale = stale or nil,
+  })
+end
+
+---The virtual lines drawn on a file's header row in the open view.
+---@param path string
+---@return table[]
+local function drawn_on(path)
+  local V = assert(view.current())
+  local row = V.render.file_rows[assert(h.file_index(V, path), path .. " is not in scope")]
+  for _, m in ipairs(h.virt_marks(V)) do
+    if m[2] == row - 1 then
+      return m[4].virt_lines
+    end
+  end
+  return {}
+end
+
+---@param line table[]
+---@return string
+local function text_of(line)
+  local out = {}
+  for _, chunk in ipairs(line) do
+    out[#out + 1] = chunk[1]
+  end
+  return table.concat(out)
+end
+
+---The one virtual line drawn on a file's header, as text.
+---@param path string
+---@return string
+local function only_line_on(path)
+  local virt = drawn_on(path)
+  assert(#virt == 1, ("%s carries %d virtual lines: %s"):format(path, #virt, vim.inspect(virt)))
+  return text_of(virt[1])
+end
+
+--- The dispatch everything below is judged against -----------------------------
+
+-- A bare note goes out with them, so that "a bare note is never marked either way" is a
+-- claim about a batch that actually held one.
+queue_file(CHANGED, "the agent will edit this file")
+-- Carries a staleness flag into the archive on purpose: it is persisted with the entry, and
+-- the whole point of the two rules being separate is that this one must not be drawn once
+-- the entry has gone.
+queue_file(UNCHANGED, "the agent will leave this file alone", true)
+queue.add({ type = "issue", kind = "note", note = "a thought with no file behind it" })
+
+local dispatched_ids = {}
+for _, item in ipairs(queue.all()) do
+  dispatched_ids[item.note] = item.id
+end
+
+local _, restore = h.capture_notify()
+codereview.submit()
+restore()
+
+describe("the dispatch this spec is judged against", function()
+  it("emptied the queue, so nothing below is reading one", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("archived the two entries with a repository behind them", function()
+    local batch = assert(state.archive(root)[1], "nothing was archived")
+    assert.same({ CHANGED, UNCHANGED }, { batch.entries[1].path, batch.entries[2].path })
+  end)
+
+  it("minted a snapshot to judge them against", function()
+    assert.is_truthy(state.archive(root)[1].snapshot)
+  end)
+
+  it("routed the bare note to the store that needs no root", function()
+    assert.same(1, #state.global_archive()[1].entries)
+  end)
+end)
+
+-- The agent's work: one of the two files moves, and the other is left exactly as it went.
+-- Written after the dispatch, so the snapshot genuinely predates it.
+local changed_abs = vim.fs.joinpath(root, CHANGED)
+vim.fn.writefile(vim.list_extend(vim.fn.readfile(changed_abs), { "-- the agent was here" }), changed_abs)
+
+describe("the fixture the rest of this spec depends on", function()
+  it("moved one of the two files and not the other", function()
+    local moved = h.git_lines(root, { "diff", "--name-only", state.archive(root)[1].snapshot })
+    assert.is_true(vim.tbl_contains(moved, CHANGED), vim.inspect(moved))
+    assert.is_false(vim.tbl_contains(moved, UNCHANGED), vim.inspect(moved))
+  end)
+end)
+
+--- What the reconciliation makes of it ------------------------------------------
+
+describe("the reconciliation behind the tally", function()
+  local V = { files = {} }
+  for _, path in ipairs({ CHANGED, UNCHANGED }) do
+    V.files[#V.files + 1] = { path = path }
+  end
+  local touched, untouched = state.reconcile_archive(root, V.files)
+
+  it("marks the file the agent edited", function()
+    assert.is_true(touched[dispatched_ids["the agent will edit this file"]])
+  end)
+
+  it("marks the file it did not, and counts it", function()
+    assert.is_false(touched[dispatched_ids["the agent will leave this file alone"]])
+    assert.same(1, untouched)
+  end)
+
+  it("never marks a bare note either way", function()
+    assert.is_nil(touched[dispatched_ids["a thought with no file behind it"]])
+  end)
+
+  -- Absence from a scope is not evidence that anything changed, which is the rule the
+  -- reviewed-mark reconciliation already holds. Nothing judged means nothing to tally, so
+  -- the winbar has no segment to draw rather than a zero to misread.
+  it("leaves an entry whose file the scope does not cover unjudged", function()
+    local only_one, count = state.reconcile_archive(root, { { path = UNCHANGED } })
+    assert.is_nil(only_one[dispatched_ids["the agent will edit this file"]])
+    assert.same(1, count)
+    local none, nothing = state.reconcile_archive(root, { { path = "src/routes.lua" } })
+    assert.same({}, none)
+    assert.is_nil(nothing)
+  end)
+
+  -- Staleness is the same primitive against a different blob, judged over a different set
+  -- of entries. Running one must not have run the other, in either direction.
+  local queued = queue_file(CHANGED, "queued after the dispatch")
+  -- A working-tree capture, judged against the file on disk at any scope, and against a
+  -- blob nothing will ever hash to.
+  queued.worktree = true
+  queued.blob = ("0"):rep(40)
+  local before = vim.deepcopy(queued)
+  state.reconcile_archive(root, V.files)
+
+  it("leaves a queued entry exactly as it found it, field for field", function()
+    assert.same(before, queued)
+  end)
+
+  local staled = state.reconcile_queue(root)
+
+  it("has not stopped the staleness rule reaching that entry", function()
+    assert.same(1, staled)
+    assert.is_true(queued.stale)
+  end)
+
+  queue.clear()
+end)
+
+--- What a reviewer sees ---------------------------------------------------------
+
+describe("an archived entry on the diff", function()
+  codereview.open("branch")
+  local V = assert(view.current())
+
+  it("says so on the file the agent changed", function()
+    assert.is_truthy(only_line_on(CHANGED):find("file changed", 1, true), only_line_on(CHANGED))
+  end)
+
+  it("says so on the file it did not", function()
+    assert.is_truthy(only_line_on(UNCHANGED):find("file unchanged", 1, true), only_line_on(UNCHANGED))
+  end)
+
+  -- The word is *touched*, not *addressed*: the plugin knows the file moved, not that
+  -- anyone read the note, agreed with it or acted on it.
+  it("claims nothing about the note itself", function()
+    for _, path in ipairs({ CHANGED, UNCHANGED }) do
+      local text = only_line_on(path)
+      for _, word in ipairs({ "addressed", "resolved", "handled", "done", "fixed" }) do
+        assert.is_nil(text:find(word, 1, true), ("%s says %q"):format(path, word))
+      end
+    end
+  end)
+
+  -- The flag the entry was dispatched carrying. It means "this file had moved since the
+  -- annotation was captured", which is a fact about a queue that no longer exists -- and
+  -- against the code now it would read as a claim nothing has checked.
+  it("does not draw the staleness it went out with", function()
+    assert.is_true(state.archive(root)[1].entries[2].stale, "the fixture archived no stale entry")
+    assert.is_nil(only_line_on(UNCHANGED):find("stale", 1, true), only_line_on(UNCHANGED))
+  end)
+
+  it("draws the two answers in groups of their own", function()
+    local groups = h.virt_groups(V)
+    assert.is_true(groups.CodeReviewTouched or false, vim.inspect(vim.tbl_keys(groups)))
+    assert.is_true(groups.CodeReviewUntouched or false, vim.inspect(vim.tbl_keys(groups)))
+    -- Never the group staleness draws in: one colour for both is the merge the rule refuses.
+    assert.is_nil(groups.CodeReviewStale, vim.inspect(vim.tbl_keys(groups)))
+  end)
+
+  it("links those groups into the colorscheme rather than defining colours", function()
+    for _, group in ipairs({ "CodeReviewTouched", "CodeReviewUntouched" }) do
+      local def = vim.api.nvim_get_hl(0, { name = group })
+      assert.is_truthy(def.link, ("%s is not a link: %s"):format(group, vim.inspect(def)))
+      assert.is_truthy(vim.api.nvim_get_hl(0, { name = def.link }), ("%s links nowhere"):format(group))
+    end
+  end)
+
+  it("tallies the untouched ones on the winbar", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("1 untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+end)
+
+-- A queued entry's staleness and an archived entry's touchedness are drawn from the same
+-- slot, and both have to survive the other being there.
+describe("a stale queued entry beside them", function()
+  local V = assert(view.current())
+  local queued = queue_file(CHANGED, "still to send")
+  queued.worktree = true
+  queued.blob = ("0"):rep(40)
+  view.reconcile()
+  view.paint()
+
+  it("is flagged stale, exactly as it was before touchedness existed", function()
+    local virt = drawn_on(CHANGED)
+    assert.same(2, #virt, vim.inspect(virt))
+    assert.is_truthy(text_of(virt[1]):find("⚠ stale", 1, true), text_of(virt[1]))
+  end)
+
+  it("does not take the archived entry's flag, nor give it its own", function()
+    local virt = drawn_on(CHANGED)
+    assert.is_nil(text_of(virt[1]):find("file changed", 1, true), text_of(virt[1]))
+    assert.is_truthy(text_of(virt[2]):find("file changed", 1, true), text_of(virt[2]))
+    assert.is_nil(text_of(virt[2]):find("stale", 1, true), text_of(virt[2]))
+  end)
+
+  it("leaves the tally where it was", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("1 untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+
+  queue.clear()
+  view.paint()
+end)
+
+describe("a scope that covers neither file", function()
+  local V = assert(view.current())
+  view.set_scope("staged")
+
+  it("shows only the staged file, so both archived entries are out of it", function()
+    assert.same(
+      { "src/routes.lua" },
+      vim.tbl_map(function(f)
+        return f.path
+      end, V.files)
+    )
+  end)
+
+  it("tallies nothing rather than nothing-untouched", function()
+    assert.is_nil(vim.wo[V.win].winbar:find("untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+
+  it("judges nothing", function()
+    assert.same({}, V.touched)
+    assert.is_nil(V.untouched)
+  end)
+
+  view.set_scope("branch")
+end)
+
+-- The lines the note named are gone, which is at least as touched as a rewrite.
+describe("a file deleted since the dispatch", function()
+  local V = assert(view.current())
+  vim.fn.delete(vim.fs.joinpath(root, UNCHANGED))
+  view.refresh()
+
+  it("is still in scope, so absence from one is not what is being measured", function()
+    assert.is_truthy(
+      h.file_index(V, UNCHANGED),
+      vim.inspect(vim.tbl_map(function(f)
+        return f.path
+      end, V.files))
+    )
+  end)
+
+  it("counts as touched", function()
+    assert.is_truthy(only_line_on(UNCHANGED):find("file changed", 1, true), only_line_on(UNCHANGED))
+  end)
+
+  it("leaves nothing untouched, and says so rather than going quiet", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("0 untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+end)
+
+describe("the configuration flag", function()
+  local config = require("codereview.config")
+  local V = assert(view.current())
+
+  config.get().archived = false
+  view.refresh()
+
+  it("takes the tally with the entries", function()
+    assert.is_nil(vim.wo[V.win].winbar:find("untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+
+  it("judges nothing, so nothing is spent deciding", function()
+    assert.same({}, V.touched)
+    assert.is_nil(V.untouched)
+  end)
+
+  config.get().archived = true
+  view.refresh()
+
+  it("brings both back together", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("0 untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+end)


### PR DESCRIPTION
Each entry of the **last** batch now says whether its file has changed since that batch was
dispatched — `file changed` or `file unchanged` beside the note — and the winbar tallies the
ones that have not:

```
 Code review · branch vs master · 2/7 reviewed · +40 -12 · 1 note · 2 untouched · → janus
```

`2 untouched` is the answer to *did it ignore something*, and it is exact on the case that
matters: a file the agent never opened.

## The rule, and the one it must not merge with

Staleness judges a **queued** entry against the blob it was *captured* with and means *my
note may be wrong*. Touchedness judges an **archived** entry against the working tree as it
stood when its batch was *dispatched* and means *the agent has been here*. Separate
functions on `state`, separate highlight groups, reported separately — a sentence for
staleness, a winbar segment for touchedness — and an archived entry's persisted `stale` flag
is still not drawn.

**Judged against the snapshot, not against the entry's own `blob`.** That field is the
capture blob, so reusing it would count the reviewer's own edits between annotating and
submitting as the agent's work — and it would make this comparison arithmetically identical
to the staleness one, which is how two rules become one by accident instead of by decision.
The snapshot is what the archive already records the dispatch as, so there is no second copy
of that fact to drift from it, and it is what `since-batch` diffs against: a file the tally
calls touched is exactly a file that scope shows.

Per file, never per anchor — settled in #67, and *the agent never opened this file* is exact
under the per-file rule.

## Where the halves landed

- `state.reconcile_archive` — the computation, beside the staleness reconciliation it
  parallels rather than joins. Two batched calls, neither growing with the number of files:
  `hash-object` for the working tree and `cat-file --batch-check` for the snapshot, which is
  how the two sides of a diff are already hashed.
- `view` — one small `judge_archive`, called where the diff is read (opening, refreshing,
  changing scope, and its own submit) and never from a paint, which also runs on every
  resize. The winbar reads the number rather than computing it. The view records the
  `archive_writes` it judged at, so a paint that finds the archive overtaken by an
  **immediate send** drops the verdicts and the segment rather than reporting a number about
  a batch nothing has judged.
- `render` — the flag rides in the slot staleness already used, which the two can share
  because they can never occupy it on the same entry.

Everything is drawn through the existing viewport-bounded path; nothing new scales with the
archive.

## Left unjudged rather than guessed at

A file the current scope does not cover, a file untracked when the batch went (a
`stash create` commit records none), and a **bare note**. Nothing judged means no winbar
segment at all rather than a zero to misread. A file *deleted* since the dispatch counts as
touched.

The scope rule is why the tally reads `0 untouched` inside `since-batch` — that scope shows
exactly the files that moved, so every entry it covers is touched by definition. Suppressing
it there would be a case in the view for one scope, which is what `since-batch` was built to
avoid. Documented in the README, the help file and the design notes instead.

## Tests

New `touched_spec`, 30 cases: the reconciliation, the marker, the tally, the three unjudged
cases, the deleted file, the flag, and that the queue's staleness rule is untouched in both
directions. Its fixture carries a file the agent changed **and** one it did not — with
everything touched, every assertion passes with the blob comparison deleted. Verified by
mutation: forcing the comparison to `true` reds four cases, forcing it to `false` reds five.
No existing spec had to change. `make all` is green at 30 specs / 1,109 cases.

## Notes for the reviewer

- **Wording.** The marker says `file changed` / `file unchanged` on the diff while the
  winbar says `N untouched`. The glossary entry ties them together; the diff spells out what
  is actually known so nothing on screen can be read as *addressed*.
- **`doc/codereview.txt` had drifted.** The help file never gained the `archived` flag, the
  archive's highlight groups, or a section on archived entries on the diff when #73 landed —
  nor five groups older than that. Backfilled here rather than widened by two more, since
  this slice adds to both lists.

Closes #75