### PR TITLE
feat(view): mute the review window that does not have focus

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,17 @@ One of the two windows in a split layout, holding the before- or the after-image
 _side_: a diff line's side is already add/del/ctx, and one word must not do two jobs.
 _Avoid_: side, column, window
 
+**Muted**:
+Said of a review window that does not have focus: its colours pulled toward the background
+through a highlight namespace of its own, so the focused window is the bright one and a
+reviewer never has to press a key to find out where they are. Said of a **pane** or of the
+file tree — never of anything drawn *on* the diff. Not _dimmed_: an archived **entry** is
+already drawn dimmed on the diff, and one word must not do two jobs — the same collision
+that kept _side_ reserved for a diff line's add/del/ctx when the split layout needed a word
+for its windows. The two are also different mechanisms: dimming is a highlight group the
+render chooses per entry, muting is every group at once in one window.
+_Avoid_: dimmed, greyed, faded, inactive
+
 **Filler**:
 A blank row emitted in one pane where the other has no counterpart — a pure addition, a
 pure deletion, a file that exists on only one side — so the two stay row-aligned. Distinct

--- a/README.md
+++ b/README.md
@@ -212,6 +212,23 @@ can see which packages are done without opening them. It follows the diff cursor
 Collapsed directories belong to the review rather than to the tree, so they are exactly as
 you left them when it comes back.
 
+### The window you are in is the bright one
+
+A review can hold three windows at once — the before pane, the after pane and the tree —
+and the one without focus is **muted**: its colours pulled toward the background, so where
+you are is on screen instead of something you have to press a key to find out. The
+`cursorline` goes with it, which is what stops the split layout lighting a row in both panes
+while saying nothing about either.
+
+The colours come from your own colorscheme, blended: nothing here has a palette of its own,
+and a group the plugin cannot know about is left bright rather than guessed at, so an
+unfamiliar theme degrades to *less muted* and never to *wrong*. A float — the composer, the
+queue float, the last-batch float — changes nothing: the bright window is the review window
+you were last in, not the window with the cursor in it.
+
+`muted = { enabled = false }` turns it off whole; `strength` is one number from 0 to 1
+saying how far toward the background a colour goes.
+
 ### Typed annotations
 
 A type is not decoration — it changes what the receiving agent is told to do with that
@@ -574,6 +591,8 @@ opts = {
   spans = true,                    -- emphasise what changed inside a changed line
   archived = true,                 -- draw already-dispatched entries on the diff, dimmed,
                                    -- and tally the untouched ones on the winbar
+  muted = { enabled = true,        -- mute every review window that does not have focus
+            strength = 0.5 },      -- how far its colours are pulled toward the background
   panel = { enabled = true, width = 34, position = "left" },
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
             collapsed = "▸", expanded = "▾", change_bar = "▌" },

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -338,6 +338,33 @@ what reaches the queue and what the payload says are untouched.
 
 See |codereview-highlights| for the two groups it draws with.
 
+The window without focus                                 *codereview-muted*
+
+A review holds up to three windows -- the two panes and the file tree -- and
+the one that does not have focus is *muted*: its colours pulled toward the
+background, so which window your next keystroke acts on is on screen rather
+than something you press a key to find out. Only the focused window draws a
+|cursorline|, which is what stops the split layout lighting a row in both
+panes while saying nothing about either. The tree is in the rule with the
+panes, because it competes with them for focus.
+
+Muting is a window-local highlight namespace holding a variant of every group
+in play, each computed by blending that group's colours toward `Normal`'s
+background. So the colours are your colorscheme's, blended -- never a palette
+of the plugin's own -- and a group it cannot know about is left at full
+brightness rather than guessed at: an unfamiliar theme degrades to less
+muting and never to wrong colours. The set is recomputed when you change
+colorscheme.
+
+The bright window is the review window focus was last in, not the window with
+the cursor in it, so a float changes nothing: the composer, the queue float
+and the last-batch float all take focus out of every review window, and the
+review behind them looks exactly as you left it.
+
+    muted = { enabled = false }      -- nothing muted at all
+    muted = { strength = 0.25 }      -- subtler; 1 is all the way to the
+                                     -- background, 0 is not at all
+
 ==============================================================================
 6. ANNOTATIONS                                      *codereview-annotations*
 
@@ -751,6 +778,7 @@ Defaults: >
       layout = "unified",
       spans = true,
       archived = true,
+      muted = { enabled = true, strength = 0.5 },
       panel = { enabled = true, width = 34, position = "left" },
       icons = {
         reviewed = "✓", annotated = "●", unreviewed = "○",
@@ -774,6 +802,11 @@ read rather than every time the view is drawn.
 untouched ones on the winbar (|codereview-archived|, |codereview-touched|).
 It is on by default and coarse on purpose: off is the whole history off --
 nothing drawn, nothing tallied and no `git` spent judging.
+
+`muted` mutes every review window that does not have focus
+(|codereview-muted|). `strength` is how far a colour is pulled toward the
+background, from 0 to 1. Coarse the same way: off is nothing muted, nothing
+computed and no highlight namespace attached to any window.
 
 ==============================================================================
 10. HIGHLIGHTS                                        *codereview-highlights*

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -48,6 +48,15 @@ entry appears to end mid-note. Notes go through the renderer's own `wrap`, by di
 width — the same helper, not a copy, because splitting by byte passes every ASCII assertion
 and breaks the first CJK or emoji note.
 
+**A window-local highlight namespace reaches extmark highlights.** Attaching one with
+`nvim_win_set_hl_ns` changes what a group resolves to *in that window*, and that reaches a
+line background set by `line_hl_group`, the treesitter replay's extmarks at their higher
+priority band, and the winbar alike — which is what lets a **muted** window recede without
+the render knowing anything about it. Extending a namespace a window is already showing
+works too, and takes effect on the next redraw: measured in a prototype, not assumed. A
+group the namespace does not define falls back to its global definition, so what is not in
+it stays bright.
+
 **Collapsing is done at render time, not with folds.** A collapsed file's body is never
 emitted, so the buffer and the anchor map stay small on a large review, and there is one
 mechanism instead of two.
@@ -345,6 +354,35 @@ again once it was back would repaint nothing.
 
 **`nvim_win_call` propagates only the first return value.** Returning `line("w0"), line("w$")`
 from it silently loses the end of the range.
+
+**`winhighlight` with `NormalNC` cannot mute a pane.** It is the obvious way to make an
+unfocused window recede and it is the wrong one here: it changes only a window's *default*
+foreground and background, and in the panes almost nothing uses those. A changed row carries
+its own line background, and code foregrounds come from the treesitter replay's extmarks at a
+higher priority band — so `NormalNC` leaves every changed line and every highlighted token at
+full brightness and dims little but the empty space, which reads as broken rather than as
+muted. Measured with a background group standing in for a changed line and a higher-priority
+foreground group standing in for the replay:
+
+```
+bright                      { background = 0x003300, foreground = 0xff0000 }
+muted (both defined)        { background = 0x001100, foreground = 0x550000 }
+muted (background only)     { background = 0x001100, foreground = 0xff0000 }
+```
+
+The first two lines are a window-local highlight namespace doing what `NormalNC` cannot; the
+third is the graceful failure that namespace keeps — a group with no variant in it stays
+bright rather than going wrong. `NormalNC` is adequate only on the file tree, which has
+almost no highlights of its own, and one mechanism for the three windows is worth more than
+that.
+
+**Which review window is bright is the review's last-focused one, not the current one.** The
+composer, the queue float and the archive float all take focus out of every review window, so
+a rule written against the current window mutes the whole review the moment a reviewer starts
+typing a note. The latch on the view moves only when focus lands on a review window, and
+`view_layout` reasserts the whole arrangement wherever focus is decided — window options set
+where a window is *created* are overwritten afterwards by the code that puts the panes back
+in step, so creation is not where this can live.
 
 **Closing a window does not end insert mode.** A composer opened with `startinsert` and
 submitted from an insert-mode mapping closes its float while still inserting, and focus

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -34,7 +34,7 @@ change there is felt through.
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
 | `view.lua` | The review view: the `CRView` it owns, the paint, navigation, delivery, opening and closing | stateful (windows) |
-| `view_layout.lua` | Where the review's windows are: the panes, the before pane, and the toggle between the unified and split layouts | stateful (windows) |
+| `view_layout.lua` | Where the review's windows are: the panes, the before pane, the toggle between the unified and split layouts, and which of them is muted | stateful (windows) |
 | `view_panel.lua` | The file tree's stateful half: its window and buffer, the repaint that follows the diff cursor, and the actions its keys run | stateful (windows) |
 
 ## How they stack

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -41,6 +41,23 @@ M.defaults = {
   ---the archive existed. There is no keymap beside it yet; one can be added if the switch
   ---proves too blunt.
   archived = true, ---@type boolean
+  ---Draw every review window that does not have focus **muted**: its colours pulled toward
+  ---the background, so the focused window is the bright one and a reviewer never has to
+  ---press a key to find out where they are. The file tree is in the rule with the panes,
+  ---because it competes for focus with them, and the `cursorline` goes with it -- only the
+  ---focused window draws one, which is what stops the split layout lighting a row in both
+  ---panes while saying nothing about either.
+  ---
+  ---On by default, and coarse the way `archived` is: off is nothing muted, nothing
+  ---computed and no highlight namespace attached to any window, for a reviewer whose own
+  ---dimming plugin or own taste should win. There is no keymap beside it; one can be added
+  ---if the switch proves too blunt.
+  ---
+  ---`strength` is how far toward the background a colour is pulled, from 0 (not at all) to
+  ---1 (all the way). One number rather than a palette, because the colours it works on are
+  ---the active colorscheme's -- an unrecognised theme is muted in its own colours or, for a
+  ---group the plugin cannot know about, left bright rather than replaced.
+  muted = { enabled = true, strength = 0.5 }, ---@type { enabled: boolean, strength: number }
   panel = {
     enabled = true,
     width = 34,
@@ -165,12 +182,48 @@ local function validate_boolean(name, value)
   end
 end
 
+---Reject the switch beside this one written as a bare boolean.
+---
+---`spans` and `archived` are bare booleans and `muted` is a table, so `muted = false` is the
+---natural mistake to make. Without this it is an index error raised from inside a window
+---helper the next time a review opens, rather than a sentence at `setup()` naming the line
+---to change.
+---@param value any
+local function validate_muted(value)
+  if type(value) ~= "table" then
+    error(
+      ("codereview.setup: `muted` must be a table — got %s; write `muted = { enabled = false }`"):format(
+        vim.inspect(value)
+      ),
+      0
+    )
+  end
+end
+
+---Reject a strength that is not a fraction of the way to the background.
+---
+---In the same voice as the switches above. A number outside 0..1 is not a stronger effect
+---but an arithmetic accident: past 1 the blend overshoots the background and comes back out
+---the other side, which is a colour nobody asked for rather than a louder version of one.
+---@param value any
+local function validate_strength(value)
+  if type(value) ~= "number" or value < 0 or value > 1 then
+    error(
+      ("codereview.setup: `muted.strength` must be a number between 0 and 1 — got %s"):format(vim.inspect(value)),
+      0
+    )
+  end
+end
+
 ---@param opts table|nil
 function M.setup(opts)
   M.options = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults), opts or {})
   validate_layout(M.options.layout)
   validate_boolean("spans", M.options.spans)
   validate_boolean("archived", M.options.archived)
+  validate_muted(M.options.muted)
+  validate_boolean("muted.enabled", M.options.muted.enabled)
+  validate_strength(M.options.muted.strength)
   M.options.types = resolve_types(M.options)
   return M.options
 end

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -3,6 +3,16 @@
 ---Everything is a `default = true` link to a group colorschemes already define, so the
 ---view inherits the active theme instead of hardcoding a palette, and any of these can be
 ---overridden in a user's config without the plugin fighting back.
+---
+---**A group a review window draws in has to be named in one of the tables below.** They are
+---not just where the links live: `M.groups()` derives the set the **muted** window is built
+---from by reading them, so a group that exists anywhere else is one a muted window leaves at
+---full brightness. Adding a group means adding it here -- to `LINKS` if it links to
+---something a colorscheme defines, to `SPAN_GROUPS` if it is computed, to `EDITOR_GROUPS` if
+---it is the editor's own and this plugin merely draws through it -- and then it is muted
+---without a second list learning about it. There is deliberately no register to remember to
+---update, because the one thing that would go wrong is invisible until someone looks at an
+---unfocused pane.
 local M = {}
 
 local LINKS = {
@@ -83,11 +93,41 @@ local TYPE_FALLBACK = "DiagnosticInfo"
 local SPAN_SOURCE = "DiffText"
 local SPAN_GROUPS = { "CodeReviewAddSpan", "CodeReviewDelSpan" }
 
+-- What a review window draws in that is not this plugin's to define: the text with no
+-- capture over it, the row under the cursor, the gutter and the winbar. Named here rather
+-- than where they are muted, so that every group this plugin has an opinion about is in one
+-- file. The capture groups the treesitter replay resolves are not in any list: they depend
+-- on what a reviewer has scrolled past, and `syntax.lua` already caches them per capture.
+local EDITOR_GROUPS = { "Normal", "CursorLine", "LineNr", "WinBar", "WinBarNC" }
+
 local function apply_spans()
   local source = vim.api.nvim_get_hl(0, { name = SPAN_SOURCE, link = false })
   for _, group in ipairs(SPAN_GROUPS) do
     vim.api.nvim_set_hl(0, group, { bg = source.bg, ctermbg = source.ctermbg, default = true })
   end
+end
+
+---Every highlight group a review window is known to draw in.
+---
+---Derived from the tables `apply` writes rather than kept beside them, so a group added
+---there is one the muting knows about without a second list learning of it. A configured
+---annotation type's group is in here too, for the same reason it is in `apply`: the plugin
+---cannot know its name in advance.
+---
+---What this cannot enumerate is the treesitter replay's capture groups, which resolve as a
+---reviewer scrolls -- `syntax.lua` holds those, and whoever wants the whole set asks both.
+---@return string[]
+function M.groups()
+  local out = {}
+  for group in pairs(LINKS) do
+    out[#out + 1] = group
+  end
+  vim.list_extend(out, SPAN_GROUPS)
+  vim.list_extend(out, EDITOR_GROUPS)
+  for _, t in ipairs(require("codereview.config").get().types) do
+    out[#out + 1] = t.hl
+  end
+  return out
 end
 
 function M.apply()

--- a/lua/codereview/syntax.lua
+++ b/lua/codereview/syntax.lua
@@ -20,6 +20,12 @@ local M = {}
 -- otherwise, which is thousands of calls per file.
 local hl_cache = {}
 
+-- How many entries have ever been written into that cache. Counted rather than measured,
+-- so that anything mirroring the set can tell in one comparison whether it has moved --
+-- this is read on the scroll path, where walking the cache per keystroke would be work
+-- done for the answer "nothing new".
+local resolutions = 0
+
 ---Highlight group for a capture.
 ---
 ---Prefers the language-specific `@keyword.lua` when a colorscheme defines it, falling
@@ -39,6 +45,7 @@ local function resolve_hl(name, lang)
   local ok, def = pcall(vim.api.nvim_get_hl, 0, { name = specific, link = true })
   local group = (ok and not vim.tbl_isempty(def)) and specific or ("@" .. name)
   hl_cache[key] = group
+  resolutions = resolutions + 1
   return group
 end
 
@@ -336,12 +343,36 @@ function M.repainted(view)
   view.syntax_rows = nil
 end
 
+---Every highlight group the replay has resolved so far, as the memo holds them.
+---
+---The memo itself rather than a copy, and read-only by contract: this is asked on the
+---scroll path, where an allocation per keystroke would be paid on a review nobody is
+---highlighting anything new in. Keyed by `capture.language`, which is the memo's own key;
+---what a caller wants is the values.
+---
+---A file is parsed only as its rows come near the window, so this set *grows* while a
+---review is open. Anything mirroring it -- the muting namespace is the one -- has to be
+---extended as it does rather than built from it once.
+---@return table<string, string>
+function M.resolved_groups()
+  return hl_cache
+end
+
+---How many resolutions have been made, ever. Only ever compared with itself.
+---@return integer
+function M.resolutions()
+  return resolutions
+end
+
 ---Forget capture-name -> highlight-group resolutions.
 ---
 ---Which group a capture resolves to depends on what the colorscheme defines, so the
 ---answers are only valid for the colorscheme that was active when they were cached.
 function M.clear_hl_cache()
   hl_cache = {}
+  -- Moved, not reset: the count is only ever compared with itself, and a mirror that saw
+  -- the old total must not read the empty cache as "nothing has changed".
+  resolutions = resolutions + 1
 end
 
 return M

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -52,6 +52,7 @@ local NS = vim.api.nvim_create_namespace("codereview")
 ---@field panel_buf integer|nil
 ---@field panel_win integer|nil
 ---@field queue_win integer|nil           The window a queue float is open in
+---@field focus_win integer|nil           The review window focus last landed in: the bright one
 ---@field tab integer
 ---@field augroup integer                 Autocommands belonging to this review
 ---@field render CRRender|nil             The after pane's render
@@ -323,6 +324,11 @@ function M.paint(keep_file)
   if config.get().syntax then
     syntax.apply(V, NS)
   end
+  -- A pass that parsed a file resolved capture groups nothing knew about before it, and a
+  -- **muted** window needs a variant of each or the tokens it just gained come out bright.
+  -- Here rather than inside the pass, so that the module that knows about windows is called
+  -- by the one that owns them rather than reaching back up for them.
+  view_layout.mute_extend()
 
   view_layout.resync(V)
 end
@@ -449,6 +455,17 @@ function M.cursor_moved()
   if config.get().syntax then
     require("codereview.syntax").apply(V, NS)
   end
+  -- Whatever that pass resolved, muted in the pane that does not have focus -- which is
+  -- usually not the pane the scroll happened in. Cheap when it resolved nothing new: one
+  -- integer comparison and no allocation.
+  --
+  -- Deliberately here as well as in the paint, and *not* covered by a spec: what reaches
+  -- this and not the paint is scrolling into a file whose language nothing has parsed yet,
+  -- which needs a diff taller than the viewport margin holding more than one language. The
+  -- tall fixture is single-language and the many-language one is short enough to parse on
+  -- open, so no fixture in the suite has that shape -- see tests/README.md. Removing this
+  -- line reds nothing; it is still the line that keeps a real scroll from thinning out.
+  view_layout.mute_extend()
   -- Cheap: an anchor lookup, and then nothing at all unless the cursor left the file it
   -- was in.
   follow_file()
@@ -1224,6 +1241,10 @@ function M.open(spec)
   require("codereview.state").restore(V, key)
   M.reconcile()
 
+  -- Before the windows below it: every one of them takes focus while it is being built, and
+  -- this is what is watching when they hand it back.
+  view_layout.watch_focus(V)
+
   -- Before the panel, so the panel's `topleft`/`botright` split lands outside both panes
   -- rather than between them.
   if layout == "split" then
@@ -1245,6 +1266,19 @@ function M.open(spec)
       if M.current() then
         M.paint()
       end
+    end,
+  })
+
+  -- A **muted** window's colours are blends of the theme's, so they cannot outlive it.
+  -- Declared after `hl.setup()`, which is the first thing this function does and which
+  -- re-links the plugin's own groups from its own `ColorScheme` autocommand: the two fire in
+  -- the order they were declared, so the groups this reads have been re-linked by the time
+  -- it reads them. Watched from here rather than from `hl.lua`, which would have to reach
+  -- back up into the module that owns the windows to say it.
+  vim.api.nvim_create_autocmd("ColorScheme", {
+    group = V.augroup,
+    callback = function()
+      view_layout.recolour()
     end,
   })
 

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -22,10 +22,19 @@
 ---
 ---The two window helpers below are shared rather than private: every surface the review
 ---builds a window for wants the same scratch buffer and the same window options, the file
----tree's included, and one copy of each is what keeps them the same.
+---tree's included, and one copy of each is what keeps them the same. The window helper is
+---also where a review window is *enrolled* in the focus rule, which is what keeps a pane
+---rebuilt by a layout toggle and a re-summoned tree obeying it.
+---
+---**Which review window is bright is the one focus last landed in**, and that rule reaches
+---the file tree as well as the panes -- the tree is not a pane, but it competes with them
+---for focus, and where the cursor is is a question about the review's windows rather than
+---about its layout. See `mute` below.
 local config = require("codereview.config")
+local hl = require("codereview.hl")
 local keymaps = require("codereview.keymaps")
 local render = require("codereview.render")
+local syntax = require("codereview.syntax")
 
 local M = {}
 
@@ -209,6 +218,50 @@ function M.attach_pane(V, view, buf)
   })
 end
 
+---Every window this module has enrolled in the focus rule, as a set.
+---
+---Enrolment goes through `window_opts` below, the one helper every review window already
+---passes through -- the file tree's included, though it is not a pane -- so a pane the
+---layout toggle rebuilt and a tree dismissed and summoned again join the set on the same
+---line that gives them their options, rather than by a caller remembering to say so.
+---
+---Module-level, because `window_opts` is handed a window and nothing else. Windows that
+---have gone are dropped as they are found, and every read is filtered to the review's own
+---tab page as well, so a window id Neovim reuses after a review closed cannot inherit a
+---namespace the review left behind.
+---@type table<integer, boolean>
+local enrolled = {}
+
+---@param win integer
+local function enrol(win)
+  for w in pairs(enrolled) do
+    if not vim.api.nvim_win_is_valid(w) then
+      enrolled[w] = nil
+    end
+  end
+  enrolled[win] = true
+end
+
+---@param V CRView
+---@param win integer
+---@return boolean
+local function is_review_window(V, win)
+  return enrolled[win] ~= nil and vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_tabpage(win) == V.tab
+end
+
+---Every enrolled window that still belongs to this review.
+---@param V CRView
+---@return integer[]
+local function review_windows(V)
+  local out = {}
+  for win in pairs(enrolled) do
+    if is_review_window(V, win) then
+      out[#out + 1] = win
+    end
+  end
+  return out
+end
+
 ---@param win integer
 function M.window_opts(win)
   vim.wo[win].wrap = false
@@ -216,9 +269,195 @@ function M.window_opts(win)
   vim.wo[win].relativenumber = false
   vim.wo[win].signcolumn = "no"
   vim.wo[win].foldcolumn = "0"
+  -- What a window opens with rather than what it keeps: with muting on, `cursorline`
+  -- becomes a function of focus and `mute` owns it from here. This is what a review window
+  -- looks like with muting off, which is what it looked like before muting existed.
   vim.wo[win].cursorline = true
   vim.wo[win].list = false
   vim.wo[win].spell = false
+  enrol(win)
+end
+
+--- Muting ---------------------------------------------------------------------
+
+---The namespace holding a muted variant of every group a review window draws in.
+---
+---One namespace shared by every muted window rather than one each: what is in it is a
+---function of the colorscheme and the configured strength, not of which window is being
+---muted. Attaching it is what mutes a window; handing the window the global namespace back
+---is what brightens it.
+local NS_MUTED = vim.api.nvim_create_namespace("codereview_muted")
+
+---Which groups the namespace already holds a variant for.
+---@type table<string, boolean>
+local variants = {}
+
+---`Normal`'s background, memoised until the colorscheme changes.
+---@type integer|nil
+local toward = nil
+
+---What the muted colours are pulled toward.
+---
+---A theme that gives `Normal` no background at all has the terminal's behind it, and the
+---only thing knowable about that is which way the theme says it leans.
+---@return integer
+local function backdrop()
+  if not toward then
+    local normal = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
+    toward = normal.bg or (vim.o.background == "light" and 0xffffff or 0x000000)
+  end
+  return toward
+end
+
+---Pull one colour toward another, channel by channel.
+---@param colour integer 0xRRGGBB
+---@param target integer 0xRRGGBB
+---@param strength number 0 leaves the colour alone, 1 replaces it with `target`
+---@return integer
+local function blend(colour, target, strength)
+  local out = 0
+  for _, place in ipairs({ 65536, 256, 1 }) do
+    local from = math.floor(colour / place) % 256
+    local to = math.floor(target / place) % 256
+    out = out + math.floor(from + (to - from) * strength + 0.5) * place
+  end
+  return out
+end
+
+---Give `group` a muted variant in the namespace, once.
+---
+---**A group left without one stays bright, and that is the feature.** A group the namespace
+---does not define falls back to its global definition -- measured, not assumed -- so a
+---colorscheme this plugin has never heard of, or one whose group carries no colour of its
+---own to blend, comes out merely less muted instead of wrongly coloured. Nothing here
+---reaches for a palette when a lookup comes back empty, and nothing should.
+---
+---Only the true-colour attributes are blended. `ctermfg`/`ctermbg` are indices into a
+---palette with no channels to pull, so they are carried across untouched.
+---
+---A lookup that came back with nothing is not remembered as done, so a rebuild that somehow
+---ran before the theme's own groups were re-linked costs one pass of muting rather than a
+---review that stays bright until the next colorscheme change.
+---@param group string
+---@param strength number
+local function ensure_variant(group, strength)
+  if variants[group] then
+    return
+  end
+  local ok, def = pcall(vim.api.nvim_get_hl, 0, { name = group, link = false })
+  if not ok or type(def) ~= "table" or (def.fg == nil and def.bg == nil) then
+    return
+  end
+  variants[group] = true
+  local muted = vim.tbl_extend("force", {}, def)
+  muted.fg = def.fg and blend(def.fg, backdrop(), strength) or nil
+  muted.bg = def.bg and blend(def.bg, backdrop(), strength) or nil
+  pcall(vim.api.nvim_set_hl, NS_MUTED, group, muted)
+end
+
+---How many capture resolutions the namespace was last extended against.
+---@type integer
+local extended_at = -1
+
+---Extend the namespace with every group now in play that it does not hold yet.
+---
+---Extended rather than built once, because the set grows while a review is open: a file is
+---parsed only as its rows come near the window, so which capture groups the replay has
+---resolved is a function of how far a reviewer has scrolled. Adding to a namespace a window
+---is already showing takes effect on the next redraw -- measured, not assumed -- which is
+---what keeps a file parsed while its pane was muted muted too.
+---
+---Called by the view wherever it has just run the replay -- a paint, and every keystroke a
+---reviewer holds -- so the guard is what keeps it free: with nothing newly resolved this is
+---one integer comparison and no allocation at all. Asked for from there rather than said
+---from inside the replay, which would have `syntax.lua` reaching up into this one.
+function M.mute_extend()
+  local cfg = config.get().muted
+  if not cfg.enabled or syntax.resolutions() == extended_at then
+    return
+  end
+  extended_at = syntax.resolutions()
+  for _, group in ipairs(hl.groups()) do
+    ensure_variant(group, cfg.strength)
+  end
+  for _, group in pairs(syntax.resolved_groups()) do
+    ensure_variant(group, cfg.strength)
+  end
+end
+
+---Recompute every variant against the colorscheme that is active now.
+---
+---A variant is a blend of colours the theme decides, so it means nothing once the theme has
+---changed. Driven by the view's `ColorScheme` autocommand, which is declared after the one
+---`hl.lua` re-links its own groups from -- so what this reads has already been re-linked.
+---
+---Every group the namespace already holds is recomputed rather than dropped: the diff on
+---screen still carries extmarks naming the capture groups the old theme resolved, and those
+---have to be right before anything reparses.
+function M.recolour()
+  local known = variants
+  toward, variants, extended_at = nil, {}, -1
+  local cfg = config.get().muted
+  if not cfg.enabled then
+    return
+  end
+  for group in pairs(known) do
+    ensure_variant(group, cfg.strength)
+  end
+  M.mute_extend()
+end
+
+---Mute every review window except the one focus last landed in.
+---
+---**The bright one is the review's last-focused window, not the current one.** That is what
+---makes a float change nothing: the composer, the queue float and the archive float all
+---move focus out of every review window, and a rule written against the current window
+---would mute the entire review the moment a reviewer started typing a note. The latch moves
+---only when focus lands on a review window, and a latch naming a window that has gone
+---answers the after pane -- the same default `focused_pane` takes for a caller in neither.
+---
+---With muting off this returns having done nothing at all: no namespace is attached to
+---anything, no colour is computed, and `cursorline` is left as `window_opts` set it.
+---@param V CRView|nil
+function M.mute(V)
+  if not (V and vim.api.nvim_win_is_valid(V.win) and config.get().muted.enabled) then
+    return
+  end
+  M.mute_extend()
+  local bright = (V.focus_win and vim.api.nvim_win_is_valid(V.focus_win)) and V.focus_win or V.win
+  for _, win in ipairs(review_windows(V)) do
+    local focused = win == bright
+    -- One lit row means one thing: in the split layout `cursorbind` holds both panes on the
+    -- same row, so two cursorlines say nothing about either.
+    vim.wo[win].cursorline = focused
+    vim.api.nvim_win_set_hl_ns(win, focused and 0 or NS_MUTED)
+  end
+end
+
+---Follow focus for the rest of this review.
+---
+---One `WinEnter`/`WinLeave` pair on the view's augroup rather than one autocommand per
+---buffer: which window is muted is a property of the *set* and not of any one of them, so
+---every focus change recomputes all of them. Wired to the events rather than to the view's
+---own navigation, so that an ordinary window-switch key is worth exactly as much as `gp`.
+---
+---And reasserted here rather than only where a window is created, because window options
+---set at creation are overwritten by the code that puts the panes back in step afterwards.
+---@param V CRView
+function M.watch_focus(V)
+  vim.api.nvim_create_autocmd({ "WinEnter", "WinLeave" }, {
+    group = V.augroup,
+    callback = function()
+      local win = vim.api.nvim_get_current_win()
+      -- Only when focus is *on* a review window: on `WinLeave` it still is, and the window
+      -- being left is the one the latch already names, so the pair costs no special case.
+      if is_review_window(V, win) then
+        V.focus_win = win
+      end
+      M.mute(V)
+    end,
+  })
+  M.mute(V)
 end
 
 --- The before pane -------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
 | `codereview/archive_child.lua` | Spawned by `archive_spec` to dispatch a batch and exit — deliberately not a spec. |
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
+| `codereview/muted_child.lua` | Spawned four times by `muted_spec`, one painted cell each — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
 
@@ -56,6 +57,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
+| `muted_spec` | The review window without focus: which window is bright, the namespace and the `cursorline` that follow focus, a float changing nothing, a rebuilt pane and a re-summoned tree, the group left bright on purpose, the colorscheme change, the switch — and the cells four child processes read |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
@@ -247,6 +249,37 @@ so the out-of-core language path is still checked locally without ever failing C
   the view's exported actions can notice: `panel_spec` therefore asserts that the tree
   comes back in a *different* buffer carrying the same mappings, and drives one of them
   through the keys. Without that, a panel that comes back with no keymaps at all passes.
+- **A window option is reasserted downstream, so deleting the line that sets it proves
+  nothing.** `cursorline` is set in `view_layout.window_opts` where a review window is built
+  and then set again, as a function of focus, everywhere focus is decided — so a teeth check
+  that removes it from the helper reds nothing that matters. Break the muting where focus is
+  decided instead: mute against the *current* window rather than the view's latch, and the
+  float cases go red; stop recomputing on `WinEnter`/`WinLeave`, and everything about which
+  window is bright does.
+- **No fixture is both tall and multilingual, so one line of the muting has no spec.**
+  `view.lua` widens the muted namespace at two moments, and only one of them can be
+  measured here. A paint that parses a file is reached by `muted_spec`'s scope change;
+  a *scroll* that parses one can only differ from it when the newly parsed file's language
+  has never been parsed before, and that needs a diff taller than the viewport margin
+  holding two languages. `mkbig` is Lua only, `mkfixture` is short enough that everything
+  parses on open, and `mktree` is neither. Deleting the call in `cursor_moved` therefore
+  reds nothing — which is a gap in the fixtures, not a line to remove. Anyone giving `mkbig`
+  a second language should take this bullet out and assert it.
+- **The set of capture groups only ever grows, and it is module-level.** `syntax.lua`'s
+  capture → group memo lives for the process, so once any block has opened a review over a
+  scope holding Markdown, no later block in that file can be the first to resolve a Markdown
+  group. `muted_spec`'s claim that a file parsed *after* its pane lost focus is muted too
+  therefore has to run first, and it starts in a scope holding one Lua file before widening
+  to one that holds both. Same shape as `layout_spec`'s restart cases having to run first.
+- **`nvim__inspect_cell` is honest only on the first call a process makes.** Read the same
+  cell twice in a row, with a forced `redraw!` before each, and the second answer differs
+  from the first and is wrong — attributes belonging to something else on screen entirely.
+  Measured, and it is why `muted_spec` spawns `muted_child.lua` once per cell instead of
+  reading four cells in one process. Two more traps ride with it: the screen grid a headless
+  Neovim keeps is **80x24 whatever `columns` and `lines` say**, so a window drawn past
+  column 80 is drawn into cells nothing can read; and the cell has to be located with
+  `screenpos`, because the change bar and the `│` separator are multibyte and a buffer
+  column is not a screen column.
 - **`WinResized` is no use to a test.** It is fired from the main loop, so it lands after
   whatever changed the width has returned — and in a headless spec, which never pumps the
   loop, it does not land at all. Anything that changes a window's width has to repaint for

--- a/tests/codereview/muted_child.lua
+++ b/tests/codereview/muted_child.lua
@@ -1,0 +1,91 @@
+-- One painted cell of a review, read in a process of its own.
+--
+-- Deliberately a separate process, and deliberately one cell. `nvim__inspect_cell` reports
+-- a cell's real foreground and background only on the **first** call a process makes; every
+-- call after it returns attributes belonging to something else entirely, which was measured
+-- rather than assumed -- reading the same cell twice in a row gives two different answers,
+-- and the second one is wrong. So the whole point of this file is to make exactly one such
+-- call, in one arrangement, and print what it saw.
+--
+-- The screen is 80x24 because that is the grid a headless Neovim keeps whatever `columns`
+-- and `lines` are set to: a window drawn past column 80 is drawn into cells no assertion can
+-- read.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- muted_spec with FIXTURE, FOCUS, CELL and MUTED in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.termguicolors = true
+vim.o.columns = 80
+vim.o.lines = 24
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+-- Colours the arithmetic is exact on: every channel is even, so a blend halfway to a black
+-- background is a colour with no rounding in it.
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
+vim.api.nvim_set_hl(0, "@keyword", { fg = 0xee0000 })
+-- A group this plugin cannot know about: not one of its own, and not one the treesitter
+-- replay resolves. It must come out of a muted window at full brightness.
+vim.api.nvim_set_hl(0, "MutedChildStranger", { fg = 0x00ee00 })
+
+require("codereview").setup({
+  layout = "unified",
+  syntax = true,
+  muted = { enabled = vim.env.MUTED ~= "0", strength = 0.5 },
+})
+
+local view = require("codereview.view")
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+
+-- The first token the replay painted on an *added* line, so one cell carries both halves of
+-- the question: the line's own background under a foreground from a higher priority band.
+local row, col
+local painted = vim.api.nvim_buf_get_extmarks(V.buf, vim.api.nvim_create_namespace("codereview"), 0, -1, {
+  details = true,
+})
+for _, m in ipairs(painted) do
+  local anchor = V.render.anchors[m[2] + 1]
+  if m[4].hl_group == "@keyword" and anchor and anchor.kind == "line" then
+    local ln = V.files[anchor.file].hunks[anchor.hunk].lines[anchor.line]
+    if ln.side == "add" then
+      row, col = m[2] + 1, m[3]
+      break
+    end
+  end
+end
+assert(row, "no keyword was painted on an added line -- did the replay run?")
+
+if vim.env.CELL == "stranger" then
+  -- Over the same cell, above the replay's band, in a namespace of this file's own so the
+  -- review's next repaint would not clear it.
+  vim.api.nvim_buf_set_extmark(V.buf, vim.api.nvim_create_namespace("muted_child"), row - 1, col, {
+    end_col = col + 1,
+    hl_group = "MutedChildStranger",
+    priority = 200,
+  })
+end
+
+local tree = assert(V.panel_win, "no file tree")
+vim.api.nvim_set_current_win(vim.env.FOCUS == "tree" and tree or V.win)
+
+vim.cmd("redraw!")
+local pos = vim.fn.screenpos(V.win, row, col + 1)
+assert(pos.row > 0 and pos.col > 0, "the row under test is off screen")
+local cell = vim.api.nvim__inspect_cell(1, pos.row - 1, pos.col - 1)
+local attrs = cell[2] or {}
+
+-- `nvim -l` sends print to stderr, not stdout, so muted_spec reads both.
+print(
+  ("cell %s fg=%s bg=%s at %d,%d"):format(
+    cell[1],
+    attrs.foreground and ("%06x"):format(attrs.foreground) or "none",
+    attrs.background and ("%06x"):format(attrs.background) or "none",
+    pos.row,
+    pos.col
+  )
+)
+vim.cmd("qa!")

--- a/tests/codereview/muted_spec.lua
+++ b/tests/codereview/muted_spec.lua
@@ -1,0 +1,508 @@
+-- A review window without focus is **muted**.
+--
+-- Asserted at the altitude a reviewer's editor actually holds it: the highlight namespace
+-- each review window is drawing through, and its `cursorline`. Never the functions that set
+-- them -- focus is moved with an ordinary window-switch key as readily as with the plugin's
+-- own `<Tab>`, because what is being pinned down is the autocommand wiring and not one code
+-- path that happens to call the right helper.
+--
+-- One level lower, and only where there is no higher way to say it, the namespace's own
+-- contents are read: that a variant is derived from the theme that is active now, and that a
+-- group this plugin cannot know about has none.
+--
+-- Lower still, the cells the reviewer's screen really holds. Those are in `muted_child.lua`,
+-- one process per reading, because `nvim__inspect_cell` tells the truth only on the first
+-- call a process makes -- see the header there.
+local h = require("tests.helpers")
+
+h.ui(120, 45)
+local fixture = h.cd_fixture("mkfixture")
+
+local config = require("codereview.config")
+local queue = require("codereview.queue")
+local syntax = require("codereview.syntax")
+local view = require("codereview.view")
+
+-- The plugin's own namespace, by name: `nvim_create_namespace` hands back the id a name
+-- already has, so this is a lookup rather than a second namespace.
+local MUTED = vim.api.nvim_create_namespace("codereview_muted")
+
+-- Colours with even channels, so a blend halfway to a black background has no rounding in
+-- it and the numbers below can be read at a glance.
+vim.o.termguicolors = true
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
+-- A group this plugin cannot know about: not one of its own, and not one the treesitter
+-- replay resolves. Defined up here, before any review has built a namespace, so that an
+-- implementation which enumerated every group the editor knows would sweep it up and the
+-- case below would notice.
+vim.api.nvim_set_hl(0, "MutedSpecStranger", { fg = 0x00ee00 })
+
+---What a window is drawing through, in words.
+---@param win integer|nil
+---@return string|nil
+local function drawing(win)
+  if not (win and vim.api.nvim_win_is_valid(win)) then
+    return nil
+  end
+  local ns = vim.api.nvim_get_hl_ns({ winid = win })
+  if ns == MUTED then
+    return "muted"
+  end
+  return ns == 0 and "bright" or "untouched"
+end
+
+---Every review window at once, named, so a failure says which one is wrong.
+---@return table<string, string|nil>
+local function arrangement()
+  local V = assert(view.current(), "no review view open")
+  return { after = drawing(V.win), before = drawing(V.before_win), tree = drawing(V.panel_win) }
+end
+
+---@return table<string, boolean|nil>
+local function cursorlines()
+  local V = assert(view.current(), "no review view open")
+  local out = {}
+  for name, win in pairs({ after = V.win, before = V.before_win, tree = V.panel_win }) do
+    if win and vim.api.nvim_win_is_valid(win) then
+      out[name] = vim.wo[win].cursorline
+    end
+  end
+  return out
+end
+
+---@param rgb integer
+---@return integer[]
+local function channels(rgb)
+  return { math.floor(rgb / 65536) % 256, math.floor(rgb / 256) % 256, rgb % 256 }
+end
+
+--- A file parsed after its pane lost focus ---------------------------------------
+--
+-- First in the file, and it has to be: the set of capture groups the replay has resolved is
+-- module-level and only ever grows, so once any block below has opened a review over the
+-- whole branch there is no group left in this process that a later parse could be the first
+-- to reach. This one starts in a scope holding one Lua file and widens to one holding
+-- Markdown as well, from the tree, with both panes muted throughout.
+
+require("codereview").setup({ layout = "split", syntax = true })
+view.open("staged")
+
+describe("a file whose syntax is parsed only after its pane lost focus", function()
+  local V = assert(view.current(), "no review view open")
+
+  it("starts with both panes bright behind the tree", function()
+    view.toggle_focus()
+    assert.same({ after = "muted", before = "muted", tree = "bright" }, arrangement())
+  end)
+
+  local seen = {}
+  for _, group in pairs(syntax.resolved_groups()) do
+    seen[group] = true
+  end
+
+  it("has resolved nothing about the file it cannot see yet", function()
+    local files = {}
+    for _, file in ipairs(V.files) do
+      files[#files + 1] = file.path
+    end
+    assert.is_false(vim.tbl_contains(files, "src/nonl.md"), table.concat(files, ", "))
+  end)
+
+  view.set_scope("branch")
+
+  it("never took focus out of the tree to do it", function()
+    assert.same(V.panel_win, vim.api.nvim_get_current_win())
+    assert.same({ after = "muted", before = "muted", tree = "bright" }, arrangement())
+  end)
+
+  -- The guard the case below is worth nothing without: with no group newly resolved, "every
+  -- new group has a variant" holds over an empty set.
+  local fresh = {}
+  for _, group in pairs(syntax.resolved_groups()) do
+    if not seen[group] then
+      fresh[#fresh + 1] = group
+    end
+  end
+
+  it("resolves capture groups the review had never drawn before", function()
+    assert.is_true(#fresh > 0, "the wider scope parsed nothing new")
+  end)
+
+  it("mutes every one of them", function()
+    local bright = {}
+    for _, group in ipairs(fresh) do
+      local def = vim.api.nvim_get_hl(0, { name = group, link = false })
+      -- A group the theme gives no colour of its own is deliberately left without a
+      -- variant; it is the case below, not a miss here.
+      if (def.fg or def.bg) and vim.tbl_isempty(vim.api.nvim_get_hl(MUTED, { name = group })) then
+        bright[#bright + 1] = group
+      end
+    end
+    assert.same({}, bright)
+  end)
+end)
+
+--- Which window is bright --------------------------------------------------------
+
+describe("a review in the split layout with the tree open", function()
+  local V = assert(view.current(), "no review view open")
+  vim.api.nvim_set_current_win(V.win)
+
+  it("is on by default", function()
+    assert.is_true(config.get().muted.enabled)
+  end)
+
+  it("leaves the focused pane bright and mutes the other two", function()
+    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
+  end)
+
+  it("lights one row, in the window that has focus", function()
+    assert.same({ after = true, before = false, tree = false }, cursorlines())
+  end)
+
+  it("moves the brightness with focus, from one pane to the other", function()
+    vim.api.nvim_set_current_win(V.before_win)
+    assert.same({ after = "muted", before = "bright", tree = "muted" }, arrangement())
+    assert.same({ after = false, before = true, tree = false }, cursorlines())
+  end)
+
+  it("moves it between a pane and the tree, in both directions", function()
+    vim.api.nvim_set_current_win(V.panel_win)
+    assert.same({ after = "muted", before = "muted", tree = "bright" }, arrangement())
+    vim.api.nvim_set_current_win(V.win)
+    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
+  end)
+end)
+
+describe("focus moved with an ordinary window-switch key", function()
+  local V = assert(view.current(), "no review view open")
+
+  -- Fed rather than called, and positional rather than cyclic: the tree, the before pane
+  -- and the after pane sit left to right in that order. A rule wired to the plugin's own
+  -- navigation instead of to the events would leave this one untouched.
+  it("mutes the pane it leaves and brightens the one it enters", function()
+    vim.api.nvim_set_current_win(V.win)
+    h.feed("<C-w>h")
+    assert.same(V.before_win, vim.api.nvim_get_current_win())
+    assert.same({ after = "muted", before = "bright", tree = "muted" }, arrangement())
+  end)
+
+  it("reaches the tree the same way", function()
+    h.feed("<C-w>h")
+    assert.same(V.panel_win, vim.api.nvim_get_current_win())
+    assert.same({ after = "muted", before = "muted", tree = "bright" }, arrangement())
+  end)
+
+  it("leaves the review in the state the plugin's own key leaves it in", function()
+    local by_key = arrangement()
+    -- `<Tab>` from the tree is the plugin's own way back to the diff; take it there and back
+    -- so the two are compared on the same window.
+    view.toggle_focus()
+    view.toggle_focus()
+    assert.same(by_key, arrangement())
+    assert.same(V.panel_win, vim.api.nvim_get_current_win())
+  end)
+end)
+
+--- Floats change nothing ----------------------------------------------------------
+
+describe("a float taking focus", function()
+  local V = assert(view.current(), "no review view open")
+  local annotate = require("codereview.annotate")
+
+  ---The floating window in this tab, if there is one. Found by being floating rather than
+  ---by a handle the plugin hands out: asking the composer where it is would pass against a
+  ---composer that never appeared.
+  ---@return integer|nil
+  local function floating()
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+      if vim.api.nvim_win_get_config(win).relative ~= "" then
+        return win
+      end
+    end
+  end
+
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { assert(h.line_row(V, "src/fresh.lua")), 0 })
+  local was = arrangement()
+
+  it("has a bright pane to lose", function()
+    assert.same("bright", was.after)
+  end)
+
+  -- The shipped composer, with no `compose` adapter injected: a real float, entered, that
+  -- stays open until it is dismissed.
+  annotate.annotate("bug")
+  local composer = floating()
+
+  it("opens a composer that takes focus", function()
+    assert.is_truthy(composer, "no floating window was opened")
+    assert.same(composer, vim.api.nvim_get_current_win())
+  end)
+
+  it("leaves every review window exactly as it was", function()
+    assert.same(was, arrangement())
+    assert.same({ after = true, before = false, tree = false }, cursorlines())
+  end)
+
+  if composer and vim.api.nvim_win_is_valid(composer) then
+    vim.api.nvim_win_close(composer, true)
+  end
+
+  -- And the queue float, which needs something queued: a composer that answers by itself.
+  require("codereview").setup({
+    layout = "split",
+    syntax = true,
+    compose = function(_, on_accept)
+      on_accept(nil, "a note about the muted window")
+    end,
+    send = function()
+      return true
+    end,
+  })
+  vim.api.nvim_set_current_win(V.win)
+  annotate.annotate("bug")
+  view.review_queue()
+  local float = floating()
+
+  it("opens a queue float over the review", function()
+    assert.is_truthy(float, "no queue float was opened")
+    assert.same(1, queue.count())
+  end)
+
+  it("leaves every review window exactly as it was, again", function()
+    assert.same(was, arrangement())
+    assert.same({ after = true, before = false, tree = false }, cursorlines())
+  end)
+
+  if float and vim.api.nvim_win_is_valid(float) then
+    vim.api.nvim_win_close(float, true)
+    view.release_queue_float(float)
+  end
+
+  -- And the archive float, which needs a batch to have gone.
+  vim.api.nvim_set_current_win(V.win)
+  view.submit()
+  require("codereview.archive").open()
+  local archive = floating()
+
+  it("opens an archive float over the review", function()
+    assert.is_truthy(archive, "no archive float was opened")
+  end)
+
+  it("leaves every review window exactly as it was, a third time", function()
+    assert.same(was, arrangement())
+    assert.same({ after = true, before = false, tree = false }, cursorlines())
+  end)
+
+  if archive and vim.api.nvim_win_is_valid(archive) then
+    vim.api.nvim_win_close(archive, true)
+  end
+  queue.clear()
+end)
+
+--- Windows the review builds again ------------------------------------------------
+
+describe("a pane rebuilt by a layout toggle", function()
+  local V = assert(view.current(), "no review view open")
+  vim.api.nvim_set_current_win(V.win)
+  view.toggle_layout()
+
+  it("leaves the unified layout with one pane and the tree", function()
+    assert.is_nil(V.before_win)
+    assert.same({ after = "bright", before = nil, tree = "muted" }, arrangement())
+  end)
+
+  view.toggle_layout()
+
+  it("mutes the pane that comes back, without waiting for the next focus change", function()
+    assert.is_truthy(V.before_win)
+    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
+    assert.same({ after = true, before = false, tree = false }, cursorlines())
+  end)
+end)
+
+describe("a tree dismissed and summoned again", function()
+  local V = assert(view.current(), "no review view open")
+  vim.api.nvim_set_current_win(V.win)
+  view.toggle_panel()
+
+  it("leaves the panes alone while it is gone", function()
+    assert.is_nil(V.panel_win)
+    assert.same({ after = "bright", before = "muted", tree = nil }, arrangement())
+  end)
+
+  view.toggle_panel()
+
+  it("mutes the tree that comes back, in a buffer nothing bound anything to before", function()
+    assert.is_truthy(V.panel_win)
+    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
+    assert.same({ after = true, before = false, tree = false }, cursorlines())
+  end)
+end)
+
+--- What the namespace holds -------------------------------------------------------
+
+describe("a group the plugin cannot know about", function()
+  it("is left out of the namespace deliberately, so it renders at full brightness", function()
+    assert.same({}, vim.api.nvim_get_hl(MUTED, { name = "MutedSpecStranger" }))
+  end)
+
+  -- Nobody is to "fix" the case above by giving the namespace a palette of its own: a group
+  -- with no variant falling back to its global definition is what keeps an unrecognised
+  -- theme merely less muted instead of wrongly coloured. `muted_child.lua` reads the cell.
+  it("keeps a group the plugin does know about muted beside it", function()
+    local add = vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" })
+    assert.is_truthy(add.bg, "CodeReviewAdd has no muted variant")
+  end)
+end)
+
+describe("changing colorscheme", function()
+  local before = vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" }).bg
+  local was = vim.api.nvim_get_hl(0, { name = "CodeReviewAdd", link = false }).bg
+
+  vim.cmd("colorscheme blue")
+
+  local now = vim.api.nvim_get_hl(0, { name = "CodeReviewAdd", link = false }).bg
+  local backdrop = vim.api.nvim_get_hl(0, { name = "Normal", link = false }).bg or 0x000000
+  local after = vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" }).bg
+
+  -- Without this the case below passes on a theme that happens to paint a changed line the
+  -- same colour the last one did, which would prove nothing about recomputing anything.
+  it("is a change the theme really made", function()
+    assert.is_true(was ~= now, ("both themes give a changed line %s"):format(tostring(now)))
+  end)
+
+  it("recomputes the muted colour against the theme that is active now", function()
+    assert.is_true(before ~= after, "the muted colour is the one the old theme was blended into")
+    assert.is_true(after ~= now, "the muted colour is the new theme's, unmuted")
+    local theme, back, muted = channels(now), channels(backdrop), channels(after)
+    for i = 1, 3 do
+      local lo, hi = math.min(theme[i], back[i]), math.max(theme[i], back[i])
+      assert.is_true(
+        muted[i] >= lo and muted[i] <= hi,
+        ("channel %d: %d is not between the theme's %d and the background's %d"):format(i, muted[i], theme[i], back[i])
+      )
+    end
+  end)
+end)
+
+--- Nothing else on screen ---------------------------------------------------------
+
+describe("a window that is not the review's", function()
+  local V = assert(view.current(), "no review view open")
+  vim.api.nvim_set_current_win(V.win)
+  local was = arrangement()
+
+  vim.cmd("tabnew")
+  local outsider = vim.api.nvim_get_current_win()
+
+  it("is left drawing through no namespace of the plugin's", function()
+    assert.same("untouched", drawing(outsider))
+  end)
+
+  it("does not mute the review it took focus from", function()
+    assert.same(was, arrangement())
+  end)
+
+  vim.cmd("tabclose")
+  vim.api.nvim_set_current_win(V.win)
+end)
+
+--- With the switch off ------------------------------------------------------------
+
+describe("a review opened with muting off", function()
+  require("codereview").setup({ layout = "split", syntax = true, muted = { enabled = false } })
+  view.close()
+  view.open("branch")
+  local V = assert(view.current(), "no review view open")
+
+  it("attaches no namespace to any of its windows", function()
+    assert.same({ after = "untouched", before = "untouched", tree = "untouched" }, arrangement())
+  end)
+
+  it("draws a cursorline in every one of them, as it did before muting existed", function()
+    assert.same({ after = true, before = true, tree = true }, cursorlines())
+  end)
+
+  it("leaves them that way when focus moves", function()
+    vim.api.nvim_set_current_win(V.panel_win)
+    assert.same({ after = "untouched", before = "untouched", tree = "untouched" }, arrangement())
+    assert.same({ after = true, before = true, tree = true }, cursorlines())
+  end)
+end)
+
+--- The cells a reviewer's screen holds ---------------------------------------------
+
+-- One child per reading, because `nvim__inspect_cell` is only honest on the first call a
+-- process makes. Each opens the same review over this spec's fixture, in the unified layout
+-- at 80x24, and reads the first token the treesitter replay painted on an *added* line --
+-- one cell carrying a changed line's background under a foreground from a higher priority
+-- band, which is the only shape that can tell muting that reaches the diff from muting that
+-- reaches nothing but the empty space.
+describe("the cell under a reviewer's eye", function()
+  ---@param env table<string, string>
+  ---@return string
+  local function child(env)
+    local run = vim
+      .system({
+        vim.v.progpath,
+        "--clean",
+        "-l",
+        vim.fs.joinpath(h.root, "tests", "codereview", "muted_child.lua"),
+      }, {
+        cwd = fixture,
+        text = true,
+        env = vim.tbl_extend("force", {
+          FIXTURE = fixture,
+          XDG_STATE_HOME = vim.fn.tempname() .. "-state",
+          GIT_CONFIG_GLOBAL = "/dev/null",
+          GIT_CONFIG_SYSTEM = "/dev/null",
+        }, env),
+      })
+      :wait(60000)
+    -- `nvim -l` sends print to stderr, so read both streams rather than guessing.
+    local out = (run.stdout or "") .. (run.stderr or "")
+    assert(run.code == 0, out)
+    return vim.trim(out)
+  end
+
+  local focused = child({ FOCUS = "diff", CELL = "token" })
+  local muted = child({ FOCUS = "tree", CELL = "token" })
+  local stranger = child({ FOCUS = "tree", CELL = "stranger" })
+  local off = child({ FOCUS = "tree", CELL = "token", MUTED = "0" })
+
+  it("carries the changed line's background and the replay's foreground while focused", function()
+    assert.same("cell l fg=ee0000 bg=004400", (focused:gsub(" at %d+,%d+$", "")))
+  end)
+
+  -- The regression the `winhighlight`/`NormalNC` route would be: it changes a window's
+  -- default colours, and neither of these two comes from those.
+  it("mutes both of them once its pane loses focus", function()
+    assert.same("cell l fg=770000 bg=002200", (muted:gsub(" at %d+,%d+$", "")))
+  end)
+
+  it("leaves a group with no variant at its global brightness on a muted background", function()
+    assert.same("cell l fg=00ee00 bg=002200", (stranger:gsub(" at %d+,%d+$", "")))
+  end)
+
+  it("paints exactly what it painted before muting existed when the switch is off", function()
+    assert.same("cell l fg=ee0000 bg=004400", (off:gsub(" at %d+,%d+$", "")))
+  end)
+end)
+
+--- A configuration mistake --------------------------------------------------------
+
+-- Last, because it deliberately leaves a bad value in the options: the switches beside this
+-- one are bare booleans, so `muted = false` is the mistake worth catching loudly.
+describe("the switch written the way the coarse ones are", function()
+  local ok, err = pcall(require("codereview").setup, { muted = false })
+
+  it("fails at setup rather than inside a window helper later", function()
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("muted = { enabled = false }", 1, true), tostring(err))
+  end)
+
+  require("codereview").setup({ layout = "split", syntax = true })
+end)


### PR DESCRIPTION
A review can hold three windows at once — the before **pane**, the after pane and the file
tree — and nothing on screen said which one the next keystroke would act on. In the split
**layout** it was worse than ambiguous: `cursorbind` holds both panes on the same row, so two
`cursorline`s were lit and neither meant *you are here*.

A review window without focus is now **muted**: its colours pulled toward the background, so
the focused window is the bright one. Only that window draws a `cursorline`. The tree is in
the rule with the panes, because it competes with them for focus.

## How

**A window-local highlight namespace, not `winhighlight` with `NormalNC`.** That route cannot
do this job and is now written down in the design notes with the measured reason: it changes
only a window's *default* foreground and background, and in the panes almost nothing uses
those — a changed row carries its own line background, and code foregrounds come from the
treesitter replay's extmarks at a higher priority band. It would leave every changed line and
every highlighted token bright and dim little but the empty space. A namespace reaches all
three, and a group it has no variant for falls back to its global definition — which is what
keeps an unrecognised colorscheme *less muted* rather than wrongly coloured. There is no
palette anywhere in this: every muted colour is one of the active theme's, blended toward
`Normal`'s background by one configurable factor.

**The bright window is the review's last-focused one, latched on the view** — not the current
window. That is what makes a float change nothing: the composer, the queue float and the
archive float all move focus out of every review window, and a rule written against the
current window would mute the whole review the moment a reviewer started typing a note.

**Enrolment goes through the shared window helper** in `view_layout.lua`, the one every
review window already passes through, the tree's included — so a pane rebuilt by a layout
toggle and a re-summoned tree come back obeying the rule. That helper is where #105 left the
tree's window construction, so the tree stayed enrolled across the extraction without this
knowing what a tree is. The arrangement is recomputed by one `WinEnter`/`WinLeave` pair on
the view's augroup, because which window is muted is a property of the *set*; and it is
reasserted where focus is decided rather than only where a window is created.

**The group set grows during a review**, since a file is parsed only as its rows come near
the window. The view widens the namespace at the two moments it has just run the replay — a
paint, and every keystroke — at the cost of one integer comparison when nothing new resolved.
The whole thing is recomputed from a `ColorScheme` autocommand on the view's augroup,
declared after the one `hl.lua` re-links its own groups from, so what it reads has already
been re-linked.

## Module graph: no new cycles

An earlier revision had `view_layout` requiring `hl` and `syntax` while `hl.apply` and
`syntax.apply` reached back through `package.loaded` — two new cycles, and
`lua/codereview/CLAUDE.md` would have had to be rewritten in three places to stay true.

Both edges are gone. The view already requires all three modules, so it drives both:
`view.paint` and `view.cursor_moved` call `view_layout.mute_extend()` where they have just
run the replay, and `view.open` registers the `ColorScheme` autocommand. `view_layout` now
requires only modules strictly below it and is required only by `view` and `view_panel`, so
**the map is true as written** — "The two cycles" is still two, `view_layout` still belongs in
the list of modules that *would* be a third but take the view as an argument instead, and the
stacking order that puts `syntax` a tier below `view_layout` is now the direction the code
actually points. Only one row changed: `view_layout`'s, to name muting among what it owns.

This was the project's own stated preference — hand the dependency in rather than reach back
up for it — and it cost nothing: the seam is still the moment the set of groups changes,
because that is the moment the view returns from the replay.

## Configuration

```lua
muted = { enabled = true, strength = 0.5 }
```

Coarse the way `archived` is: off is nothing muted, nothing computed and no namespace
attached to anything. `muted = false` — the mistake the bare-boolean switches beside it
invite — fails at `setup()` naming the line to change instead of raising from inside a window
helper later. No keymap.

`hl.lua` now says the invariant `M.groups()` rests on out loud: a group a review window draws
in has to be named in one of that file's tables, because that is what the muted set is derived
from. A group that lives anywhere else is one a muted window leaves bright.

## Tests

`muted_spec` owns this, named for the state the way `touched_spec` is: which window is bright
and which is muted at open and after every focus move, focus moved with `<C-w>h` proving the
rule is wired to the events and not to `<Tab>`, `cursorline` following focus, the three floats
changing nothing, a rebuilt pane and a re-summoned tree obeying immediately, a group left
bright on purpose, the colorscheme change, a window outside the review left alone, and the
switch off.

Four of its cases read the cell a reviewer's screen actually holds — a changed line's
background under a token the treesitter replay painted, which is the exact regression the
`NormalNC` route would be. Those run in `muted_child.lua`, one process each, because
`nvim__inspect_cell` is honest only on the first call a process makes; that, and the 80x24
grid a headless Neovim keeps whatever `columns` says, are now in `tests/README.md`.

Every assertion was checked by breaking the code it measures, on the rebased tree, each
mutation applied and run **separately**:

| Mutation | Cases red |
| --- | --- |
| bright = the current window instead of the latch | 4 — every float case, and the outsider |
| no recompute on `WinEnter`/`WinLeave` | 17 |
| no enrolment in the window helper | 18 |
| namespace built once instead of extended | 2 — the file parsed while muted, and its cell |
| no widening after the **paint**'s replay | 1 — the file parsed while muted |
| no widening after the **keystroke**'s replay | **0 — see below** |
| no rebuild on `ColorScheme` | 1 |
| `cursorline` constant instead of a function of focus | 7 |
| only `Normal` muted (what `NormalNC` amounts to) | 4, including the muted cell |
| a variant for every group the editor knows | 2 — both "left bright" cases |
| `cursorline` deleted from the window helper | 2, and only with muting **off** — which is the point: something downstream reasserts it, so that is not a teeth check for anything here |

**The one line with no spec, stated rather than hidden.** Deleting the widening call in
`cursor_moved` reds nothing. What reaches it and not the paint is *scrolling* into a file
whose language nothing has parsed yet, and that needs a diff taller than the viewport margin
holding more than one language: `mkbig` is Lua only, `mkfixture` is short enough that
everything parses on open. No fixture in the suite has that shape, so this is a gap in the
fixtures rather than a line to remove — and it is now a bullet in `tests/README.md` and a
comment at the call site, so the next reader does not assume coverage that is not there.

Rebased onto `9eb0bef`; `make all` passes — 31 spec files, 1,154 cases, 0 failures, 0 errors.

Closes #102
