### PR TITLE
refactor(view): complete the CRView contract and give the pane autocommand one entry point

### DIFF
--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -872,7 +872,6 @@ function M.set_scope(spec)
   V.reviewed = V.per_scope[key].reviewed
   V.expanded = V.per_scope[key].expanded
   require("codereview.state").restore(V, key)
-  queue_restored = true
   M.reconcile()
 
   if #files == 0 then
@@ -1720,7 +1719,6 @@ function M.open(spec)
   V.reviewed = V.per_scope[key].reviewed
   V.expanded = V.per_scope[key].expanded
   require("codereview.state").restore(V, key)
-  queue_restored = true
   M.reconcile()
 
   -- Before the panel, so the panel's `topleft`/`botright` split lands outside both panes

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -33,6 +33,7 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@field per_scope table<string, { reviewed: table<string,string>, expanded: table<string,boolean> }>
 ---@field reviewed table<string, string>   Path -> blob at the time it was marked
 ---@field expanded table<string, boolean>
+---@field collapsed table<string, boolean> Directory path -> folded shut in the file tree
 ---@field notes table<string, table[]>     Line key -> queued annotations
 ---@field archived table<string, table[]>  Line key -> archived entries; empty when off
 ---@field touched table<integer, boolean>  Archived entry id -> whether its file has moved
@@ -45,12 +46,17 @@ local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 ---@field layout "unified"|"split"
 ---@field panel_buf integer|nil
 ---@field panel_win integer|nil
+---@field queue_win integer|nil           The window a queue float is open in
 ---@field tab integer
 ---@field augroup integer                 Autocommands belonging to this review
 ---@field render CRRender|nil             The after pane's render
 ---@field before_render CRRender|nil      nil in the unified layout
 ---@field panel_render CRPanelRender|nil
+---@field panel_current integer|nil       File index the tree is following; its repaint latch
 ---@field painted_bands table<integer, boolean>|nil  Row bands whose marks have been emitted
+---@field syntax_cache table<string, CRCapture[]|false>  `path|side` -> captures; false to skip it
+---@field syntax_painted table<string, boolean>|nil      Path -> already replayed onto this render
+---@field syntax_rows table<integer, CRFileRows>|nil     File index -> where its lines are drawn
 
 ---@type CRView|nil
 local V = nil

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -489,6 +489,31 @@ function M.paint(keep_file)
   resync()
 end
 
+---Everything a moved cursor comes due for, in the order it comes due.
+---
+---Both the diff's own marks and its highlighting are bounded by the viewport, so
+---scrolling into rows nothing has been emitted onto is what emits them, and scrolling
+---into an un-parsed file is what triggers its parse. One trigger for the two of them:
+---they share a margin, so they come due at the same moment. Cheap on every other scroll --
+---a band already emitted is a lookup, an already-painted file is skipped, and an
+---already-parsed one repaints from cache.
+---
+---Exported so that the autocommand driving it wires one name rather than reaching into
+---three internals at once. It runs on every keystroke a reviewer holds, so the guards
+---here are what keep it cheap rather than decoration around it.
+function M.cursor_moved()
+  if not M.current() then
+    return
+  end
+  paint_bands()
+  if config.get().syntax then
+    require("codereview.syntax").apply(V, NS)
+  end
+  -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
+  -- immediately unless the cursor crossed into a different file.
+  sync_panel()
+end
+
 ---Write progress to disk. Called from every mutation rather than from `paint`, which
 ---also runs on resize and would turn a window drag into a stream of file writes.
 ---
@@ -1399,27 +1424,13 @@ local function attach_pane(buf)
     end,
   })
 
-  -- Both the diff's own marks and its highlighting are bounded by the viewport, so
-  -- scrolling into rows nothing has been emitted onto is what emits them, and scrolling
-  -- into an un-parsed file is what triggers its parse. One trigger for the two of them:
-  -- they share a margin, so they come due at the same moment. Cheap on every other scroll --
-  -- a band already emitted is a lookup, an already-painted file is skipped, and an
-  -- already-parsed one repaints from cache.
+  -- One name rather than the three reaches behind it, wired directly rather than wrapped:
+  -- this fires on every keystroke a reviewer holds, so nothing sits between the event and
+  -- the work it comes due for.
   vim.api.nvim_create_autocmd({ "WinScrolled", "CursorMoved" }, {
     group = V.augroup,
     buffer = buf,
-    callback = function()
-      if not M.current() then
-        return
-      end
-      paint_bands()
-      if config.get().syntax then
-        require("codereview.syntax").apply(V, NS)
-      end
-      -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
-      -- immediately unless the cursor crossed into a different file.
-      sync_panel()
-    end,
+    callback = M.cursor_moved,
   })
 end
 


### PR DESCRIPTION
The prefactor that makes both extractions ordinary moves. Nothing leaves `view.lua`; what
changes is the contract the next two slices are written against.

Three commits, one per part.

## `@class CRView` is complete

The annotation described most of the table rather than the table. It now declares
`collapsed`, `panel_current`, `queue_win` and `syntax_cache` — and two more the issue did
not name.

**What the issue got wrong, and what I did instead.** #96 and #95 both say four fields are
missing. Six are: `syntax_painted` and `syntax_rows` sit on the view exactly as
`syntax_cache` does, written by `syntax.lua` and dropped by `invalidate` and `repainted`,
and `docs/design-notes.md` already describes `syntax_rows` as sitting "on the view … beside
`syntax_cache` and `syntax_painted`, and follows their rule exactly". Declaring four of the
three would have left the type saying that two of the fields a second module mutates are not
part of the contract, which is the defect the slice exists to remove. The PRD's own story 24
asks for *every* field the view carries, so I completed it rather than stopping at the count.

No field went in that I could not point at a use for. Five of the six are read by a spec
through `view.current()`: `V.collapsed`, `V.panel_current`, `V.queue_win`, `V.syntax_cache`
and `V.syntax_rows` all appear in `tests/codereview/`, which is what makes them contract
rather than incident.

`syntax_painted` is the exception, and it is worth naming precisely rather than folding into
the count. It appears under `tests/` only in `perf.lua`, which is not a spec and is not part
of `make test`. What justifies it is not the suite but eight uses in `lua/` — written and
dropped by `syntax.lua`, read by its own replay — and `docs/design-notes.md`, which names it
beside `syntax_cache` and `syntax_rows` as sitting on the view and following their rule. Real,
and mutated by a second module; just not pinned by the suite the way the other five are. Nothing speculative was added, and the enumeration was
taken from actual use in `view.lua`, `syntax.lua`, `state.lua`, `annotate.lua` and the suite
rather than from the issue.

## The two dead `queue_restored` assignments are gone

Shown unreachable rather than asserted:

- `queue_restored` is nowhere declared in `view.lua`, so both assignments wrote an
  undeclared **global**.
- The only other `queue_restored` in the repository is `local queue_restored = false` at
  `lua/codereview/state.lua:449`, declared at file scope *before* both of its uses (l. 463
  read, l. 466 write). Its reads therefore bind to the local at compile time and can never
  see a global.
- Measured, not inferred: with `_G.queue_restored` set to `true` up front, `state.ensure_queue()`
  still ran `restore_queue` on its first call and latched only on its second — the global has
  no effect on the latch.

```
global before anything: nil
restore_queue calls after first ensure_queue (global already true): 1
restore_queue calls after second ensure_queue: 1
```

Nothing replaces them, and no test was added: there is no behaviour to pin, and the real
latch already has coverage that spawns a second process because it is per session.

## The pane autocommand has one entry point

The `CursorMoved`/`WinScrolled` callback `attach_pane` installs reached into three things at
once — the viewport-bounded emission, the syntax replay, and the file tree's
follow-the-cursor sync. `view.cursor_moved()` now does all three and the autocommand wires
only that name.

Order and guards are byte-for-byte what they were: the `M.current()` guard first, then
`paint_bands()`, then the replay behind `config.get().syntax`, then `sync_panel()` — the
emission and the replay share a margin and come due at the same moment, and the tree still
repaints only when the cursor crosses into a different file. The comment that explained the
shared margin travelled verbatim with the code it documents; nothing was reworded.

Wired as `callback = M.cursor_moved` rather than through a wrapping closure, so nothing sits
between the event and the work on a path a reviewer pays for per keystroke.

## `make perf`

Before is `ec91f2c`, after is this branch, same machine, back to back.

| | 60 files | 300 files |
| --- | --- | --- |
| cursor move — before | 0.0 ms | 0.1 ms |
| cursor move — after | 0.0 ms | 0.0 ms |
| 50 moves (holding `j`) — before | 0 ms | 4 ms |
| 50 moves (holding `j`) — after | 1 ms | 1 ms |
| open — before | 186 ms | 536 ms |
| open — after | 176 ms | 539 ms |
| repaint — before | 40 ms | 182 ms |
| repaint — after | 38 ms | 114 ms |

No regression on the path this slice touches. Read the differences as noise rather than as an
improvement: three runs each side put the 300-file `50 moves` figure at 4/1/0 ms before and
1/1/1 ms after, and the repaint at 182/108/154 ms before and 114/103/113 ms after — both
straddle each other, and the per-keystroke figure is at the timer's floor on both sides.

## Verification

`make all` green. **Zero diff under `tests/`** — the whole change is 35 insertions and 20
deletions in `lua/codereview/view.lua` and nothing else. 30 spec files, 1115 assertions, 0
failures, 0 errors. `bounded_spec` (17) and `syntax_spec` (23) pin the two halves of the
moved callback, `panel_spec` (47) pins the repaint latch behind the third, and
`queue_jump_panel_spec` (12) passes unedited too.

No key, window, repaint or notification changed.

Closes #96

