### PR TITLE
feat(view): name the file under the cursor on each pane's winbar

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,15 @@ pure deletion, a file that exists on only one side — so the two stay row-align
 from a **pad**, the blank row after a hunk, which both panes draw.
 _Avoid_: padding, spacer
 
+**Sticky header**:
+The current file named on a **pane**'s winbar, so the file survives reading past its own
+header row in the diff. The file the *cursor* is in, not the one at the top of the viewport,
+and always shown rather than only once the real header has gone — it names the file an
+annotation would attach to. Carries what the in-buffer file header carries: the icon, the
+chevron, the path, the `+N -M` and the note count, with the review summary right-aligned
+beside it.
+_Avoid_: breadcrumb, pinned header, floating header
+
 **Span**:
 The run of characters within a paired line that differs from its counterpart, emphasised so
 the eye lands on the change rather than on the line. Not _range_: a **range** is already a

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ an exact scroll offset across a structural move would be preserving something me
 
 Chrome is split too: a hunk header shows its pre-image range on the left and its post-image
 range plus git's section heading on the right, and a renamed file shows its old path on the
-left and its new path on the right.
+left and its new path on the right — on the winbar as well as in the buffer, so the left
+pane's sticky header names the pre-image path beside the revision it is showing.
 
 Horizontal scrolling is **not** synchronised, because doing so would mean changing
 `scrollopt`, a global option this plugin does not own.
@@ -228,6 +229,29 @@ you were last in, not the window with the cursor in it.
 
 `muted = { enabled = false }` turns it off whole; `strength` is one number from 0 to 1
 saying how far toward the background a colour goes.
+
+### The file you are in, on the winbar
+
+A file's header row scrolls off the top as soon as you read past the first screenful of it.
+The **sticky header** keeps it:
+
+```
+ ○ ▾ src/routes.lua  +12 -3  [2 notes]        branch vs master · 2/7 reviewed · +40 -9
+```
+
+The same icon, chevron, path, `+N -M` and note count the in-buffer header carries, with the
+review summary right-aligned beside it. It names the file the **cursor** is in — not the one
+at the top of the window — so it is the file an annotation would attach to, which is what
+you are reaching for when you annotate twenty lines into a hunk. It works with the tree
+dismissed, and with a review opened without one.
+
+In the split layout each pane names its own side, so a rename reads correctly on the side
+holding the old name; the unified layout spells it `old → new`, exactly as the file header
+does. On a pane too narrow for both halves the summary gives way first — starting with what
+the file beside it now says twice — and the path keeps its tail.
+
+The bar is chrome of the review window it sits on, so it mutes with that window: on the pane
+without focus the sticky header recedes with everything else in it.
 
 ### Typed annotations
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -252,8 +252,10 @@ file, never to whatever code happens to be above it.
 Chrome is split too, so headers stay aligned as well. A hunk header shows its
 pre-image range on the left and its post-image range plus git's section
 heading on the right; a renamed file shows its old path on the left and its
-new path on the right. The right pane's winbar carries the review status; the
-left names the revision it is showing.
+new path on the right. Each pane's winbar names its own side of that rename
+too: the right carries the review status beside the post-image path, the left
+names the revision it is showing beside the pre-image path. See
+|codereview-sticky-header|.
 
 Both panes accept annotations, and the pane the cursor is in decides what is
 captured: a deleted line on the left, the post-image line on the right. The
@@ -298,6 +300,32 @@ is what decides at the start of every session. It is deliberately not written
 to the state file -- that file is per repository and a layout preference is
 not, and a stored preference would silently override a `layout` you had since
 changed.
+
+The sticky header                                  *codereview-sticky-header*
+
+Each pane's winbar names the file the cursor is in, so reading past that
+file's own header row in the diff does not cost you the file: >
+    ○ ▾ src/routes.lua  +12 -3  [2 notes]    branch vs master · 2/7 reviewed
+<
+It carries what the in-buffer file header carries -- the icon, the chevron,
+the path, the `+N -M` and the note count -- with the review summary
+right-aligned beside it. A rename follows the same rule the file header
+follows: the unified layout spells `old -> new`, and in the split layout each
+pane names its own side, so the left pane names the pre-image path beside the
+revision it is showing.
+
+The file named is the one under the *cursor*, not the one at the top of the
+window, and it is always shown rather than only once the real header has
+scrolled off -- so it names the file an annotation would attach to, which is
+what matters when you annotate twenty lines into a hunk. It works with the
+file tree dismissed, and with a review that was opened without one.
+
+On a pane too narrow to hold both halves, the summary gives way first -- and
+gives up what the file beside it now says twice (the plugin's own name, the
+review's line totals, the queue's note count) before anything only it can say.
+The path is then cut from its head, keeping its tail, because the file's own
+name is the part being kept. A review with no files at all shows the summary
+alone, with no empty file segment.
 
 What changed inside a line                                 *codereview-spans*
 

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -57,6 +57,30 @@ works too, and takes effect on the next redraw: measured in a prototype, not ass
 group the namespace does not define falls back to its global definition, so what is not in
 it stays bright.
 
+**The winbar draws in `WinBar`/`WinBarNC` and in nothing of the plugin's own.** The bar is
+plain text: it carries no `%#Group#` markup and cannot, because every `%` on it is escaped
+(see below). So the **sticky header** mutes with its window through those two built-in
+groups and needs nothing added to the muted set — which is also the whole of what keeps the
+two features from colliding, and is why `split_spec` asserts the painted cell of a muted
+pane's bar rather than trusting that the two happen to agree.
+
+**The winbar is padded by hand, in display columns, and every `%` in it is escaped.** The
+statusline's `%=` would right-align the review summary for free and cannot be used: the bar
+carries a path a reviewer's repository chose, and a `%f` in one would be read as a
+statusline item and expanded into something else — so the whole bar is escaped on the way
+out, `%=` included. What is left is arithmetic, and it counts columns rather than bytes.
+Almost everything on that bar is multibyte — the file icons, the chevron, the `·`
+separators, a rename's `→` — so a bar padded by `#` lands a dozen columns short of the pane
+and every ASCII assertion in the suite still passes. The renamed file is what catches it.
+
+**What the sticky header sheds on a narrow pane is decided by what it now says twice.** The
+summary drops the plugin's own name, the review's line totals and the queue's note count
+first — the file segment beside them carries a chevron, that file's own `+N -M` and that
+file's own note count — and only then does the path give up its head, down to the file's own
+name. Below that the summary keeps shedding, from its head, so the target it ends on is the
+last thing to go. Shedding the summary's *tail* was the first attempt and is wrong: the
+tail is where everything nothing else on screen says has accumulated.
+
 **Collapsing is done at render time, not with folds.** A collapsed file's body is never
 emitted, so the buffer and the anchor map stay small on a large review, and there is one
 mechanism instead of two.
@@ -348,7 +372,10 @@ diff cursor runs on every `CursorMoved`; rebuilding the tree on each keystroke i
 on a large review. The crossing is judged on the view rather than inside the tree's sync,
 and judged whether or not there is a tree — a latch that stopped with the window would sit
 on the file being read at the moment the tree was dismissed, and reading that same file
-again once it was back would repaint nothing.
+again once it was back would repaint nothing. The **sticky header** hangs off the same
+crossing, which is the other half of why: a winbar hung off the tree's own repaint would
+name the right file with the tree open and freeze the moment it was dismissed — the one
+case the header exists for.
 
 ## Windows, modes and focus
 

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -29,7 +29,7 @@ change there is felt through.
 | `payload.lua` | The queue rendered as the message an agent receives; `@ref`s resolved at submit time | pure |
 | `queue.lua` | The queue itself — module-level, not per-view, so reopening a view scatters nothing | stateful (memory) |
 | `queue_float.lua` | The float over the queue: an entry as a run of bar-marked rows, and the keys that drop, jump, copy and submit | stateful (float) |
-| `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk | pure |
+| `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named | pure |
 | `state.lua` | Persisted review progress, and the blob comparisons over it — staleness, and touchedness kept in a function of its own | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -10,6 +10,12 @@
 ---what makes row alignment a property of the returned data, guaranteed by construction,
 ---rather than an emergent property of two independent calls agreeing -- and it is what lets
 ---every property that makes the split layout correct be asserted with no window on screen.
+---
+---What a *file* is called is here too, in `file_label`, for surfaces that name one somewhere
+---other than in the diff -- the winbar's **sticky header** is the second. Which icon it
+---carries, how a rename is spelled in each layout and which files have a pre-image side are
+---rules rather than formats, and two copies of them would answer differently on the first
+---file only one of the two authors had in mind.
 local M = {}
 
 ---@class CRAnchor
@@ -121,6 +127,42 @@ end
 ---a second copy would be a second set of rules about what "too wide" means.
 M.truncate = truncate
 
+---The last `width` display columns of `text`, with `…` where the head was cut.
+---
+---`truncate`'s mirror, and the **sticky header**'s: a path that has to give up columns
+---gives up the directories above it, because the file's own name is at the end of it and
+---that is the part being kept. Cutting the other way keeps the part every file in a
+---directory shares and drops the only part that says which file this is.
+---
+---By display width, like everything else here: a path a reviewer's repository chose can
+---hold anything, and counting its bytes overshoots the moment one of them is not ASCII.
+---@param text string
+---@param width integer
+---@return string
+local function keep_tail(text, width)
+  if vim.fn.strdisplaywidth(text) <= width then
+    return text
+  end
+  -- One column goes to the ellipsis. Below two there is nothing left to say but that
+  -- something was cut, which is still worth saying.
+  if width <= 1 then
+    return "…"
+  end
+  local chars = vim.fn.strchars(text)
+  local lo, hi = 0, chars
+  while lo < hi do
+    local mid = math.floor((lo + hi + 1) / 2)
+    if vim.fn.strdisplaywidth(vim.fn.strcharpart(text, chars - mid)) <= width - 1 then
+      lo = mid
+    else
+      hi = mid - 1
+    end
+  end
+  return "…" .. vim.fn.strcharpart(text, chars - lo)
+end
+
+M.keep_tail = keep_tail
+
 ---Longest prefix of `text` that fits in `width` display columns, and what is left.
 ---
 ---By display width rather than by characters: a note containing CJK or an emoji occupies
@@ -201,6 +243,66 @@ end
 ---@return table
 local function new_pane()
   return { lines = {}, anchors = {}, marks = {}, file_rows = {}, hunk_rows = {} }
+end
+
+---@class CRFileLabel
+---@field reviewed boolean       Whether the file is marked reviewed
+---@field expanded boolean       Whether its body is drawn, with the default already applied
+---@field notes integer          Queued annotations anywhere in it
+---@field icon string
+---@field chevron string
+---@field name string            Its path as this layout spells it: `old → new` when unified
+---@field before string|nil      The pre-image path; nil for a file with no pre-image at all
+---@field stat string            `+N -M`, or `binary`
+---@field right string           That stat, with the note count beside it when there is one
+
+---How a file is named, wherever it is named.
+---
+---Everything here is a *rule* rather than a format: which icon a file carries, whether it
+---counts as expanded when nothing has said, how a rename is spelled in each layout, and
+---which files have a pre-image side to name at all. The in-buffer file header asks, and so
+---does the **sticky header** on the winbar -- one function, because a second copy of these
+---answers would drift on the first file whose status only one of the two surfaces had in
+---mind, and a reviewer would then be told two things about one file at once.
+---@param file CRFile
+---@param opts { icons: table, reviewed: table<string, string>|nil, expanded: table<string, boolean>, notes: table<string, table[]>|nil, layout: string|nil }
+---@return CRFileLabel
+function M.file_label(file, opts)
+  local icons = opts.icons
+  local reviewed = opts.reviewed and opts.reviewed[file.path] ~= nil
+  local expanded = opts.expanded[file.path]
+  if expanded == nil then
+    expanded = not reviewed
+  end
+
+  -- Count notes on this file so the header can advertise them even when collapsed --
+  -- otherwise a reviewed file silently hides the comments you left on it.
+  local notes = 0
+  if opts.notes then
+    for key, items in pairs(opts.notes) do
+      if key:sub(1, #file.path + 1) == file.path .. ":" then
+        notes = notes + #items
+      end
+    end
+  end
+
+  local stat = file.binary and "binary" or ("+%d -%d"):format(file.added, file.removed)
+  local split = opts.layout == "split"
+  return {
+    reviewed = reviewed,
+    expanded = expanded,
+    notes = notes,
+    icon = reviewed and icons.reviewed or (notes > 0 and icons.annotated or icons.unreviewed),
+    chevron = expanded and icons.expanded or icons.collapsed,
+    -- A rename reads as a rename when each pane draws its own path; only the unified
+    -- layout, which has one header to say it in, spells the arrow out.
+    name = (not split and file.old_path) and ("%s → %s"):format(file.old_path, file.path) or file.path,
+    -- The half the before pane holds. A file that exists only on the after side has no
+    -- pre-image path at all, and neither its header row nor its winbar names one.
+    before = (file.status ~= "A" and file.status ~= "U") and (file.old_path or file.path) or nil,
+    stat = stat,
+    right = notes > 0 and ("%s  [%d note%s]"):format(stat, notes, notes == 1 and "" or "s") or stat,
+  }
 end
 
 ---Build the view.
@@ -448,33 +550,15 @@ function M.build(files, opts)
   end
 
   for fi, file in ipairs(files) do
-    local reviewed = opts.reviewed and opts.reviewed[file.path] ~= nil
-    local expanded = opts.expanded[file.path]
-    if expanded == nil then
-      expanded = not reviewed
-    end
-
-    -- Count notes on this file so the header can advertise them even when collapsed --
-    -- otherwise a reviewed file silently hides the comments you left on it.
-    local note_count = 0
-    if opts.notes then
-      for key, items in pairs(opts.notes) do
-        if key:sub(1, #file.path + 1) == file.path .. ":" then
-          note_count = note_count + #items
-        end
-      end
-    end
-
     --- File header -----------------------------------------------------------
-    local icon = reviewed and icons.reviewed or (note_count > 0 and icons.annotated or icons.unreviewed)
-    local chevron = expanded and icons.expanded or icons.collapsed
-    -- A rename reads as a rename when each pane draws its own path; only the unified
-    -- layout, which has one header to say it in, spells the arrow out.
-    local name = (not split and file.old_path) and ("%s → %s"):format(file.old_path, file.path) or file.path
+    -- Asked rather than assembled here: the winbar's sticky header names the same file by
+    -- the same rules, and this is the surface those rules are named after.
+    local label = M.file_label(file, opts)
+    local reviewed, expanded, note_count = label.reviewed, label.expanded, label.notes
+    local icon, chevron = label.icon, label.chevron
 
-    local left = ("%s %s %s"):format(icon, chevron, name)
-    local stat = file.binary and "binary" or ("+%d -%d"):format(file.added, file.removed)
-    local right = note_count > 0 and ("%s  [%d note%s]"):format(stat, note_count, note_count == 1 and "" or "s") or stat
+    local left = ("%s %s %s"):format(icon, chevron, label.name)
+    local stat, right = label.stat, label.right
 
     left = truncate(left, math.max(10, width - #right - 2))
     local pad = math.max(1, width - vim.fn.strdisplaywidth(left) - vim.fn.strdisplaywidth(right))
@@ -484,9 +568,9 @@ function M.build(files, opts)
     -- to sit under the after pane's name. A file that exists only on the after side has no
     -- pre-image path at all, so its header row is filler like the rest of it.
     local bheader = nil
-    if before and file.status ~= "A" and file.status ~= "U" then
+    if before and label.before then
       local indent = (" "):rep(vim.fn.strdisplaywidth(icon) + vim.fn.strdisplaywidth(chevron) + 2)
-      bheader = truncate(indent .. (file.old_path or file.path), before_width)
+      bheader = truncate(indent .. label.before, before_width)
     end
 
     -- The before pane's header row is chrome even when it is empty: it is where this file

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -113,10 +113,61 @@ end
 -- is stays here -- see `current_file` below -- because it is a fact about the diff, and the
 -- tree is only the first thing to ask for it.
 
-local function update_winbar()
-  if not vim.api.nvim_win_is_valid(V.win) then
-    return
+--- The winbar ------------------------------------------------------------------
+
+-- Each pane's winbar carries two halves: the **sticky header** naming the file the cursor
+-- is in, and the review summary beside it. The file is what survives scrolling past its own
+-- header row, so it takes the left -- and it is written where the summary already was
+-- rather than over it, because a bar that answered *which file* by dropping *which review*
+-- would have moved the problem rather than solved it.
+
+local SEP = " · "
+-- One blank column at each edge, and at least two between the halves, so the two never
+-- read as one sentence.
+local MARGIN, GAP = 1, 2
+
+---@param text string
+---@return integer
+local function cols(text)
+  return vim.fn.strdisplaywidth(text)
+end
+
+---Lay one winbar out: `left` against the left margin, `right` against the right edge.
+---
+---Padded with spaces rather than with the statusline's `%=`, because every `%` in this bar
+---is escaped on the way out -- a path is a name a reviewer's repository chose, and `%f` in
+---one would otherwise be read as a statusline item and expanded into something else. The
+---padding is counted in display columns and not in bytes: the summary's separators, the
+---file icons and a rename's arrow are all multibyte, so a bar padded by `#` drifts left by
+---two columns for every one of them, and does it on the very first path with an accent.
+---@param width integer Columns the winbar has
+---@param left string
+---@param right string Empty to leave the bar left-aligned, as it is with nothing to align
+---@return string
+local function lay_out(width, left, right)
+  if right == "" then
+    return (" "):rep(MARGIN) .. left
   end
+  local pad = width - 2 * MARGIN - cols(left) - cols(right)
+  return (" "):rep(MARGIN) .. left .. (" "):rep(math.max(GAP, pad)) .. right .. (" "):rep(MARGIN)
+end
+
+---@param win integer
+---@param bar string
+local function set_winbar(win, bar)
+  vim.wo[win].winbar = bar:gsub("%%", "%%%%")
+end
+
+---What the review summary says, one segment per `·`.
+---
+---A list rather than a string because a pane too narrow for both halves is one the summary
+---gives way on, and which segment goes is the only thing here that is not a format.
+---`spare` marks the ones the sticky header beside them now says twice: the plugin's own
+---name, against a bar that names a file with a review chevron on it; the review's line
+---totals, against the file's own `+N -M` two columns to the left; the queue's note count,
+---against the file's own. What is not spare is what nothing else on screen says.
+---@return { text: string, spare: boolean|nil }[]
+local function summary_segments()
   local reviewed = 0
   for _ in pairs(V.reviewed) do
     reviewed = reviewed + 1
@@ -126,41 +177,183 @@ local function update_winbar()
   for _, items in pairs(V.notes) do
     notes = notes + #items
   end
-  local bar = (" Code review · %s · %d/%d reviewed · +%d -%d"):format(
-    V.scope.label,
-    reviewed,
-    #V.files,
-    added,
-    removed
-  )
+  local out = {
+    { text = "Code review", spare = true },
+    { text = V.scope.label },
+    { text = ("%d/%d reviewed"):format(reviewed, #V.files) },
+    { text = ("+%d -%d"):format(added, removed), spare = true },
+  }
   if notes > 0 then
-    bar = bar .. (" · %d note%s"):format(notes, notes == 1 and "" or "s")
+    out[#out + 1] = { text = ("%d note%s"):format(notes, notes == 1 and "" or "s"), spare = true }
   end
   -- Read rather than computed: this runs on every paint, and a paint runs on every resize.
   -- The git behind the number is paid where the archive is judged, which is where the diff
   -- is read -- see `judge_archive`.
   if V.untouched then
-    bar = bar .. (" · %d untouched"):format(V.untouched)
+    out[#out + 1] = { text = ("%d untouched"):format(V.untouched) }
   end
   local to = delivery.target()
   if to and to.short then
-    bar = bar .. (" · → %s"):format(to.short)
+    out[#out + 1] = { text = ("→ %s"):format(to.short) }
   end
-  vim.wo[V.win].winbar = bar:gsub("%%", "%%%%")
+  return out
 end
 
----Name the revision the before pane is showing.
+---The summary as one string, minus whatever a narrow pane has made it drop.
+---@param segments { text: string, spare: boolean|nil }[]
+---@param dropped table<integer, boolean>|nil
+---@return string
+local function join(segments, dropped)
+  local kept = {}
+  for i, seg in ipairs(segments) do
+    if not (dropped and dropped[i]) then
+      kept[#kept + 1] = seg.text
+    end
+  end
+  return table.concat(kept, SEP)
+end
+
+---How the render would name the file the cursor is in, or nil when it is in none.
+---
+---Asked on every paint rather than read off `V.current_file`, for the reason the tree asks:
+---a paint can run between two crossings -- a resize, a fold, a scope change -- and the
+---latch is what decides when the *bar changes*, not what the bar says.
+---@param layout string
+---@return CRFileLabel|nil
+local function current_label(layout)
+  local index = M.current_file()
+  local file = index and V.files[index]
+  if not file then
+    return nil
+  end
+  return render.file_label(file, {
+    icons = config.get().icons,
+    reviewed = V.reviewed,
+    expanded = V.expanded,
+    notes = V.notes,
+    layout = layout,
+  })
+end
+
+---The file under the cursor, named as its own in-buffer header names it.
+---
+---Split into the part that may be cut and the parts that may not: the icon, the chevron and
+---the stat are a handful of columns each and say what no number of columns of path can, so
+---when a pane runs out of room the path is what gives them up.
+---@param label CRFileLabel
+---@return { head: string, path: string, tail: string }
+local function file_segment(label)
+  return { head = ("%s %s "):format(label.icon, label.chevron), path = label.name, tail = "  " .. label.right }
+end
+
+---Fit the file and the summary into `room` columns, and say what each is left holding.
+---
+---Four steps, in the order a reviewer can afford to lose things:
+---
+---1. the summary drops what the file beside it repeats, to keep the whole path;
+---2. the path gives up its head, down to the file's own name;
+---3. the summary drops the rest, from its head, so the target it ends on is the last to go;
+---4. the path takes whatever is left, which on an absurd pane is the ellipsis alone.
+---
+---The path is what a reviewer scrolled here to keep, and its *tail* is the part that says
+---which file this is -- the directories above it are shared with every sibling and are what
+---can go. The summary's own facts outrank those directories, which is step 3 sitting where
+---it does: a bar that had shed the scope to spell out two more directory names would have
+---kept the least of what it was holding.
+---@param room integer Columns, margins already taken off
+---@param file { head: string, path: string, tail: string }
+---@param segments { text: string, spare: boolean|nil }[]
+---@return string left, string right
+local function fit(room, file, segments)
+  -- The order they go in: the spares, then the rest from the head.
+  local order, spares = {}, {}
+  for i, seg in ipairs(segments) do
+    if seg.spare then
+      spares[#spares + 1] = i
+    end
+  end
+  vim.list_extend(order, spares)
+  for i, seg in ipairs(segments) do
+    if not seg.spare then
+      order[#order + 1] = i
+    end
+  end
+
+  local dropped = {}
+  local summary, path_room
+  local function measure()
+    summary = join(segments, dropped)
+    path_room = room - cols(file.head) - cols(file.tail) - (summary ~= "" and GAP + cols(summary) or 0)
+  end
+  measure()
+
+  -- Cut back to the file's own name, and no further, before the summary gives up anything
+  -- it alone says.
+  local floor = math.min(cols(file.path), cols("…" .. file.path:match("[^/]*$")))
+  local next_drop = 1
+  ---@param last integer Last position in `order` this step may reach
+  ---@param want integer Columns the path is being kept at
+  local function shed(last, want)
+    while next_drop <= last and path_room < want do
+      dropped[order[next_drop]] = true
+      next_drop = next_drop + 1
+      measure()
+    end
+  end
+  -- Step 1 keeps the whole path; steps 3 and 4 keep only the file's own name.
+  shed(#spares, cols(file.path))
+  shed(#order, floor)
+
+  return file.head .. render.keep_tail(file.path, path_room) .. file.tail, summary
+end
+
+---The after pane's winbar: the file under the cursor, and the review summary beside it.
+local function update_winbar()
+  if not vim.api.nvim_win_is_valid(V.win) then
+    return
+  end
+  local width = vim.api.nvim_win_get_width(V.win)
+  local segments = summary_segments()
+  -- The layout decides how a rename is spelled, and it is the render's decision rather than
+  -- a second one taken here: one header per file when unified, one side per pane when split.
+  local label = current_label(view_layout.has_before(V) and "split" or "unified")
+  if not label then
+    -- No file under the cursor -- an empty review. The summary has the bar to itself,
+    -- exactly as it did before there was anything to share it with, rather than a segment
+    -- advertising a file that is not there.
+    set_winbar(V.win, lay_out(width, join(segments), ""))
+    return
+  end
+  local left, right = fit(width - 2 * MARGIN, file_segment(label), segments)
+  set_winbar(V.win, lay_out(width, left, right))
+end
+
+---Name the revision the before pane is showing, and the path it is showing it at.
 ---
 ---The after pane's winbar already says what the review is; what it cannot say is which of
 ---the two images is the base, and a reviewer should never have to infer that from the code.
+---The pre-image path rides on the right of it, so a rename reads correctly on the side that
+---holds the old name -- each pane naming its own side, which is the rule the in-buffer
+---header follows in this layout rather than a second one invented for the winbar.
 local function update_before_winbar()
   if not view_layout.has_before(V) then
     return
   end
   local rev = V.scope.before
   -- `:0` is git's name for the index, and a name nobody reads as one.
-  local bar = (" Before · %s"):format(rev == ":0" and "index" or rev)
-  vim.wo[V.before_win].winbar = bar:gsub("%%", "%%%%")
+  local left = ("Before · %s"):format(rev == ":0" and "index" or rev)
+  local width = vim.api.nvim_win_get_width(V.before_win)
+  -- A file that exists only on the after side has no pre-image path to name, exactly as its
+  -- header row on this pane has none: the revision keeps the bar to itself and says so by
+  -- naming nothing beside it.
+  local label = current_label("split")
+  local path = label and label.before or ""
+  -- The revision is what this pane exists to name and is never cut for the path's sake: on
+  -- a pane too narrow to hold both, a base revision half spelled out is worse than none of
+  -- the path, which the after pane is naming anyway.
+  local room = width - 2 * MARGIN - GAP - cols(left)
+  path = (path ~= "" and room >= 2) and render.keep_tail(path, room) or ""
+  set_winbar(V.before_win, lay_out(width, left, path))
 end
 
 ---Write one pane's render into its buffer: the lines, and nothing else.
@@ -302,12 +495,17 @@ function M.paint(keep_file)
   V.painted_bands = {}
 
   view_panel.paint_panel(V, M)
-  update_winbar()
-  update_before_winbar()
 
   if keep_file and V.render.file_rows[keep_file] then
     view_layout.place(V, V.render.file_rows[keep_file])
   end
+
+  -- After `place`, not before it: the winbar names the file the cursor is in, and parking
+  -- the cursor on a file is what decides which file that is. Built here rather than left to
+  -- the crossing latch because a paint can change what the bar says without the cursor
+  -- having moved at all -- a note queued, a file marked reviewed, a pane resized.
+  update_winbar()
+  update_before_winbar()
 
   -- After `place`, not before it: parking the cursor on a file is what decides which rows
   -- are near the window, and a repaint has to leave the rows it lands on painted rather
@@ -425,13 +623,17 @@ M.current_file = current_file
 ---
 ---Everything that follows the diff hangs off the crossing rather than off the movement:
 ---this is reached from every `CursorMoved`, and rebuilding the tree on each keystroke is
----real work on a large review.
+---real work on a large review. The **sticky header** is the second thing hanging off it and
+---costs what the tree costs -- an anchor lookup per keystroke, and two winbars only when
+---the answer changed.
 local function follow_file()
   local index = current_file()
   if index == V.current_file then
     return
   end
   V.current_file = index
+  update_winbar()
+  update_before_winbar()
   view_panel.sync_panel(V, M)
 end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
 | `codereview/muted_child.lua` | Spawned four times by `muted_spec`, one painted cell each — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
+| `codereview/winbar_child.lua` | Spawned three times by `split_spec` to read one cell of a pane's winbar — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
 
 | Spec | Covers |
@@ -39,7 +40,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
 | `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them — and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, and a review with no files |
-| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, and each pane's winbar naming its own side of a rename |
+| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, each pane's winbar naming its own side of a rename, and the painted cell proving that bar mutes with its pane |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
@@ -280,6 +281,17 @@ so the out-of-core language path is still checked locally without ever failing C
   column 80 is drawn into cells nothing can read; and the cell has to be located with
   `screenpos`, because the change bar and the `│` separator are multibyte and a buffer
   column is not a screen column.
+- **A muted winbar cannot be told from a bright one by its text**, and a non-current window
+  draws its winbar in `WinBarNC` whether or not anything is muted — so "the unfocused pane's
+  bar is not `WinBar`" holds with the muted namespace never reaching the winbar at all. The
+  sticky header carries no group of the plugin's own, so that namespace covering `WinBar`
+  and `WinBarNC` is the only thing making it recede with its pane, and the only assertion
+  that can see it is the painted cell. `split_spec` spawns `winbar_child.lua` three times
+  over one cell inside the path the bar names — focused, muted, and **muted off** — and it
+  is the third that gives the second its teeth: without it the muted reading is only known
+  to differ from `WinBar`, not to be a blend of anything. Its window position is taken from
+  `nvim_win_get_position`, which is the winbar's own row, and the offset into the bar is a
+  display width, since the icon and the chevron in front of the path are both multibyte.
 - **`WinResized` is no use to a test.** It is fired from the main loop, so it lands after
   whatever changed the width has returned — and in a headless spec, which never pumps the
   loop, it does not land at all. Anything that changes a window's width has to repaint for

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,8 +38,8 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | --- | --- |
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
-| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, and archived entries on the diff: where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them |
-| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, and the two intersections nobody else owns |
+| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them — and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, and a review with no files |
+| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, and each pane's winbar naming its own side of a rename |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
@@ -397,6 +397,30 @@ so the out-of-core language path is still checked locally without ever failing C
   remove the `BufEnter`/`WinEnter`/`InsertEnter` autocmd in `view_layout.lua` and the
   `stopinsert` in `annotate.lua`'s `collect`: it must fail with `mode='i'`. A headless
   version of that test passes whether or not the fix exists, which is why it drives a pty.
+- **A winbar assertion has to say how wide the pane was.** Both halves of the sticky header
+  fit on a wide pane and neither one does on a narrow one, so "the summary is still there"
+  and "the summary gave way" are both true depending on a number no assertion mentions.
+  Worse, nothing resizes itself: `vim.o.columns` hands every new column to the *last*
+  window rather than sharing them, and `WinResized` never lands in a headless spec — so a
+  case that widens a terminal and asserts is usually asserting against the width it started
+  at. `render_spec` sets the pane's width outright and asserts it took, and `split_spec`
+  widens the terminal, levels the windows with `wincmd =`, repaints by hand and *guards*
+  that the before pane really did end up wide enough to hold a revision and a path at once.
+  Without that guard its rename cases pass by reading a bar the path never reached.
+- **An ASCII winbar cannot fail the byte-padding bug.** The bar is padded to the pane's
+  width by arithmetic, and by *bytes* it comes out a dozen columns short while every
+  substring assertion in the suite still passes. `render_spec` parks on `src/newname.lua`,
+  whose bar carries `○`, `▾`, `→` and `·` at once, and asserts the bar's display width is
+  the pane's width exactly — with a second assertion that the bar really is longer in bytes
+  than in columns, or the case is comparing two equal numbers and measuring nothing.
+  Replacing `view.lua`'s two `cols(...)` calls in `lay_out` with `#` must red it. Same trap
+  as "an ASCII fixture cannot fail the byte-splitting bug".
+- **The sticky header's teeth are in the case with no tree.** With the tree open, a winbar
+  hung off the tree's own repaint follows the cursor perfectly, so every case but that one
+  passes with the crossing latch put back inside `view_panel.sync_panel`. Returning early
+  from `view.lua`'s `follow_file` when `V.panel_win` is nil must red the tree-dismissed case
+  in `render_spec` — it freezes on the file that was being read when the tree went away —
+  and one case in `panel_spec`. That is the whole reason #103 moved the latch.
 - **A set comparison passes when one set was never read.** `map_spec` matches the module
   map's rows with a pattern over the table's first column, so reformatting that column —
   dropping the backticks, say — silently yields no rows, and "no row names a module that is

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -338,3 +338,211 @@ describe("line keys", function()
     })
   end)
 end)
+
+-- The sticky header: the file the cursor is in, named on the winbar so that reading past
+-- that file's own header row no longer costs a reviewer the file.
+--
+-- Asserted through the window option, as the scope above already is -- what a reviewer's
+-- editor holds after a real cursor movement, never the function that put it there. This is
+-- the *unified* layout's bar, including the rename spelled `old → new`; the per-pane rules
+-- are `split_spec`'s. Every case reads a file from well below its header row, because the
+-- header is exactly what has gone by the time this matters.
+--
+-- These blocks run last in this file and move the pane's width and the scope about, which
+-- nothing below them would survive.
+describe("the sticky header", function()
+  local V = view.current()
+
+  local function bar()
+    return vim.wo[V.win].winbar
+  end
+
+  ---Read a file the way a reviewer does -- autocmd and all, which is the only thing that
+  ---moves the crossing latch -- landing on its *last* code row rather than on its header.
+  ---@param path string
+  ---@return integer row, integer header
+  local function read_into(path)
+    local index = assert(h.file_index(V, path))
+    local last
+    for row = 1, #V.render.lines do
+      local a = V.render.anchors[row]
+      if a and a.file == index and a.kind == "line" then
+        last = row
+      end
+    end
+    assert(last, "no code rows for " .. path)
+    vim.api.nvim_set_current_win(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { last, 0 })
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+    return last, V.render.file_rows[index]
+  end
+
+  local away = "src/nonl.md"
+  local row, header = read_into(away)
+  local first = V.files[1].path
+
+  -- Guards the block itself: parked on the file's header row, or on the first file in the
+  -- diff, every case below would pass with the winbar naming whatever is at the top.
+  it("really is reading a file from below its own header", function()
+    assert.is_true(row > header + 1, ("row %d is not below header %d"):format(row, header))
+    assert.is_true(first ~= away, "the file being read is the first one in the diff")
+  end)
+
+  it("names the file the cursor is in, not the one the diff starts with", function()
+    assert.is_truthy(bar():find(away, 1, true), bar())
+    assert.is_nil(bar():find(first, 1, true), bar())
+  end)
+
+  it("carries that file's own stat beside its name", function()
+    local file = V.files[assert(h.file_index(V, away))]
+    assert.is_truthy(bar():find(("+%d -%d"):format(file.added, file.removed), 1, true), bar())
+  end)
+
+  -- Two crossings rather than one: a bar that named the file it was built with and never
+  -- moved again would pass a single absolute assertion.
+  it("changes when the cursor crosses into another file", function()
+    read_into("src/main.lua")
+    assert.is_truthy(bar():find("src/main.lua", 1, true), bar())
+    assert.is_nil(bar():find(away, 1, true), bar())
+
+    read_into(away)
+    assert.is_truthy(bar():find(away, 1, true), bar())
+    assert.is_nil(bar():find("src/main.lua", 1, true), bar())
+  end)
+
+  -- The half this slice must not have cost anyone: everything the winbar said before it
+  -- existed is still on it, moved to the right rather than dropped.
+  it("keeps the review summary beside the file", function()
+    local added, removed = require("codereview.diff").totals(V.files)
+    assert.is_truthy(bar():find(V.scope.label, 1, true), bar())
+    assert.is_truthy(bar():find(("0/%d reviewed"):format(#V.files), 1, true), bar())
+    assert.is_truthy(bar():find(("+%d -%d"):format(added, removed), 1, true), bar())
+  end)
+end)
+
+-- The case the feature exists for. The tree is the one surface that answered "which file am
+-- I in" before this, it is dismissible, and a sticky header hung off the tree's own repaint
+-- would freeze exactly here -- `queue_jump_panel_spec` is the prior art for reaching this
+-- state, and this is the same reason it exists.
+describe("the sticky header with the tree dismissed", function()
+  local V = view.current()
+  view.toggle_panel()
+
+  local function bar()
+    return vim.wo[V.win].winbar
+  end
+
+  ---@param path string
+  ---@return integer index
+  local function read_into(path)
+    local index = assert(h.file_index(V, path))
+    vim.api.nvim_set_current_win(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index] + 1, 0 })
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+    return index
+  end
+
+  it("really has no tree", function()
+    assert.is_nil(V.panel_win)
+    assert.is_nil(V.panel_render)
+  end)
+
+  it("still names the file the cursor crosses into", function()
+    read_into("src/main.lua")
+    assert.is_truthy(bar():find("src/main.lua", 1, true), bar())
+    read_into("src/nonl.md")
+    assert.is_truthy(bar():find("src/nonl.md", 1, true), bar())
+    assert.is_nil(bar():find("src/main.lua", 1, true), bar())
+  end)
+end)
+
+describe("the sticky header on a pane that has to choose", function()
+  local V = view.current()
+  view.toggle_panel() -- back, so the after pane has a neighbour to give columns to
+
+  local function bar()
+    return vim.wo[V.win].winbar
+  end
+
+  ---Resize the pane and repaint. `WinResized` is fired from the main loop and never lands
+  ---in a headless spec, so the repaint is this test's to drive.
+  ---@param width integer
+  ---@return integer width
+  local function resize(width)
+    vim.api.nvim_win_set_width(V.win, width)
+    view.paint()
+    local index = assert(h.file_index(V, "src/newname.lua"))
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index] + 1, 0 })
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+    return vim.api.nvim_win_get_width(V.win)
+  end
+
+  local wide = resize(100)
+
+  it("really resized the pane", function()
+    assert.same(100, wide)
+  end)
+
+  -- The in-buffer header's rule, not a second one: one header per file in this layout, so
+  -- the arrow is spelled out.
+  it("spells a rename out as the file header does", function()
+    assert.is_truthy(bar():find("src/oldname.lua → src/newname.lua", 1, true), bar())
+  end)
+
+  -- The one case an ASCII assertion cannot make. This bar carries `○`, `▾`, `→` and `·`,
+  -- every one of them wider in bytes than in columns, so a bar padded by `#` overshoots the
+  -- pane by a dozen columns and this is what notices. The guard is the second assertion:
+  -- with an all-ASCII bar the two lengths agree and the case measures nothing.
+  it("fills the pane exactly, counting columns rather than bytes", function()
+    assert.same(wide, vim.fn.strdisplaywidth(bar()), bar())
+    assert.is_true(#bar() > wide, "nothing multibyte on the bar to measure")
+  end)
+
+  local narrow = resize(45)
+
+  it("really narrowed the pane", function()
+    assert.same(45, narrow)
+  end)
+
+  it("keeps the path's tail and shows the cut", function()
+    assert.is_truthy(bar():find("src/newname.lua", 1, true), bar())
+    assert.is_truthy(bar():find("…", 1, true), bar())
+    assert.is_nil(bar():find("src/oldname.lua", 1, true), bar())
+  end)
+
+  -- The summary gives way, and gives up what the file beside it now says twice before what
+  -- only it can say: the plugin's own name and the review's line totals go, the reviewed
+  -- tally is still there.
+  it("sheds the summary rather than the file", function()
+    assert.is_nil(bar():find("Code review", 1, true), bar())
+    assert.is_truthy(bar():find(("0/%d reviewed"):format(#V.files), 1, true), bar())
+  end)
+end)
+
+describe("the sticky header on a review with no files", function()
+  local V = view.current()
+  -- A revspec whose two ends are the same commit: a review that opened on a real scope and
+  -- has nothing in it, which is the only way to reach an empty one -- `open` refuses.
+  view.set_scope("HEAD..HEAD")
+
+  local function bar()
+    return vim.wo[V.win].winbar
+  end
+
+  it("really has no files", function()
+    assert.same(0, #V.files)
+  end)
+
+  -- Left-aligned and starting with the summary's first word: no file segment, and no empty
+  -- one either. A bar that drew the icons with nothing after them would fail here.
+  it("gives the summary the winbar to itself", function()
+    assert.same(" Code review", bar():sub(1, #" Code review"), bar())
+    assert.is_truthy(bar():find("0/0 reviewed", 1, true), bar())
+  end)
+
+  it("draws no chevron for a file that is not there", function()
+    local icons = config.get().icons
+    assert.is_nil(bar():find(icons.collapsed, 1, true), bar())
+    assert.is_nil(bar():find(icons.expanded, 1, true), bar())
+  end)
+end)

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -1210,3 +1210,68 @@ describe("syntax highlighting in the split layout", function()
     assert.is_true(#on_row > 0, ("nothing highlighted on before-pane row %d"):format(row))
   end)
 end)
+
+-- The **sticky header**, per pane. The unified layout's bar is `render_spec`'s, arrow and
+-- all; what only this layout can say is that each pane names its own side -- the after pane
+-- the post-image path, the before pane the pre-image path beside the base revision it
+-- already carried. That is the in-buffer file header's rename rule, and this is the winbar
+-- following it rather than inventing a second one.
+--
+-- Last in this file: it widens the terminal, which nothing below it would survive.
+describe("the sticky header in the split layout", function()
+  local V = view.current()
+  -- Both bars have to hold a 40-character revision and a path at once, and a third of a
+  -- 120-column terminal is not enough for that -- the pane would truncate its way to a pass
+  -- or a fail for reasons that have nothing to do with which side it names. Widening the
+  -- terminal hands every new column to the last window, so the panes are levelled after it,
+  -- and the repaint is this test's to drive: `WinResized` never lands in a headless spec.
+  vim.o.columns = 200
+  vim.cmd("wincmd =")
+  view.paint()
+
+  ---@param path string
+  local function read_into(path)
+    local index = assert(h.file_index(V, path))
+    focus(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index] + 1, 0 })
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+  end
+
+  read_into("src/newname.lua")
+  local after, before = vim.wo[V.win].winbar, vim.wo[V.before_win].winbar
+
+  -- Guards the block: on a pane with no room for both, the before pane's path is dropped
+  -- rather than drawn over its revision, and every case here would be reading that instead.
+  it("really gave each pane room for a revision and a path", function()
+    local width = vim.api.nvim_win_get_width(V.before_win)
+    local need = vim.fn.strdisplaywidth(V.scope.before) + #" Before ·   src/oldname.lua "
+    assert.is_true(width >= need, ("%d columns, %d needed"):format(width, need))
+  end)
+
+  it("names the post-image path on the after pane, and only that side", function()
+    assert.is_truthy(after:find("src/newname.lua", 1, true), after)
+    assert.is_nil(after:find("src/oldname.lua", 1, true), after)
+  end)
+
+  it("names the base revision and the pre-image path on the before pane", function()
+    assert.is_truthy(before:find(V.scope.before, 1, true), before)
+    assert.is_truthy(before:find("src/oldname.lua", 1, true), before)
+  end)
+
+  it("keeps the review summary on the after pane where it has always been", function()
+    assert.is_truthy(after:find(V.scope.label, 1, true), after)
+    assert.is_truthy(after:find("reviewed", 1, true), after)
+  end)
+
+  -- A file added on the branch exists on one side only, and the before pane's header row for
+  -- it is filler. Its winbar says the same thing by naming nothing.
+  it("names no pre-image for a file that has none", function()
+    read_into("src/fresh.lua")
+    assert.is_truthy(vim.wo[V.win].winbar:find("src/fresh.lua", 1, true), vim.wo[V.win].winbar)
+    assert.is_nil(vim.wo[V.before_win].winbar:find("fresh", 1, true), vim.wo[V.before_win].winbar)
+  end)
+
+  it("still names the revision on a pane naming no file", function()
+    assert.is_truthy(vim.wo[V.before_win].winbar:find(V.scope.before, 1, true), vim.wo[V.before_win].winbar)
+  end)
+end)

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -1275,3 +1275,74 @@ describe("the sticky header in the split layout", function()
     assert.is_truthy(vim.wo[V.before_win].winbar:find(V.scope.before, 1, true), vim.wo[V.before_win].winbar)
   end)
 end)
+
+-- The sticky header and **muting**, together. Neither slice could see this: the winbar was
+-- written against a base with no muting in it, and muting against one whose winbar named no
+-- file. What their combination implies is that the file segment is chrome of a review window
+-- and has to recede with it -- and the bar carries no highlight group of the plugin's own,
+-- so it draws in `WinBar` and `WinBarNC` and mutes only because the muted set covers those
+-- two. Nothing about that is visible in the bar's *text*, which is identical bright or
+-- muted, so this is asserted at the cell and can be asserted nowhere else.
+--
+-- One child process per reading, as `muted_spec` does and for the reason measured there:
+-- `nvim__inspect_cell` is honest only on the first call a process makes.
+describe("the sticky header on a muted pane", function()
+  ---@param env table<string, string>
+  ---@return string
+  local function child(env)
+    local run = vim
+      .system({
+        vim.v.progpath,
+        "--clean",
+        "-l",
+        vim.fs.joinpath(h.root, "tests", "codereview", "winbar_child.lua"),
+      }, {
+        cwd = root,
+        text = true,
+        env = vim.tbl_extend("force", {
+          FIXTURE = root,
+          XDG_STATE_HOME = vim.fn.tempname() .. "-state",
+          GIT_CONFIG_GLOBAL = "/dev/null",
+          GIT_CONFIG_SYSTEM = "/dev/null",
+        }, env),
+      })
+      :wait(60000)
+    -- `nvim -l` sends print to stderr, so read both streams rather than guessing.
+    local out = (run.stdout or "") .. (run.stderr or "")
+    assert(run.code == 0, out)
+    return vim.trim(out)
+  end
+
+  -- Always the *after* pane's bar, over the first character of the path it names. Which pane
+  -- has focus is what decides whether that pane is the muted one.
+  local muted = child({ FOCUS = "before", MUTED = "1" })
+  local bright = child({ FOCUS = "after", MUTED = "1" })
+  local unmuted_nc = child({ FOCUS = "before", MUTED = "0" })
+
+  -- Every reading is of a cell inside the path, so a bar that had stopped naming the file
+  -- would fail here before any colour was compared.
+  it("really read the file segment in all three arrangements", function()
+    for _, reading in ipairs({ muted, bright, unmuted_nc }) do
+      assert.same("cell s", reading:sub(1, #"cell s"), reading)
+    end
+  end)
+
+  it("draws the file segment at full brightness on the pane with focus", function()
+    assert.same("cell s fg=eeee00 bg=006600", bright)
+  end)
+
+  -- `WinBar`'s colours blended halfway to `Normal`'s background -- the muted namespace's
+  -- variant, not the group itself.
+  it("mutes the file segment with the pane it names the file for", function()
+    assert.same("cell s fg=770000 bg=002200", muted)
+  end)
+
+  -- The reading that gives the one above its teeth. A non-current window draws its winbar in
+  -- `WinBarNC` whether or not anything is muted, so "the muted pane's bar is not `WinBar`"
+  -- would hold with the namespace never reaching the winbar at all. With muting off the same
+  -- cell comes back at `WinBarNC`'s own brightness, which is what the muted reading is
+  -- darker *than*.
+  it("comes back at that group's own brightness with muting off", function()
+    assert.same("cell s fg=ee0000 bg=004400", unmuted_nc)
+  end)
+end)

--- a/tests/codereview/winbar_child.lua
+++ b/tests/codereview/winbar_child.lua
@@ -1,0 +1,91 @@
+-- One painted cell of a pane's **sticky header**, read in a process of its own.
+--
+-- The intersection neither slice could see. The winbar names the file the cursor is in, and
+-- a review window without focus is **muted** through a highlight namespace -- and the bar
+-- carries no highlight group of the plugin's own, so it draws in `WinBar` when its window
+-- has focus and in `WinBarNC` when it does not, both of which the muted set covers. Whether
+-- the file segment actually recedes with its pane is therefore a question about that
+-- namespace reaching the winbar, and **no assertion about the bar's text can answer it**:
+-- the text is identical bright or muted. Only the cell is different.
+--
+-- `WinBarNC` is what a non-current window's bar draws in whether or not anything is muted,
+-- which is exactly why the control reading matters: with muting off the same cell must come
+-- back at `WinBarNC`'s own colour. Muted and unmuted differing is the claim; a bar that
+-- ignored the namespace would return the second colour in both runs.
+--
+-- The three constraints are `muted_child.lua`'s, for the reasons measured there: exactly one
+-- `nvim__inspect_cell` call per process, because only the first is honest; an 80x24 grid,
+-- because that is what a headless Neovim keeps whatever `columns` says; and colours whose
+-- channels are all even, so a half-strength blend toward a black background has no rounding
+-- in it.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. Spawned by
+-- `split_spec` with FIXTURE, FOCUS and MUTED in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.termguicolors = true
+vim.o.columns = 80
+vim.o.lines = 24
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+-- The two groups a winbar can draw in, given distinct colours so the reading says which one
+-- it came from as well as how bright it was.
+vim.api.nvim_set_hl(0, "WinBar", { fg = 0xeeee00, bg = 0x006600 })
+vim.api.nvim_set_hl(0, "WinBarNC", { fg = 0xee0000, bg = 0x004400 })
+
+require("codereview").setup({
+  layout = "split",
+  syntax = false,
+  -- No tree: three windows over 80 columns leave a pane too narrow to name a file at all,
+  -- and the file segment is the whole point of the cell being read.
+  panel = { enabled = false },
+  muted = { enabled = vim.env.MUTED ~= "0", strength = 0.5 },
+})
+
+local view = require("codereview.view")
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+
+-- Read a file the way a reviewer does, so the bar names the file under the cursor rather
+-- than whichever one the review happened to open on.
+local PATH = "src/nonl.md"
+local index
+for i, f in ipairs(V.files) do
+  if f.path == PATH then
+    index = i
+  end
+end
+assert(index, PATH .. " is not in this fixture's branch scope")
+vim.api.nvim_set_current_win(V.win)
+vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index] + 1, 0 })
+vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+
+-- Focus decides which pane is muted; the cell read is always the *after* pane's, so
+-- FOCUS=before is the muted reading and FOCUS=after the bright one.
+vim.api.nvim_set_current_win(vim.env.FOCUS == "before" and V.before_win or V.win)
+
+-- Where the path starts on that bar, in display columns rather than bytes: the icon and the
+-- chevron in front of it are both multibyte, so a byte offset lands two cells early.
+local bar = vim.wo[V.win].winbar
+local at = assert(bar:find(PATH, 1, true), "the winbar does not name " .. PATH .. ": " .. bar)
+local offset = vim.fn.strdisplaywidth(bar:sub(1, at - 1))
+
+-- A window's own position is its winbar's row, its text beginning one row below.
+local top, left = unpack(vim.api.nvim_win_get_position(V.win))
+
+vim.cmd("redraw!")
+local cell = vim.api.nvim__inspect_cell(1, top, left + offset)
+local attrs = cell[2] or {}
+
+-- `nvim -l` sends print to stderr, not stdout, so split_spec reads both.
+print(
+  ("cell %s fg=%s bg=%s"):format(
+    cell[1],
+    attrs.foreground and ("%06x"):format(attrs.foreground) or "none",
+    attrs.background and ("%06x"):format(attrs.background) or "none"
+  )
+)
+vim.cmd("qa!")


### PR DESCRIPTION
Closes #104. Rebased onto `876cbb9` (#107, muted windows); `make all` passes — 1,180 cases,
0 failures, 0 errors.

Each pane's winbar names the file the cursor is in — the **sticky header** — so that reading
past a file's own header row no longer costs a reviewer the file.

```
 ○ ▾ src/routes.lua  +12 -3  [2 notes]        branch vs master · 2/7 reviewed · +40 -9
```

It carries what the in-buffer file header carries (icon, chevron, path, `+N -M`, note count)
with today's review summary right-aligned beside it. The before pane keeps naming the base
revision and gains the pre-image path, so a rename reads correctly on the side holding the
old name. The rename rule is the in-buffer header's, unchanged: `old → new` in the unified
layout, each pane naming its own side in the split one.

## How it hangs together

- It hangs off the file-crossing latch #103 moved onto the view, so it changes on a crossing
  and does nothing in between — and works with the tree dismissed, which is the case it
  exists for. Nothing here reaches into the tree's module, and neither fact is copied.
- `render.file_label` is new and is where a file's name now comes from — the in-buffer
  header asks it too. Which icon, whether a file counts as expanded when nothing has said,
  how a rename is spelled per layout, and which files have a pre-image side are rules rather
  than formats; a second copy on the winbar would drift.
- The winbar is padded by hand in display columns rather than with `%=`: every `%` on the
  bar is escaped, and that escaping applies to the reviewer's own paths, not just to the
  format string.

## Truncation

The summary never loses a segment from the format. On a pane too narrow for both halves it
gives up what the file beside it now says twice — the plugin's own name, the review's line
totals, the queue's note count — before anything only it can say, and the path is then cut
from its head, keeping its tail. Measured on the fixture, after pane, `src/oldname.lua →
src/newname.lua` under the cursor:

| pane | winbar |
| --- | --- |
| 100 | `○ ▾ src/oldname.lua → src/newname.lua  +1 -1` … `branch vs master · 0/8 reviewed · +8 -4` |
| 80 | `○ ▾ src/oldname.lua → src/newname.lua  +1 -1` … `branch vs master · 0/8 reviewed` |
| 60 | `○ ▾ …c/newname.lua  +1 -1  branch vs master · 0/8 reviewed` |
| 45 | `○ ▾ …→ src/newname.lua  +1 -1  0/8 reviewed` |
| 25 | `○ ▾ …newname.lua  +1 -1` |
| 18 | `○ ▾ ….lua  +1 -1` |

A review with no files shows the summary alone, with no empty file segment.

## Highlight groups, and the intersection with #107

**This adds no highlight group**, and cannot: every `%` on the bar is escaped, so `%#Group#`
markup is unreachable and the bar is plain text. It draws in Neovim's own `WinBar` and
`WinBarNC`, both of which #107's muted set already covers — so the file segment recedes with
its pane for free.

That was true by construction and unasserted by either side, so it is now pinned at the
painted cell (`winbar_child.lua`, spawned three times by `split_spec`, under `muted_child`'s
three measured constraints — one `nvim__inspect_cell` per process, an 80x24 grid, even
colour channels). One cell inside the path the bar names, on the *after* pane:

| reading | cell |
| --- | --- |
| pane has focus | `fg=eeee00 bg=006600` — `WinBar`, full brightness |
| pane muted | `fg=770000 bg=002200` — `WinBarNC` blended halfway to `Normal`'s background |
| pane muted, `muted.enabled = false` | `fg=ee0000 bg=004400` — `WinBarNC`'s own colour |

The third reading is what gives the second its teeth. A non-current window draws its winbar
in `WinBarNC` whether or not anything is muted, so "the unfocused pane's bar is not
`WinBar`" would hold with the namespace never reaching the winbar at all.

**Measured gap this closes:** taking `WinBar`/`WinBarNC` out of `hl.lua`'s `EDITOR_GROUPS`
reds exactly one case in the suite — this one — and leaves `muted_spec` **entirely green**
(38/38).

## Verification

The six pre-existing winbar assertions pass unchanged — the first cut of the truncation
broke two of them, which is what led to the shed order above.

Red-first evidence. Every cut applied **separately** on the rebased tree, each run alone:

| Cut | Cases red | What it looked like |
| --- | --- | --- |
| `follow_file` returns early with no tree (the pre-#103 shape) | 5 | *the sticky header with the tree dismissed…* freezes on `○ ▾ src/nonl.md  +1 -1` — the file being read when the tree went away — and never follows the cursor into `src/main.lua`. The other 4 are #103's own, in `panel_spec` and `queue_jump_panel_spec` |
| `lay_out` pads by `#` instead of display columns | 1 | *fills the pane exactly…* — 92 columns of bar in a 100-column pane |
| both `shed(…)` calls removed | 7 | the summary sits there whole while the path is squeezed to `…onl.md`; 5 in `render_spec`, 2 in `split_spec` |
| `render.keep_tail` → `render.truncate` | 1 | *keeps the path's tail…* — the bar reads `src/oldname.lua →…`, having dropped the only part that says which file it is |
| `WinBar`/`WinBarNC` out of the muted set | 1 | the muted pane's bar returns `fg=ee0000 bg=004400`, identical to the muting-off control |

Before this change the bar had no file segment at all, so every assertion above had nothing
to find.