### PR TITLE
refactor(view): lift the file tree into a module of its own

### DIFF
--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -33,16 +33,17 @@ change there is felt through.
 | `state.lua` | Persisted review progress, and the blob comparisons over it — staleness, and touchedness kept in a function of its own | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
-| `view.lua` | The review view: the `CRView` it owns, the paint, navigation, the file tree, delivery, opening and closing | stateful (windows) |
+| `view.lua` | The review view: the `CRView` it owns, the paint, navigation, delivery, opening and closing | stateful (windows) |
 | `view_layout.lua` | Where the review's windows are: the panes, the before pane, and the toggle between the unified and split layouts | stateful (windows) |
+| `view_panel.lua` | The file tree's stateful half: its window and buffer, the repaint that follows the diff cursor, and the actions its keys run | stateful (windows) |
 
 ## How they stack
 
 - **Require nothing**: `diff`, `drafts`, `panel`, `queue`, `types`.
 - **Above them**, in that order: `git`, `payload`, `render`; then `state`, `config`; then
   `archive`, `delivery`, `keymaps`, `syntax`; then `composer`, `hl`, `queue_float`,
-  `view_layout`.
-- **The hubs**: `view` requires fourteen of the modules above, `annotate` nine. A change that
+  `view_layout`; then `view_panel`.
+- **The hubs**: `view` requires thirteen of the modules above, `annotate` nine. A change that
   is not local to a leaf almost certainly reaches one of them.
 - **On top**: `capture`, then `init`.
 
@@ -60,15 +61,17 @@ the `since-batch` scope. Function-local on both sides, as above. The alternative
 the snapshot in from outside, which would put the one scope that needs it into every caller
 of `resolve_scope` — and scope resolution is exactly what must stay one function.
 
-`keymaps`, `queue_float` and `view_layout` would each be a third. All three run the view's
-exported actions, and all three take them as an argument — `view` hands itself in — rather
-than requiring `view` for them. That is deliberate, and it is what leaves `keymaps` a
+`keymaps`, `queue_float`, `view_layout` and `view_panel` would each be a third. All four run
+the view's exported actions, and all four take them as an argument — `view` hands itself in —
+rather than requiring `view` for them. That is deliberate, and it is what leaves `keymaps` a
 function of its arguments and the configured annotation types. `queue_float` reads no view
 state either: the one field it needs, the window a float is open in, stays on `view` behind
 two accessors, because closing a float on submit is a rule about the view's windows.
-`view_layout` does read view state, but never its own copy of it: the `CRView` table is
-handed in beside the view and mutated in place, exactly as `syntax` and `state` are handed
-it, so there is still one table and `view` still owns it.
+`view_layout` and `view_panel` do read view state, but never their own copy of it: the
+`CRView` table is handed in beside the view and mutated in place, exactly as `syntax` and
+`state` are handed it, so there is still one table and `view` still owns it. The one edge
+between the two is `view_panel` requiring `view_layout` for the window construction both
+surfaces share, and it points one way only.
 
 ## Where reading pays
 
@@ -77,9 +80,10 @@ it, so there is still one table and `view` still owns it.
   `keymaps` is the one to open when the question is what a key does or where to add one —
   it is a table, not a search through the surface that happens to bind it.
 - **Carries the churn**: `view` and `annotate` by a wide margin, then `config`, `composer`
-  and `state`. `queue_float` and `view_layout` are both newly split out of `view` and
-  inherit its history rather than starting clean — the float's rows and its keys have both
-  been rewritten recently, and the panes carry every trap the split layout ever cost.
+  and `state`. `queue_float`, `view_layout` and `view_panel` are all newly split out of
+  `view` and inherit its history rather than starting clean — the float's rows and its keys
+  have both been rewritten recently, the panes carry every trap the split layout ever cost,
+  and the tree's window has been dismissible for less time than it has existed.
 
 Re-derive with `git log --oneline --follow -- lua/codereview/<name>.lua` before leaning on
 that grouping; it moves.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -7,8 +7,11 @@
 ---handed this module the same way; what stays here is the jump from a queued **entry** into
 ---the diff, and the window a float is open in. Where the review's windows *are* is
 ---`view_layout.lua`, handed this module the same way again: the **panes**, the before pane,
----and the toggle between the two layouts. The single `V` below is what it mutates, and the
----two names it took out from under `keymaps.lua` and `annotate.lua` are re-exported here.
+---and the toggle between the two layouts. The **file tree**'s window and the actions its
+---keys run are `view_panel.lua`, handed this module the same way once more; its pure half
+---is `panel.lua`, which this module no longer reaches at all. The single `V` below is what
+---all three mutate, and the names they took out from under `keymaps.lua` and `annotate.lua`
+---are re-exported here.
 ---
 ---In the split layout the view keeps its existing buffer and window as the **after** pane
 ---and gains a before pane beside it. The after-image is the primary one everywhere else --
@@ -18,17 +21,15 @@
 local config = require("codereview.config")
 local git = require("codereview.git")
 local render = require("codereview.render")
-local panel = require("codereview.panel")
 local hl = require("codereview.hl")
 local delivery = require("codereview.delivery")
-local keymaps = require("codereview.keymaps")
 local queue_float = require("codereview.queue_float")
 local view_layout = require("codereview.view_layout")
+local view_panel = require("codereview.view_panel")
 
 local M = {}
 
 local NS = vim.api.nvim_create_namespace("codereview")
-local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
 
 ---@class CRView
 ---@field root string
@@ -105,63 +106,9 @@ end
 
 --- Painting --------------------------------------------------------------------
 
----Index of the file the diff cursor is currently inside, for the panel's highlight.
----@return integer|nil
-local function current_file_index()
-  local win, rendered = view_layout.focused_pane(V)
-  if not (rendered and vim.api.nvim_win_is_valid(win)) then
-    return nil
-  end
-  local row = vim.api.nvim_win_get_cursor(win)[1]
-  for r = row, 1, -1 do
-    if rendered.anchors[r] then
-      return rendered.anchors[r].file
-    end
-  end
-  return nil
-end
-
-local function paint_panel()
-  if not (V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
-    return
-  end
-  local cfg = config.get()
-  V.panel_render = panel.build(V.files, {
-    width = vim.api.nvim_win_get_width(V.panel_win),
-    icons = cfg.icons,
-    reviewed = V.reviewed,
-    notes = V.notes,
-    collapsed = V.collapsed,
-    current = current_file_index(),
-  })
-  vim.bo[V.panel_buf].modifiable = true
-  vim.api.nvim_buf_set_lines(V.panel_buf, 0, -1, false, V.panel_render.lines)
-  vim.bo[V.panel_buf].modifiable = false
-  vim.api.nvim_buf_clear_namespace(V.panel_buf, NS_PANEL, 0, -1)
-  for _, m in ipairs(V.panel_render.marks) do
-    pcall(vim.api.nvim_buf_set_extmark, V.panel_buf, NS_PANEL, m.row, m.col, m.opts)
-  end
-end
-
----Move the panel's highlight (and cursor, when it is not focused) to follow the diff.
----
----Repaints only when the file actually changed: this runs on every CursorMoved, and
----rebuilding the tree on each keystroke is wasted work on a large review.
-local function sync_panel()
-  if not (V and V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
-    return
-  end
-  local index = current_file_index()
-  if index == V.panel_current then
-    return
-  end
-  V.panel_current = index
-  paint_panel()
-  local row = index and V.panel_render.file_row[index]
-  if row and vim.api.nvim_get_current_win() ~= V.panel_win then
-    pcall(vim.api.nvim_win_set_cursor, V.panel_win, { row, 0 })
-  end
-end
+-- The file tree is painted by `view_panel.lua`, which is handed the view it mutates. What
+-- is left here is the diff's own paint, and the two moments the tree comes due with it: a
+-- repaint of everything, and a cursor that crossed into a different file.
 
 local function update_winbar()
   if not vim.api.nvim_win_is_valid(V.win) then
@@ -351,7 +298,7 @@ function M.paint(keep_file)
   -- paint: what a band means is decided by the render it was emitted from.
   V.painted_bands = {}
 
-  paint_panel()
+  view_panel.paint_panel(V)
   update_winbar()
   update_before_winbar()
 
@@ -400,7 +347,7 @@ function M.cursor_moved()
   end
   -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
   -- immediately unless the cursor crossed into a different file.
-  sync_panel()
+  view_panel.sync_panel(V)
 end
 
 ---Write progress to disk. Called from every mutation rather than from `paint`, which
@@ -483,6 +430,11 @@ local function nearest(rows, from, forward)
   return best
 end
 
+---Exported because the tree walks its own file rows with `]f` and `[f` exactly as the diff
+---walks its, and "the nearest row in that direction" is one rule rather than two copies of
+---one. It is the only thing `view_panel.lua` needs from this section.
+M.nearest = nearest
+
 ---Put a file header at the top of the window rather than leaving it wherever it lands:
 ---jumping to a file is a request to read it, and its first hunk should be on screen.
 ---
@@ -490,13 +442,13 @@ end
 ---
 ---Exported because the layout toggle lands a cursor the same way every jump here does, and
 ---it is the one arrival the two halves of this share: placing the panes is
----`view_layout.lua`'s and following the diff with the tree is this module's, so the pair is
----glued where the view that owns both is.
+---`view_layout.lua`'s and following the diff with the tree is `view_panel.lua`'s, so the
+---pair is glued where the view that owns both is.
 ---@param row integer
 ---@param cmd string|nil `zt`, `zz`, or nil to leave the window where it is
 local function goto_row(row, cmd)
   view_layout.place(V, row, cmd)
-  sync_panel()
+  view_panel.sync_panel(V)
 end
 
 M.goto_row = goto_row
@@ -641,25 +593,12 @@ end
 
 --- Focus -----------------------------------------------------------------------
 
----Move between the tree and the diff.
+-- Moving between the tree and the diff is a question about the tree's existence rather than
+-- about the diff, so its body is `view_panel.lua`'s. What is left here is the name
+-- `keymaps.lua` binds to `<Tab>` in both.
+
 function M.toggle_focus()
-  if not M.current() then
-    return
-  end
-  if not (V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
-    return
-  end
-  if vim.api.nvim_get_current_win() == V.panel_win then
-    vim.api.nvim_set_current_win(V.win)
-  else
-    -- Entering the tree, land on the file being read rather than wherever the cursor was.
-    local index = current_file_index()
-    local row = index and V.panel_render and V.panel_render.file_row[index]
-    vim.api.nvim_set_current_win(V.panel_win)
-    if row then
-      pcall(vim.api.nvim_win_set_cursor, V.panel_win, { row, 0 })
-    end
-  end
+  view_panel.toggle_focus(V, M)
 end
 
 function M.toggle_reviewed()
@@ -859,6 +798,10 @@ end
 ---it keeps none about delivery (ADR-0001): everything the host needs to fetch either image
 ---is in the spec, and what it does with them is its own. Nothing it opens has an anchor
 ---map, so this is a read-only detour -- there is nowhere in there to annotate from.
+---
+---Exported because the tree's `gd` hands a file over too, knowing no line in it. What a host
+---is handed is one rule about the scope a review is of, not one rule per surface that can
+---ask for it.
 ---@param file CRFile
 ---@param line integer|nil nil when the caller knows a file but no position in it
 local function hand_to_diff(file, line)
@@ -882,6 +825,8 @@ local function hand_to_diff(file, line)
   })
 end
 
+M.hand_to_diff = hand_to_diff
+
 ---`gd`: read the file under the cursor in the host's diff tool.
 ---
 ---At the line `<CR>` opens, deleted-line fallback and all -- one rule about where a diff
@@ -901,178 +846,35 @@ end
 
 --- Panel actions ---------------------------------------------------------------
 
----@return integer|nil file_index, string|nil dir_path, integer row
-local function panel_at_cursor()
-  if not (V.panel_render and V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
-    return nil, nil, 0
-  end
-  local row = vim.api.nvim_win_get_cursor(V.panel_win)[1]
-  return V.panel_render.row_file[row], V.panel_render.row_dir[row], row
-end
+-- The tree's actions are `view_panel.lua`'s, which is handed this module and the view it
+-- mutates. What is left here are the six names `keymaps.lua` binds onto the tree's buffer,
+-- so that the key table does not learn where the bodies moved to.
 
----Keep the cursor on the same tree row across a repaint, so collapsing a directory does
----not fling the cursor to the top of the panel.
----@param row integer
-local function keep_panel_cursor(row)
-  if V.panel_win and vim.api.nvim_win_is_valid(V.panel_win) then
-    local last = vim.api.nvim_buf_line_count(V.panel_buf)
-    pcall(vim.api.nvim_win_set_cursor, V.panel_win, { math.min(row, last), 0 })
-  end
-end
-
----`<CR>`: open a file, or fold a directory.
 function M.panel_select()
-  local fi, dir, row = panel_at_cursor()
-  if dir then
-    V.collapsed[dir] = not V.collapsed[dir] or nil
-    paint_panel()
-    keep_panel_cursor(row)
-    return
-  end
-  if not fi or not V.render.file_rows[fi] then
-    return
-  end
-  -- Jumping to a reviewed file expands it: you asked to look at it.
-  if V.expanded[V.files[fi].path] == false then
-    V.expanded[V.files[fi].path] = true
-    M.paint()
-  end
-  vim.api.nvim_set_current_win(V.win)
-  goto_row(V.render.file_rows[fi], "zt")
+  view_panel.panel_select(V, M)
 end
 
----`gd` in the tree: read the file under the cursor in the host's diff tool.
----
----With no line. The tree knows which file you are looking at and nothing about where in
----it, and a row that is a directory names no file at all.
 function M.panel_open_diff()
-  if not M.current() then
-    return
-  end
-  local fi = panel_at_cursor()
-  if not fi then
-    return
-  end
-  hand_to_diff(V.files[fi], nil)
+  view_panel.panel_open_diff(V, M)
 end
 
 ---@param shut boolean|nil nil toggles
 function M.panel_fold(shut)
-  local _, dir, row = panel_at_cursor()
-  if not V.panel_render then
-    return
-  end
-
-  if not dir then
-    -- On a file, `h` folds the directory containing it -- the same reflex as in any tree.
-    -- The parent is the nearest directory row above with a SMALLER depth; the nearest one
-    -- by position may be a sibling directory the cursor has already scrolled past.
-    if shut ~= true then
-      return
-    end
-    local depth = V.panel_render.row_depth[row]
-    for r = row - 1, 1, -1 do
-      if V.panel_render.row_dir[r] and (V.panel_render.row_depth[r] or 0) < (depth or 0) then
-        V.collapsed[V.panel_render.row_dir[r]] = true
-        paint_panel()
-        keep_panel_cursor(r)
-        return
-      end
-    end
-    return
-  end
-
-  if shut == nil then
-    V.collapsed[dir] = not V.collapsed[dir] or nil
-  else
-    V.collapsed[dir] = shut or nil
-  end
-  paint_panel()
-  keep_panel_cursor(row)
+  view_panel.panel_fold(V, shut)
 end
 
 ---@param shut boolean
 function M.panel_fold_all(shut)
-  if not M.current() then
-    return
-  end
-  V.collapsed = {}
-  if shut then
-    for _, dir in ipairs(panel.dir_paths(panel.tree(V.files, { reviewed = V.reviewed, notes = V.notes }))) do
-      V.collapsed[dir] = true
-    end
-  end
-  paint_panel()
-  keep_panel_cursor(1)
+  view_panel.panel_fold_all(V, M, shut)
 end
 
----Toggle reviewed from the tree. On a directory, this applies to the whole subtree --
----"I have read this package" is a thing you want to say in one keystroke.
 function M.panel_toggle_reviewed()
-  local fi, dir, row = panel_at_cursor()
-
-  if dir then
-    local indices = panel.files_under(V.files, dir)
-    if #indices == 0 then
-      return
-    end
-    local all_reviewed = true
-    for _, index in ipairs(indices) do
-      if not V.reviewed[V.files[index].path] then
-        all_reviewed = false
-        break
-      end
-    end
-    for _, index in ipairs(indices) do
-      local file = V.files[index]
-      if all_reviewed then
-        V.reviewed[file.path] = nil
-        V.expanded[file.path] = true
-      else
-        V.reviewed[file.path] = file.blob or ""
-        V.expanded[file.path] = false
-      end
-    end
-    M.paint()
-    M.persist()
-    keep_panel_cursor(row)
-    info(
-      ("%s %d file%s under %s"):format(
-        all_reviewed and "Unmarked" or "Marked",
-        #indices,
-        #indices == 1 and "" or "s",
-        dir
-      )
-    )
-    return
-  end
-
-  if not fi then
-    return
-  end
-  local file = V.files[fi]
-  if V.reviewed[file.path] then
-    V.reviewed[file.path] = nil
-    V.expanded[file.path] = true
-  else
-    V.reviewed[file.path] = file.blob or ""
-    V.expanded[file.path] = false
-  end
-  M.paint()
-  M.persist()
-  keep_panel_cursor(row)
+  view_panel.panel_toggle_reviewed(V, M)
 end
 
 ---@param forward boolean
 function M.panel_jump_file(forward)
-  local _, _, row = panel_at_cursor()
-  if not V.panel_render then
-    return
-  end
-  local target = nearest(V.panel_render.file_rows, row, forward)
-  if target then
-    keep_panel_cursor(target)
-  end
+  view_panel.panel_jump_file(V, M, forward)
 end
 
 --- Delivery -------------------------------------------------------------------
@@ -1286,64 +1088,12 @@ end
 
 --- The panel window ------------------------------------------------------------
 
----Build the panel: its window, its buffer and its keymaps.
----
----An operation of its own rather than a step inside `open`, because the toggle has to be
----able to run it again. The panel buffer is `bufhidden = "wipe"`, so a dismissed panel
----leaves nothing to re-attach: the buffer is gone and every keymap bound to it with it.
-local function show_panel()
-  local cfg = config.get()
-  vim.api.nvim_set_current_win(V.win)
-  vim.cmd(cfg.panel.position == "right" and "botright vsplit" or "topleft vsplit")
-  local pwin = vim.api.nvim_get_current_win()
-  local pbuf = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_win_set_buf(pwin, pbuf)
-  view_layout.scratch(pbuf, "codereviewpanel")
-  view_layout.window_opts(pwin)
-  vim.api.nvim_win_set_width(pwin, cfg.panel.width)
-  vim.wo[pwin].winfixwidth = true
-  V.panel_buf, V.panel_win = pbuf, pwin
-  keymaps.panel(pbuf, M)
-  vim.api.nvim_set_current_win(V.win)
-end
+-- The tree's window is `view_panel.lua`'s, built and dismissed there as the before pane is
+-- built and dismissed in `view_layout.lua`. What is left here is the name `keymaps.lua`
+-- binds to `gp` in both the diff and the tree.
 
----Dismiss the panel. Collapsed directories are untouched: they live on the review.
-local function hide_panel()
-  local win = V.panel_win
-  V.panel_buf, V.panel_win, V.panel_render = nil, nil, nil
-  -- The tree follows the diff by repainting only when the cursor crosses into a different
-  -- file. With no tree to repaint, that latch would sit on whatever was being read when it
-  -- was dismissed, and reading that file again once it is back would repaint nothing.
-  V.panel_current = nil
-  -- A reviewer who dismisses the tree is not asking to be left in the window they
-  -- dismissed, so leave it deliberately rather than letting Neovim pick a successor.
-  if vim.api.nvim_get_current_win() == win then
-    vim.api.nvim_set_current_win(V.win)
-  end
-  pcall(vim.api.nvim_win_close, win, true)
-end
-
----Show or dismiss the file tree, from the diff or from the tree itself.
----
----Configuration decides the state a review opens in; this decides it from there on.
 function M.toggle_panel()
-  if not M.current() then
-    return
-  end
-  if V.panel_win and vim.api.nvim_win_is_valid(V.panel_win) then
-    hide_panel()
-  else
-    show_panel()
-  end
-  -- With three windows competing for the terminal's columns, the panel's arrival or
-  -- departure is taken out of, or given back to, whichever pane Neovim picked. Split the
-  -- difference so the two panes stay comparable, which is the whole point of the layout.
-  view_layout.balance_panes(V)
-  -- The diff just changed width and its file headers are padded to that width, so this has
-  -- to repaint. The resize autocmd does not cover it: WinResized is fired from the main
-  -- loop, so it lands after the toggle has returned -- and never at all if nothing else
-  -- pumps the loop, which is exactly the headless case.
-  M.paint()
+  view_panel.toggle_panel(V, M)
 end
 
 --- The layout ------------------------------------------------------------------
@@ -1430,7 +1180,7 @@ function M.open(spec)
     view_layout.show_before_pane(V, M)
   end
   if cfg.panel.enabled then
-    show_panel()
+    view_panel.show_panel(V, M)
   end
   view_layout.balance_panes(V)
 

--- a/lua/codereview/view_panel.lua
+++ b/lua/codereview/view_panel.lua
@@ -1,0 +1,383 @@
+---The file tree's stateful half: its window, its buffer, and the actions its keys run.
+---
+---`panel.lua` is the pure half -- the tree built out of a file list, the single-child chains
+---compacted, what folding leaves visible, the per-directory tallies -- and this is the half
+---that was never split out with it: where that tree is drawn, when it is redrawn, which file
+---it is following, and what each of its keys does to the review underneath it. The same
+---division `render.lua` and `view.lua` already have for the diff.
+---
+---**The review view is handed in rather than required**, as `keymaps.lua`, `queue_float.lua`
+---and `view_layout.lua` are handed it. Where this calls back -- the tree's `<CR>` expands a
+---collapsed file and jumps into the diff, a subtree marked reviewed repaints and persists,
+---and the window toggle repaints -- it takes `view` as an argument. That is what keeps this
+---module out of the cycle `view` and `annotate` already sit in.
+---
+---**`CRView` is handed in too, and mutated in place.** The view is one table, owned by
+---`view.lua`, and the tree's window, its buffer, its render and the file it is following are
+---written onto it here exactly where they were written before -- the same arrangement
+---`syntax.lua` has with its caches. Nothing about a review is copied into a local.
+---
+---The tree's window is not a **pane**: the panes are the two images a split layout draws, and
+---this window sits beside them. What it does share with them is how a review window is made --
+---the scratch buffer, the window options, and the balance the panes need when this one arrives
+---or leaves beside them -- and all three are `view_layout.lua`'s, which this module requires.
+---That edge is one-directional.
+local config = require("codereview.config")
+local keymaps = require("codereview.keymaps")
+local panel = require("codereview.panel")
+local view_layout = require("codereview.view_layout")
+
+local M = {}
+
+local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
+
+---@param msg string
+local function info(msg)
+  vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
+
+--- Painting --------------------------------------------------------------------
+
+---Index of the file the diff cursor is currently inside, for the panel's highlight.
+---@param V CRView
+---@return integer|nil
+local function current_file_index(V)
+  local win, rendered = view_layout.focused_pane(V)
+  if not (rendered and vim.api.nvim_win_is_valid(win)) then
+    return nil
+  end
+  local row = vim.api.nvim_win_get_cursor(win)[1]
+  for r = row, 1, -1 do
+    if rendered.anchors[r] then
+      return rendered.anchors[r].file
+    end
+  end
+  return nil
+end
+
+---@param V CRView
+function M.paint_panel(V)
+  if not (V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
+    return
+  end
+  local cfg = config.get()
+  V.panel_render = panel.build(V.files, {
+    width = vim.api.nvim_win_get_width(V.panel_win),
+    icons = cfg.icons,
+    reviewed = V.reviewed,
+    notes = V.notes,
+    collapsed = V.collapsed,
+    current = current_file_index(V),
+  })
+  vim.bo[V.panel_buf].modifiable = true
+  vim.api.nvim_buf_set_lines(V.panel_buf, 0, -1, false, V.panel_render.lines)
+  vim.bo[V.panel_buf].modifiable = false
+  vim.api.nvim_buf_clear_namespace(V.panel_buf, NS_PANEL, 0, -1)
+  for _, m in ipairs(V.panel_render.marks) do
+    pcall(vim.api.nvim_buf_set_extmark, V.panel_buf, NS_PANEL, m.row, m.col, m.opts)
+  end
+end
+
+---Move the panel's highlight (and cursor, when it is not focused) to follow the diff.
+---
+---Repaints only when the file actually changed: this runs on every CursorMoved, and
+---rebuilding the tree on each keystroke is wasted work on a large review.
+---@param V CRView|nil
+function M.sync_panel(V)
+  if not (V and V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
+    return
+  end
+  local index = current_file_index(V)
+  if index == V.panel_current then
+    return
+  end
+  V.panel_current = index
+  M.paint_panel(V)
+  local row = index and V.panel_render.file_row[index]
+  if row and vim.api.nvim_get_current_win() ~= V.panel_win then
+    pcall(vim.api.nvim_win_set_cursor, V.panel_win, { row, 0 })
+  end
+end
+
+--- Focus -----------------------------------------------------------------------
+
+---Move between the tree and the diff.
+---@param V CRView|nil
+---@param view table The review view, whose window the diff is drawn in.
+function M.toggle_focus(V, view)
+  if not view.current() then
+    return
+  end
+  if not (V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
+    return
+  end
+  if vim.api.nvim_get_current_win() == V.panel_win then
+    vim.api.nvim_set_current_win(V.win)
+  else
+    -- Entering the tree, land on the file being read rather than wherever the cursor was.
+    local index = current_file_index(V)
+    local row = index and V.panel_render and V.panel_render.file_row[index]
+    vim.api.nvim_set_current_win(V.panel_win)
+    if row then
+      pcall(vim.api.nvim_win_set_cursor, V.panel_win, { row, 0 })
+    end
+  end
+end
+
+--- Panel actions ---------------------------------------------------------------
+
+---@param V CRView
+---@return integer|nil file_index, string|nil dir_path, integer row
+local function panel_at_cursor(V)
+  if not (V.panel_render and V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
+    return nil, nil, 0
+  end
+  local row = vim.api.nvim_win_get_cursor(V.panel_win)[1]
+  return V.panel_render.row_file[row], V.panel_render.row_dir[row], row
+end
+
+---Keep the cursor on the same tree row across a repaint, so collapsing a directory does
+---not fling the cursor to the top of the panel.
+---@param V CRView
+---@param row integer
+local function keep_panel_cursor(V, row)
+  if V.panel_win and vim.api.nvim_win_is_valid(V.panel_win) then
+    local last = vim.api.nvim_buf_line_count(V.panel_buf)
+    pcall(vim.api.nvim_win_set_cursor, V.panel_win, { math.min(row, last), 0 })
+  end
+end
+
+---`<CR>`: open a file, or fold a directory.
+---@param V CRView
+---@param view table The review view: the repaint a collapsed file needs, and the arrival.
+function M.panel_select(V, view)
+  local fi, dir, row = panel_at_cursor(V)
+  if dir then
+    V.collapsed[dir] = not V.collapsed[dir] or nil
+    M.paint_panel(V)
+    keep_panel_cursor(V, row)
+    return
+  end
+  if not fi or not V.render.file_rows[fi] then
+    return
+  end
+  -- Jumping to a reviewed file expands it: you asked to look at it.
+  if V.expanded[V.files[fi].path] == false then
+    V.expanded[V.files[fi].path] = true
+    view.paint()
+  end
+  vim.api.nvim_set_current_win(V.win)
+  view.goto_row(V.render.file_rows[fi], "zt")
+end
+
+---`gd` in the tree: read the file under the cursor in the host's diff tool.
+---
+---With no line. The tree knows which file you are looking at and nothing about where in
+---it, and a row that is a directory names no file at all.
+---@param V CRView|nil
+---@param view table The review view, which owns the handover to the host.
+function M.panel_open_diff(V, view)
+  if not view.current() then
+    return
+  end
+  local fi = panel_at_cursor(V)
+  if not fi then
+    return
+  end
+  view.hand_to_diff(V.files[fi], nil)
+end
+
+---@param V CRView
+---@param shut boolean|nil nil toggles
+function M.panel_fold(V, shut)
+  local _, dir, row = panel_at_cursor(V)
+  if not V.panel_render then
+    return
+  end
+
+  if not dir then
+    -- On a file, `h` folds the directory containing it -- the same reflex as in any tree.
+    -- The parent is the nearest directory row above with a SMALLER depth; the nearest one
+    -- by position may be a sibling directory the cursor has already scrolled past.
+    if shut ~= true then
+      return
+    end
+    local depth = V.panel_render.row_depth[row]
+    for r = row - 1, 1, -1 do
+      if V.panel_render.row_dir[r] and (V.panel_render.row_depth[r] or 0) < (depth or 0) then
+        V.collapsed[V.panel_render.row_dir[r]] = true
+        M.paint_panel(V)
+        keep_panel_cursor(V, r)
+        return
+      end
+    end
+    return
+  end
+
+  if shut == nil then
+    V.collapsed[dir] = not V.collapsed[dir] or nil
+  else
+    V.collapsed[dir] = shut or nil
+  end
+  M.paint_panel(V)
+  keep_panel_cursor(V, row)
+end
+
+---@param V CRView|nil
+---@param view table The review view, asked whether there is one at all.
+---@param shut boolean
+function M.panel_fold_all(V, view, shut)
+  if not view.current() then
+    return
+  end
+  V.collapsed = {}
+  if shut then
+    for _, dir in ipairs(panel.dir_paths(panel.tree(V.files, { reviewed = V.reviewed, notes = V.notes }))) do
+      V.collapsed[dir] = true
+    end
+  end
+  M.paint_panel(V)
+  keep_panel_cursor(V, 1)
+end
+
+---Toggle reviewed from the tree. On a directory, this applies to the whole subtree --
+---"I have read this package" is a thing you want to say in one keystroke.
+---@param V CRView
+---@param view table The review view: the repaint and the write to disk this comes with.
+function M.panel_toggle_reviewed(V, view)
+  local fi, dir, row = panel_at_cursor(V)
+
+  if dir then
+    local indices = panel.files_under(V.files, dir)
+    if #indices == 0 then
+      return
+    end
+    local all_reviewed = true
+    for _, index in ipairs(indices) do
+      if not V.reviewed[V.files[index].path] then
+        all_reviewed = false
+        break
+      end
+    end
+    for _, index in ipairs(indices) do
+      local file = V.files[index]
+      if all_reviewed then
+        V.reviewed[file.path] = nil
+        V.expanded[file.path] = true
+      else
+        V.reviewed[file.path] = file.blob or ""
+        V.expanded[file.path] = false
+      end
+    end
+    view.paint()
+    view.persist()
+    keep_panel_cursor(V, row)
+    info(
+      ("%s %d file%s under %s"):format(
+        all_reviewed and "Unmarked" or "Marked",
+        #indices,
+        #indices == 1 and "" or "s",
+        dir
+      )
+    )
+    return
+  end
+
+  if not fi then
+    return
+  end
+  local file = V.files[fi]
+  if V.reviewed[file.path] then
+    V.reviewed[file.path] = nil
+    V.expanded[file.path] = true
+  else
+    V.reviewed[file.path] = file.blob or ""
+    V.expanded[file.path] = false
+  end
+  view.paint()
+  view.persist()
+  keep_panel_cursor(V, row)
+end
+
+---@param V CRView
+---@param view table The review view, whose "nearest row in that direction" rule this shares.
+---@param forward boolean
+function M.panel_jump_file(V, view, forward)
+  local _, _, row = panel_at_cursor(V)
+  if not V.panel_render then
+    return
+  end
+  local target = view.nearest(V.panel_render.file_rows, row, forward)
+  if target then
+    keep_panel_cursor(V, target)
+  end
+end
+
+--- The panel window ------------------------------------------------------------
+
+---Build the panel: its window, its buffer and its keymaps.
+---
+---An operation of its own rather than a step inside `open`, because the toggle has to be
+---able to run it again. The panel buffer is `bufhidden = "wipe"`, so a dismissed panel
+---leaves nothing to re-attach: the buffer is gone and every keymap bound to it with it.
+---@param V CRView
+---@param view table The review view, whose tree keys this buffer is given.
+function M.show_panel(V, view)
+  local cfg = config.get()
+  vim.api.nvim_set_current_win(V.win)
+  vim.cmd(cfg.panel.position == "right" and "botright vsplit" or "topleft vsplit")
+  local pwin = vim.api.nvim_get_current_win()
+  local pbuf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_win_set_buf(pwin, pbuf)
+  view_layout.scratch(pbuf, "codereviewpanel")
+  view_layout.window_opts(pwin)
+  vim.api.nvim_win_set_width(pwin, cfg.panel.width)
+  vim.wo[pwin].winfixwidth = true
+  V.panel_buf, V.panel_win = pbuf, pwin
+  keymaps.panel(pbuf, view)
+  vim.api.nvim_set_current_win(V.win)
+end
+
+---Dismiss the panel. Collapsed directories are untouched: they live on the review.
+---@param V CRView
+local function hide_panel(V)
+  local win = V.panel_win
+  V.panel_buf, V.panel_win, V.panel_render = nil, nil, nil
+  -- The tree follows the diff by repainting only when the cursor crosses into a different
+  -- file. With no tree to repaint, that latch would sit on whatever was being read when it
+  -- was dismissed, and reading that file again once it is back would repaint nothing.
+  V.panel_current = nil
+  -- A reviewer who dismisses the tree is not asking to be left in the window they
+  -- dismissed, so leave it deliberately rather than letting Neovim pick a successor.
+  if vim.api.nvim_get_current_win() == win then
+    vim.api.nvim_set_current_win(V.win)
+  end
+  pcall(vim.api.nvim_win_close, win, true)
+end
+
+---Show or dismiss the file tree, from the diff or from the tree itself.
+---
+---Configuration decides the state a review opens in; this decides it from there on.
+---@param V CRView|nil
+---@param view table The review view, whose repaint the new width comes due for.
+function M.toggle_panel(V, view)
+  if not view.current() then
+    return
+  end
+  if V.panel_win and vim.api.nvim_win_is_valid(V.panel_win) then
+    hide_panel(V)
+  else
+    M.show_panel(V, view)
+  end
+  -- With three windows competing for the terminal's columns, the panel's arrival or
+  -- departure is taken out of, or given back to, whichever pane Neovim picked. Split the
+  -- difference so the two panes stay comparable, which is the whole point of the layout.
+  view_layout.balance_panes(V)
+  -- The diff just changed width and its file headers are padded to that width, so this has
+  -- to repaint. The resize autocmd does not cover it: WinResized is fired from the main
+  -- loop, so it lands after the toggle has returned -- and never at all if nothing else
+  -- pumps the loop, which is exactly the headless case.
+  view.paint()
+end
+
+return M

--- a/tests/README.md
+++ b/tests/README.md
@@ -299,8 +299,12 @@ so the out-of-core language path is still checked locally without ever failing C
   and fed keys all propagate to the bound window, and `nvim_win_set_cursor` does not.
   Driving a binding assertion through the API therefore passes whether or not the binding
   exists — the failure mode `interactive_spec` exists to avoid — so `split_spec` drives
-  `normal!` and asserts the *other* pane followed. Removing the two `vim.wo` lines in
-  `view.lua`'s `show_before_pane` must fail three cases. The same asymmetry is why the view
+  `normal!` and asserts the *other* pane followed. The cut that bites is in
+  `view_layout.lua`'s `place`: turning its closing `bind_panes(true)` into
+  `bind_panes(false)` must fail three cases in `split_spec` and one in `layout_spec`.
+  `show_before_pane`'s own two `vim.wo` lines are belt and braces, and deleting them fails
+  nothing — `M.open` ends in `place(1)` and every jump goes through `place`, so the binding
+  is established there regardless of what built the pane. The same asymmetry is why the view
   sets both panes' cursors explicitly instead of trusting the binding to carry one across.
 - **Two panes that were never moved apart cannot be seen coming back together.** The first
   version of "both panes hold their alignment across every repaint" passed with `resync()`
@@ -357,7 +361,7 @@ so the out-of-core language path is still checked locally without ever failing C
   gap between groups instead. `queue_float_spec` keeps a third entry of another type for
   the claim that actually is about types.
 - **`interactive_spec` must keep its teeth.** To confirm it still reproduces the bug,
-  remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view.lua` and the
+  remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view_layout.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless
   version of that test passes whether or not the fix exists, which is why it drives a pty.
 - **A set comparison passes when one set was never read.** `map_spec` matches the module


### PR DESCRIPTION
Last of the three slices off #95, and the one that completes it. 383 lines arrive in
`lua/codereview/view_panel.lua`; `view.lua` goes from 1455 to 1205 — from 1748 at the start
of the PRD, a 31% cut.

Two commits. The move is one, because any cut through the middle of it is either red on
`map_spec` or does not compile; the `tests/README.md` corrections are the other, because
they are about coverage that predates this branch and should bisect on their own.

## What moved

The tree's window and buffer and their dismissal (`show_panel`, `hide_panel`), the repaint
(`paint_panel`), the follow-the-cursor sync and its latch (`sync_panel`), the index of the
file the diff cursor is inside (`current_file_index`), the row-under-cursor and
cursor-keeping helpers (`panel_at_cursor`, `keep_panel_cursor`), the six actions its keys
run (`panel_select`, `panel_open_diff`, `panel_fold`, `panel_fold_all`,
`panel_toggle_reviewed`, `panel_jump_file`), `toggle_focus` — which is about the tree's
existence rather than about the diff — and `toggle_panel`. The `codereview_panel`
namespace went with the repaint that is its only user.

`panel.lua` is untouched. It was always the pure half; this is the half that was never
split out with it.

## The seam

**`view_panel.lua` requires four modules and `view` is not one of them.** `config`,
`keymaps`, `panel` and `view_layout`. Where it calls back — `<CR>` expands a collapsed file
and jumps into the diff, a subtree marked reviewed repaints and persists, the window toggle
repaints — it takes `view` as an argument, exactly as `keymaps.lua`, `queue_float.lua` and
`view_layout.lua` do. **The two known cycles are still two.**

**The edge to `view_layout.lua` is one-directional**, and it carries four things rather than
the three the issue anticipated: `scratch` and `window_opts` build the tree's window,
`balance_panes` settles the panes when it arrives or leaves beside them, and `focused_pane`
is what `current_file_index` reads the diff cursor out of. The reverse edge — the tree's
sync inside the pane autocommand — was dissolved by #96 and is not back. Final graph:
`view` → `view_panel` → `view_layout`.

**`V` is one table and `view.lua` still owns it.** `CRView` is an explicit argument here and
mutated in place. The repaint still writes `panel_render` and `panel_current` onto the table
`view.current()` returns, which is what `panel_spec` and `queue_jump_panel_spec` read, and
is the reason this lands with no spec edited.

**Eight names re-exported**, so `keymaps.lua` does not learn about the split: the six tree
actions plus `toggle_focus` and `toggle_panel`. Thin wrappers rather than aliases, as #97
did, because `V` is a module local the sibling cannot see.

## Two names the issue did not anticipate, in the other direction

Both are the same shape as `goto_row` in #97 — a call site left behind rather than a body.

**`nearest`.** The tree's `]f`/`[f` walks its own file rows exactly as the diff's does, and
that helper is a module local in `view.lua` with three other callers that all stay. Moving
it would have pointed a diff-navigation rule at the file tree; copying it would have been a
rewrite rather than a move. One rule about "the nearest row in that direction" beats two.

**`hand_to_diff`.** The tree's `gd` and the diff's `gd` hand a file to the host's diff tool
by the same rule, differing only in that the tree knows no line. `open_diff` stays in
`view.lua` and `panel_open_diff` moves, so the shared body had to be reachable from both.
What a host is handed is one rule about the scope a review is of, not one per surface that
can ask for it — so it is exported where `V.root` and `V.scope` are, and the tree reaches it
through the view it was already handed.

## Two modules `view.lua` stops requiring

`panel` and `keymaps` both drop out. Every reach into `panel` was the tree's repaint, its
fold-all and its subtree review; the only reach into `keymaps` was `keymaps.panel` inside
`show_panel`, `keymaps.diff` having gone to `view_layout.attach_pane` in #97. So the hub
count moves **down**, not up: `view` requires thirteen modules now rather than fourteen,
counted rather than assumed (`grep -oE 'require\("codereview\.[a-z_]+"\)' | sort -u`).

## Traps preserved

- **`h` on a file still folds its parent by depth.** The scan for the nearest directory row
  above with a *smaller* depth travelled intact, capitalised `SMALLER` and all. Proved below.
- **The repaint latch is still `V.panel_current`**, and `sync_panel` still returns before
  building anything unless the diff cursor crossed into a different file — it is on the
  `CursorMoved` path and rebuilding per keystroke is real work on a large review.
- **Dismissing still clears that latch.** `hide_panel` still nils `panel_current`, so reading
  the same file again after summoning the tree repaints rather than sitting on a stale index.
- **The tree's buffer is still `bufhidden = "wipe"`**, and `show_panel` is still an operation
  rather than a step inside `open`, so a re-summoned tree is built fresh and given the whole
  key set again.
- **`toggle_panel` still rebalances and repaints itself.** The comment saying why it cannot
  lean on the resize autocommand — `WinResized` fires from the main loop, so it lands after
  the toggle returns and never at all headless — travelled with it.
- **`toggle_focus` still lands on the file being read**, not wherever the tree's cursor was.

Nothing was renamed and nothing reworded. Every docstring travelled with the function it
documents; the only prose edited in place is `view.lua`'s header, `goto_row`'s note about
which module follows the diff with the tree, and the section comments left where bodies
were — the same three kinds of edit #97 made.

## Verification

`make all` green, exit 0. **Zero diff under `tests/codereview/`** — the change is
`view_panel.lua`, `view.lua`, `lua/codereview/CLAUDE.md` and `tests/README.md`, nothing
else. **30 spec files, 1115 assertions, 0 failures, 0 errors**, identical to the baseline
measured on this branch before the change. Read from a file, not a pipe, and judged on the
runner's exit code rather than a summed tally.

`panel_spec` (47) and `queue_jump_panel_spec` (12) pass unedited, as do `focus_spec` (38),
`open_diff_spec` (16), `layout_spec` (50) and `split_spec` (81).

Three checks that the moved code is the code under test:

- **The map row is what makes `map_spec` green.** Deleting the `view_panel.lua` row fails
  "carries a row for every module" and passes again with it back. The spec was not touched.
- **The parent-by-depth rule still bites where it now lives.** Cutting the moved scan down
  to the nearest directory row above — dropping the `row_depth[r] < depth` test — reds
  `panel_spec`'s "folding h on a file folds its own parent, not the sibling above it", and
  only that one. It is the trap that would silently survive a careless move.
- **The binding check does not bite where `tests/README.md` says it does**, which is the
  second commit.

## The two `tests/README.md` corrections

Measured on `16badd2` before rewriting anything, both directions:

- Deleting `show_before_pane`'s two `vim.wo` lines: `split_spec` 81/81, `layout_spec` 50/50.
  **Fails nothing.** `place` ends with `bind_panes(true)`, `M.open` ends with `place(1)`, and
  every jump goes through `place`, so the binding is re-established regardless.
- Turning `place`'s closing `bind_panes(true)` into `bind_panes(false)`: **three `split_spec`
  cases and one `layout_spec` case**, namely "binds scrolling and the cursor in both panes",
  "moves the cursor in one pane by moving it in the other", "scrolls one pane by scrolling
  the other", and "the pane a toggle rebuilt is still bound to the after pane for scrolling".

So the entry's *count* was right and its *cut point* was wrong; the coverage was never
missing. It now names `place` and says plainly that `show_before_pane`'s own lines are belt
and braces. The `interactive_spec` entry's `view.lua` was corrected to `view_layout.lua` at
the same time — pure file-name drift from #97, no assertion affected.

One more instance of that drift is **left alone deliberately**: `docs/agents/HANDOFF.md:77`
names `view.lua` for the same insert-mode autocommand. That file is a dated record of what
was verified at a point in time rather than a live reference, and retro-editing it is the
maintainer's call, not mine.

## `make perf`

Six runs each side, back to back on the same machine; before is `16badd2` with these changes
stashed, so both sides ran under the same load.

| | before | after |
| --- | --- | --- |
| open, 60 files | 155 / 175 / 170 / 165 / 168 / 160 ms | 198 / 164 / 166 / 161 / 174 / 171 ms |
| open, 300 files | 532 / 534 / 601 / 540 / 561 / 545 ms | 548 / 532 / 508 / 524 / 539 / 550 ms |
| repaint, 60 files | 30 / 27 / 29 / 34 / 28 / 31 ms | 37 / 38 / 25 / 30 / 35 / 36 ms |
| repaint, 300 files | 111 / 153 / 115 / 104 / 98 / 122 ms | 105 / 100 / 124 / 126 / 102 / 103 ms |
| cursor move | 0.0 ms both sizes | 0.0 ms both sizes |
| 50 held keystrokes | 1 ms both sizes | 0 ms both sizes |

Every row straddles. The figure that matters here is the last two: `sync_panel` is on the
`CursorMoved` path and an accidental extra lookup there is the one performance mistake this
slice could make, and 50 held keystrokes measure at or below the timer's floor on both
sides. The three earlier "before" readings were taken before the change and the three later
ones from a stash after it, and they interleave, which is the best evidence available that
the spread is the machine rather than the diff. Not a gate.

## Module map

`lua/codereview/CLAUDE.md` gains a row for `view_panel.lua` and loses "the file tree" from
`view.lua`'s, the same correction #100 made when the layout left. The stacking line puts it
in a band of its own above `view_layout`, the hub count reads thirteen rather than fourteen,
and the cycles paragraph names it as a fourth module that takes the view's actions as an
argument, with the note that the one edge between it and `view_layout` points one way.

No key, window, repaint or notification changed.

Closes #98
