### PR TITLE
refactor(view): lift the file-crossing latch out of the tree

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -336,7 +336,10 @@ tree depth, and the parent is the nearest directory row above with a smaller one
 
 **The panel repaints only when the cursor crosses into a different file.** Following the
 diff cursor runs on every `CursorMoved`; rebuilding the tree on each keystroke is real work
-on a large review.
+on a large review. The crossing is judged on the view rather than inside the tree's sync,
+and judged whether or not there is a tree — a latch that stopped with the window would sit
+on the file being read at the moment the tree was dismissed, and reading that same file
+again once it was back would repaint nothing.
 
 ## Windows, modes and focus
 

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -56,8 +56,8 @@ local NS = vim.api.nvim_create_namespace("codereview")
 ---@field augroup integer                 Autocommands belonging to this review
 ---@field render CRRender|nil             The after pane's render
 ---@field before_render CRRender|nil      nil in the unified layout
+---@field current_file integer|nil        File index the diff cursor is in; the crossing latch
 ---@field panel_render CRPanelRender|nil
----@field panel_current integer|nil       File index the tree is following; its repaint latch
 ---@field painted_bands table<integer, boolean>|nil  Row bands whose marks have been emitted
 ---@field syntax_cache table<string, CRCapture[]|false>  `path|side` -> captures; false to skip it
 ---@field syntax_painted table<string, boolean>|nil      Path -> already replayed onto this render
@@ -108,7 +108,9 @@ end
 
 -- The file tree is painted by `view_panel.lua`, which is handed the view it mutates. What
 -- is left here is the diff's own paint, and the two moments the tree comes due with it: a
--- repaint of everything, and a cursor that crossed into a different file.
+-- repaint of everything, and a cursor that crossed into a different file. Which file that
+-- is stays here -- see `current_file` below -- because it is a fact about the diff, and the
+-- tree is only the first thing to ask for it.
 
 local function update_winbar()
   if not vim.api.nvim_win_is_valid(V.win) then
@@ -298,7 +300,7 @@ function M.paint(keep_file)
   -- paint: what a band means is decided by the render it was emitted from.
   V.painted_bands = {}
 
-  view_panel.paint_panel(V)
+  view_panel.paint_panel(V, M)
   update_winbar()
   update_before_winbar()
 
@@ -323,31 +325,6 @@ function M.paint(keep_file)
   end
 
   view_layout.resync(V)
-end
-
----Everything a moved cursor comes due for, in the order it comes due.
----
----Both the diff's own marks and its highlighting are bounded by the viewport, so
----scrolling into rows nothing has been emitted onto is what emits them, and scrolling
----into an un-parsed file is what triggers its parse. One trigger for the two of them:
----they share a margin, so they come due at the same moment. Cheap on every other scroll --
----a band already emitted is a lookup, an already-painted file is skipped, and an
----already-parsed one repaints from cache.
----
----Exported so that the autocommand driving it wires one name rather than reaching into
----three internals at once. It runs on every keystroke a reviewer holds, so the guards
----here are what keep it cheap rather than decoration around it.
-function M.cursor_moved()
-  if not M.current() then
-    return
-  end
-  paint_bands()
-  if config.get().syntax then
-    require("codereview.syntax").apply(V, NS)
-  end
-  -- Keeps the tree pointed at whatever the diff cursor is reading. Cheap: it returns
-  -- immediately unless the cursor crossed into a different file.
-  view_panel.sync_panel(V)
 end
 
 ---Write progress to disk. Called from every mutation rather than from `paint`, which
@@ -405,8 +382,77 @@ local function file_at_cursor()
   return V.files[anchor.file], anchor.file
 end
 
+---Which file the diff cursor is in, as an index into `V.files`.
+---
+---The one answer to that, for everything that follows the diff from one file into the
+---next. It is a question about the diff and its anchor map, so it is asked here rather
+---than inside whichever surface happens to want it: the file tree is an interested party,
+---not the authority, and a copy kept there would put a fact about the diff behind a
+---require on the tree's module.
+---
+---The window check is the tree's own, moved with it: this is reached from a paint, and a
+---render that outlives its window by a tick must answer nil rather than raise.
+---@return integer|nil
+local function current_file()
+  local win = view_layout.focused_pane(V)
+  if not vim.api.nvim_win_is_valid(win) then
+    return nil
+  end
+  local anchor = anchor_at_cursor()
+  return anchor and anchor.file
+end
+
 M.anchor_at_cursor = anchor_at_cursor
 M.file_at_cursor = file_at_cursor
+M.current_file = current_file
+
+--- Following the diff ----------------------------------------------------------
+
+---Everything that comes due when the cursor crosses into a different file.
+---
+---The latch is the view's rather than the tree's, and it is judged whether or not there is
+---a tree to repaint. That is the whole of it: a latch that stopped running when the tree
+---was dismissed would sit on the file being read at the moment it went away, and reading
+---that same file again once the tree was back would repaint nothing. Running it always is
+---also what lets a second consumer hang off it -- the crossing is a fact about the diff,
+---and the tree is one caller of it.
+---
+---Everything that follows the diff hangs off the crossing rather than off the movement:
+---this is reached from every `CursorMoved`, and rebuilding the tree on each keystroke is
+---real work on a large review.
+local function follow_file()
+  local index = current_file()
+  if index == V.current_file then
+    return
+  end
+  V.current_file = index
+  view_panel.sync_panel(V, M)
+end
+
+---Everything a moved cursor comes due for, in the order it comes due.
+---
+---Both the diff's own marks and its highlighting are bounded by the viewport, so
+---scrolling into rows nothing has been emitted onto is what emits them, and scrolling
+---into an un-parsed file is what triggers its parse. One trigger for the two of them:
+---they share a margin, so they come due at the same moment. Cheap on every other scroll --
+---a band already emitted is a lookup, an already-painted file is skipped, and an
+---already-parsed one repaints from cache.
+---
+---Exported so that the autocommand driving it wires one name rather than reaching into
+---three internals at once. It runs on every keystroke a reviewer holds, so the guards
+---here are what keep it cheap rather than decoration around it.
+function M.cursor_moved()
+  if not M.current() then
+    return
+  end
+  paint_bands()
+  if config.get().syntax then
+    require("codereview.syntax").apply(V, NS)
+  end
+  -- Cheap: an anchor lookup, and then nothing at all unless the cursor left the file it
+  -- was in.
+  follow_file()
+end
 
 --- Actions ---------------------------------------------------------------------
 
@@ -444,11 +490,15 @@ M.nearest = nearest
 ---it is the one arrival the two halves of this share: placing the panes is
 ---`view_layout.lua`'s and following the diff with the tree is `view_panel.lua`'s, so the
 ---pair is glued where the view that owns both is.
+---
+---A jump moves the cursor itself rather than waiting for `CursorMoved`, so the crossing is
+---judged here too -- and by the same latch, so a jump that lands in the file already being
+---read costs what standing still costs.
 ---@param row integer
 ---@param cmd string|nil `zt`, `zz`, or nil to leave the window where it is
 local function goto_row(row, cmd)
   view_layout.place(V, row, cmd)
-  view_panel.sync_panel(V)
+  follow_file()
 end
 
 M.goto_row = goto_row
@@ -860,7 +910,7 @@ end
 
 ---@param shut boolean|nil nil toggles
 function M.panel_fold(shut)
-  view_panel.panel_fold(V, shut)
+  view_panel.panel_fold(V, M, shut)
 end
 
 ---@param shut boolean

--- a/lua/codereview/view_panel.lua
+++ b/lua/codereview/view_panel.lua
@@ -2,20 +2,28 @@
 ---
 ---`panel.lua` is the pure half -- the tree built out of a file list, the single-child chains
 ---compacted, what folding leaves visible, the per-directory tallies -- and this is the half
----that was never split out with it: where that tree is drawn, when it is redrawn, which file
----it is following, and what each of its keys does to the review underneath it. The same
----division `render.lua` and `view.lua` already have for the diff.
+---that was never split out with it: where that tree is drawn, when it is redrawn, and what
+---each of its keys does to the review underneath it. The same division `render.lua` and
+---`view.lua` already have for the diff.
+---
+---**Which file the diff cursor is in is not this module's.** The tree highlights it and
+---follows it, but it is a fact about the diff and its anchor map, so it is `view.lua`'s
+---`current_file` -- asked for here, never kept here. The crossing that decides *repaint
+---now* is `view.lua`'s too, and is judged whether or not there is a tree; this module is
+---told, it does not ask. That is what lets a second surface follow the same crossing
+---without reaching down into the tree for it.
 ---
 ---**The review view is handed in rather than required**, as `keymaps.lua`, `queue_float.lua`
 ---and `view_layout.lua` are handed it. Where this calls back -- the tree's `<CR>` expands a
 ---collapsed file and jumps into the diff, a subtree marked reviewed repaints and persists,
----and the window toggle repaints -- it takes `view` as an argument. That is what keeps this
----module out of the cycle `view` and `annotate` already sit in.
+---the window toggle repaints, and every paint asks which file the cursor is in -- it takes
+---`view` as an argument. That is what keeps this module out of the cycle `view` and
+---`annotate` already sit in.
 ---
 ---**`CRView` is handed in too, and mutated in place.** The view is one table, owned by
----`view.lua`, and the tree's window, its buffer, its render and the file it is following are
----written onto it here exactly where they were written before -- the same arrangement
----`syntax.lua` has with its caches. Nothing about a review is copied into a local.
+---`view.lua`, and the tree's window, its buffer and its render are written onto it here
+---exactly where they were written before -- the same arrangement `syntax.lua` has with its
+---caches. Nothing about a review is copied into a local.
 ---
 ---The tree's window is not a **pane**: the panes are the two images a split layout draws, and
 ---this window sits beside them. What it does share with them is how a review window is made --
@@ -38,25 +46,9 @@ end
 
 --- Painting --------------------------------------------------------------------
 
----Index of the file the diff cursor is currently inside, for the panel's highlight.
 ---@param V CRView
----@return integer|nil
-local function current_file_index(V)
-  local win, rendered = view_layout.focused_pane(V)
-  if not (rendered and vim.api.nvim_win_is_valid(win)) then
-    return nil
-  end
-  local row = vim.api.nvim_win_get_cursor(win)[1]
-  for r = row, 1, -1 do
-    if rendered.anchors[r] then
-      return rendered.anchors[r].file
-    end
-  end
-  return nil
-end
-
----@param V CRView
-function M.paint_panel(V)
+---@param view table The review view, asked which file the diff cursor is in.
+function M.paint_panel(V, view)
   if not (V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
     return
   end
@@ -67,7 +59,11 @@ function M.paint_panel(V)
     reviewed = V.reviewed,
     notes = V.notes,
     collapsed = V.collapsed,
-    current = current_file_index(V),
+    -- Asked, rather than read off `V.current_file`: a paint can run between two crossings
+    -- -- a fold, a resize, the tree arriving beside a cursor nothing has moved since. The
+    -- two agree everywhere `CursorMoved` has reached, so the suite cannot tell them apart;
+    -- asking is what the tree did for itself before this moved, and a prefactor keeps it.
+    current = view.current_file(),
   })
   vim.bo[V.panel_buf].modifiable = true
   vim.api.nvim_buf_set_lines(V.panel_buf, 0, -1, false, V.panel_render.lines)
@@ -80,19 +76,18 @@ end
 
 ---Move the panel's highlight (and cursor, when it is not focused) to follow the diff.
 ---
----Repaints only when the file actually changed: this runs on every CursorMoved, and
----rebuilding the tree on each keystroke is wasted work on a large review.
+---Reached only when the diff cursor has crossed into a different file -- `view.lua` judges
+---that, and does so with or without a tree. Rebuilding the tree on each keystroke is
+---wasted work on a large review, so the cheapness that guard buys is unchanged; what
+---changed is that the guard is no longer this module's to hold.
 ---@param V CRView|nil
-function M.sync_panel(V)
+---@param view table The review view, asked which file the diff cursor is now in.
+function M.sync_panel(V, view)
   if not (V and V.panel_win and vim.api.nvim_win_is_valid(V.panel_win)) then
     return
   end
-  local index = current_file_index(V)
-  if index == V.panel_current then
-    return
-  end
-  V.panel_current = index
-  M.paint_panel(V)
+  M.paint_panel(V, view)
+  local index = view.current_file()
   local row = index and V.panel_render.file_row[index]
   if row and vim.api.nvim_get_current_win() ~= V.panel_win then
     pcall(vim.api.nvim_win_set_cursor, V.panel_win, { row, 0 })
@@ -115,7 +110,7 @@ function M.toggle_focus(V, view)
     vim.api.nvim_set_current_win(V.win)
   else
     -- Entering the tree, land on the file being read rather than wherever the cursor was.
-    local index = current_file_index(V)
+    local index = view.current_file()
     local row = index and V.panel_render and V.panel_render.file_row[index]
     vim.api.nvim_set_current_win(V.panel_win)
     if row then
@@ -154,7 +149,7 @@ function M.panel_select(V, view)
   local fi, dir, row = panel_at_cursor(V)
   if dir then
     V.collapsed[dir] = not V.collapsed[dir] or nil
-    M.paint_panel(V)
+    M.paint_panel(V, view)
     keep_panel_cursor(V, row)
     return
   end
@@ -188,8 +183,9 @@ function M.panel_open_diff(V, view)
 end
 
 ---@param V CRView
+---@param view table The review view, asked which file the diff cursor is in.
 ---@param shut boolean|nil nil toggles
-function M.panel_fold(V, shut)
+function M.panel_fold(V, view, shut)
   local _, dir, row = panel_at_cursor(V)
   if not V.panel_render then
     return
@@ -206,7 +202,7 @@ function M.panel_fold(V, shut)
     for r = row - 1, 1, -1 do
       if V.panel_render.row_dir[r] and (V.panel_render.row_depth[r] or 0) < (depth or 0) then
         V.collapsed[V.panel_render.row_dir[r]] = true
-        M.paint_panel(V)
+        M.paint_panel(V, view)
         keep_panel_cursor(V, r)
         return
       end
@@ -219,7 +215,7 @@ function M.panel_fold(V, shut)
   else
     V.collapsed[dir] = shut or nil
   end
-  M.paint_panel(V)
+  M.paint_panel(V, view)
   keep_panel_cursor(V, row)
 end
 
@@ -236,7 +232,7 @@ function M.panel_fold_all(V, view, shut)
       V.collapsed[dir] = true
     end
   end
-  M.paint_panel(V)
+  M.paint_panel(V, view)
   keep_panel_cursor(V, 1)
 end
 
@@ -343,10 +339,14 @@ end
 local function hide_panel(V)
   local win = V.panel_win
   V.panel_buf, V.panel_win, V.panel_render = nil, nil, nil
-  -- The tree follows the diff by repainting only when the cursor crosses into a different
-  -- file. With no tree to repaint, that latch would sit on whatever was being read when it
-  -- was dismissed, and reading that file again once it is back would repaint nothing.
-  V.panel_current = nil
+  -- `V.current_file` is deliberately left alone. It used to be cleared here, because the
+  -- crossing was judged inside this module's sync and stopped being judged the moment the
+  -- window went away -- so the latch sat on whatever was being read at that instant, and
+  -- reading that file again once the tree was back repainted nothing. The crossing is
+  -- `view.lua`'s now and keeps being judged with no tree, so the latch tracks a reviewer
+  -- through a dismissed tree instead of going stale behind one, and clearing it would only
+  -- forge a crossing that did not happen. `panel_spec` pins the property either way.
+  --
   -- A reviewer who dismisses the tree is not asking to be left in the window they
   -- dismissed, so leave it deliberately rather than letting Neovim pick a successor.
   if vim.api.nvim_get_current_win() == win then

--- a/tests/codereview/panel_spec.lua
+++ b/tests/codereview/panel_spec.lua
@@ -233,7 +233,7 @@ describe("panel and diff staying in sync", function()
   vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
 
   it("follows the diff cursor", function()
-    assert.same(5, V.panel_current)
+    assert.same(5, V.current_file)
   end)
 
   it("highlights exactly the current file's row", function()
@@ -481,6 +481,23 @@ describe("a review configured to start without a tree", function()
 
   it("opens with none", function()
     assert.is_nil(W.panel_win)
+  end)
+
+  -- The crossing is the diff's, not the tree's, so it is judged where there has never been
+  -- a tree to repaint -- the case the tree's own highlight can say nothing about. Two
+  -- crossings rather than one: a latch that never moved off its first value would pass a
+  -- single absolute assertion.
+  it("notices a file crossing with no tree to repaint", function()
+    local function look_at(index)
+      vim.api.nvim_win_set_cursor(W.win, { W.render.file_rows[index], 0 })
+      vim.api.nvim_exec_autocmds("CursorMoved", { buffer = W.buf })
+    end
+
+    assert.is_nil(W.panel_win)
+    look_at(3)
+    assert.same(3, W.current_file)
+    look_at(1)
+    assert.same(1, W.current_file)
   end)
 
   it("summons one on the keystroke", function()

--- a/tests/codereview/panel_spec.lua
+++ b/tests/codereview/panel_spec.lua
@@ -445,8 +445,11 @@ describe("dismissing and summoning the tree", function()
     view.toggle_reviewed()
   end)
 
-  -- The tree repaints only when the diff cursor crosses into a different file, and while
-  -- there is no tree to repaint that latch is holding a file nobody is reading any more.
+  -- The tree repaints only when the diff cursor crosses into a different file, and the
+  -- crossing is judged with no tree to repaint -- so the latch tracks a reviewer through a
+  -- dismissed tree rather than freezing on the file that was being read when it went away.
+  -- The crossing *back* at the end is what pins that: against a latch that had frozen, it
+  -- would not read as a crossing at all, and the highlight would stay where it was.
   it("follows the diff cursor again once it is back", function()
     local function look_at(index)
       vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index], 0 })


### PR DESCRIPTION
Closes #103.

A prefactor. No new behaviour, nothing new drawn — its whole value is that it changes nothing a reviewer can see, so that #104 becomes possible.

## What moved, and where

Two facts about the **diff** cursor lived inside the **file tree**:

| Fact | Before | After |
| --- | --- | --- |
| Which file the cursor is in | `view_panel.current_file_index(V)`, module-private | `view.current_file()`, beside `anchor_at_cursor`/`file_at_cursor` |
| Whether it just crossed into a different one | latched inside `view_panel.sync_panel` | `follow_file()` in `view.lua`, judged with or without a tree |

`sync_panel` returned early when the tree was dismissed, so with no tree open nothing noticed a crossing at all. It is now reached *only* on a crossing — `view.lua` decides that — and the tree is one caller of the answer rather than its owner. `view_panel` keeps `sync_panel`'s window guard and its laziness; what it no longer keeps is the decision.

`M.cursor_moved` moved below the cursor-query block so `follow_file` is lexically after the `anchor_at_cursor` it is judged from; `M.persist` stays where it was. `paint_panel` and `panel_fold` gained the `view` argument the module's other exports already take.

**Module direction is intact.** `view_panel.lua` requires `config`, `keymaps`, `panel`, `view_layout` — not `view`. The view hands itself in, as #105 established, and no fact about the diff sits behind a require on the tree.

## The naming decision

**Renamed.** `V.panel_current` → `V.current_file`, `File index the diff cursor is in; the crossing latch`.

#98 declared the view's fields a contract because specs read them, so this was a deliberate call rather than a drive-by. Once the latch is no longer the tree's, `panel_` says the wrong thing: it would leave a field named for one consumer owning a fact the diff owns, and #104's winbar hangs off the same field from the other side. Keeping the name would have meant the sticky header reading `panel_current` to find out which file it is in, which is the coupling this slice exists to remove. Its one reader was updated with it.

## Dismissing and summoning

`hide_panel` no longer clears the latch, and this is the part most worth reviewing.

The clear existed because the crossing was judged inside the tree's sync and stopped being judged the moment the window went away — so the latch sat on the file being read at that instant, and reading that same file again once the tree was back repainted nothing. A latch that keeps running cannot go stale that way: it tracks the reviewer *through* the dismissal. Clearing it now would only forge a crossing that did not happen.

Proved by breaking it rather than by assertion. Re-gating `follow_file` on the tree's existence — reintroducing exactly the old failure mode — fails four cases:

- `panel_spec` — `dismissing and summoning the tree follows the diff cursor again once it is back` (line 466: expected 3, got 4)
- `panel_spec` — `a review configured to start without a tree notices a file crossing with no tree to repaint` (line 498)
- `queue_jump_panel_spec` — `follows the jump back into the file it was dismissed on`
- `queue_jump_panel_spec` — `takes the tree's own cursor there too`

So the property has teeth against the new code, not just the old.

## Spec lines touched

Two edits, both in `tests/codereview/panel_spec.lua`. No assertion was weakened.

- **Line 236**, a rename: `assert.same(5, V.panel_current)` → `assert.same(5, V.current_file)`. The one reader of the renamed field.
- **Lines 486–502**, one added case: `notices a file crossing with no tree to repaint`. Acceptance criterion 1 asks for a crossing detected with the tree *never having been opened*, and the tree's own highlight can say nothing about that case — there is no tree to highlight. It reads the field, guards that `panel_win` really is nil, and asserts two crossings rather than one so a latch stuck on its first value cannot pass.

Suite goes 1145 → 1146 passing, the delta being exactly that case.

## One thing worth flagging

`paint_panel` asks `view.current_file()` fresh rather than reading `V.current_file`. I checked whether that choice is load-bearing by trying the other one: reading the latch passes the entire suite, including both tree specs. The two agree everywhere `CursorMoved` has reached, which is most places. I kept the fresh read because it is literally what the tree computed for itself before the move, and a prefactor should not quietly change which of two equivalent answers a paint uses — the code comment records that the suite cannot tell them apart, rather than claiming a scenario it does not pin.

`docs/design-notes.md` gains one sentence to the existing file-tree note, recording that the crossing is judged outside the tree and why a latch that stopped with the window goes stale. Deliberately scoped to that note — it is a different section from the ones slice-102 will touch, so the rebase stays trivial. No module was added or removed, and nothing in `lua/codereview/CLAUDE.md` became false.

## Verifying

`make all` passes: exit 0, no `Tests Failed`, 1146 successes. `make perf` is unchanged — cursor move 0.0 ms at both the 60- and 300-file tiers, and the tree still repaints only on a crossing.