### PR TITLE
refactor(hl): name the muted colours so the namespace can link them

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,14 @@ without the plugin fighting back. The two exceptions are `CodeReviewAddSpan` and
 `CodeReviewDelSpan`, which take `DiffText`'s background and set no foreground — still
 `default = true`, so overriding them works the same way.
 
+A **muted** window draws through a computed twin of each group, named `CodeReviewMuted.`
+plus the group it blends — `CodeReviewMuted.CodeReviewAdd`, `CodeReviewMuted.@keyword`.
+Each holds that group's own colours pulled `muted.strength` of the way toward the
+background, and each is written again on every colorscheme change, so setting one yourself
+is overwritten. Set `muted.strength`, or the group the twin is named for. A group your
+theme gives no colour of its own gets no twin, and a muted window draws it at full
+brightness.
+
 ## Adapters
 
 The plugin has no opinion about where a review goes, about which pickers you use, or about

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -882,6 +882,16 @@ languages you have installed. A background alone composes with the replay, and
 that is what keeps code readable inside an emphasised span. Both are still
 `default = true`, so overriding either works the same way as the rest.
 
+One more family is computed, and it is not yours to set. A **muted** window
+(|codereview-muted|) draws every group through a twin named `CodeReviewMuted.`
+plus the group it blends -- `CodeReviewMuted.CodeReviewAdd`,
+`CodeReviewMuted.@keyword`, and so on. Each holds the group's own colours
+pulled `muted.strength` of the way toward the background, and each is written
+again on every colorscheme change, so a definition of your own is overwritten.
+Set `muted.strength`, or the group the twin is named for, instead. A group the
+active theme gives no colour of its own gets no twin, and a muted window draws
+it at full brightness.
+
 ==============================================================================
 11. PERSISTENCE                                     *codereview-persistence*
 

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -403,6 +403,24 @@ bright rather than going wrong. `NormalNC` is adequate only on the file tree, wh
 almost no highlights of its own, and one mechanism for the three windows is worth more than
 that.
 
+**That namespace holds links, and the link is what makes the blend reachable.** Each entry
+names the group that holds the blended colour — `CodeReviewMuted.` plus the group it blends,
+so `@keyword` becomes `CodeReviewMuted.@keyword`. A group name with `@` and dots in it is
+legal, and only a name that *starts* with `@` gets the treesitter fallback chain. Three
+facts here were measured, not assumed:
+
+- A link inside a namespace resolves through to an extmark highlight and to a line
+  background, exactly as a definition in the namespace does.
+- `:colorscheme` clears every global group, the blended ones with the rest, but it leaves
+  the namespace's links alone. So a theme change is the groups' problem and the namespace
+  needs no part of it. What the window rule does on `ColorScheme` is one more pass, for a
+  group the new theme gives a colour to at last.
+- **A link that reaches no definition draws nothing at all.** It does not fall back to the
+  global group, which is what a namespace with no entry does. So a group with no blend must
+  have *no* entry in the namespace, and a blend the new theme cannot compute keeps its
+  group as a link back to the group it blends. Either way that group draws bright. An entry
+  that points at a group the theme wiped draws a hole.
+
 **Which review window is bright is the review's last-focused one, not the current one.** The
 composer, the queue float and the archive float all take focus out of every review window, so
 a rule written against the current window mutes the whole review the moment a reviewer starts

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -22,7 +22,7 @@ change there is felt through.
 | `diff.lua` | Unified-diff parsing, and the intra-line spans within a paired line | pure |
 | `drafts.lua` | Note text abandoned in a composer, keyed by absolute path, in a store of its own | stateful (disk) |
 | `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes | stateful (git) |
-| `hl.lua` | The highlight groups, all `default = true` links into whatever colorscheme is active | stateful (editor) |
+| `hl.lua` | The highlight groups: `default = true` links into whatever colorscheme is active, and the blended twin of each group a **muted** window draws | stateful (editor) |
 | `init.lua` | The public surface a host reaches: `setup`, the user commands, `annotate(type)` | stateful (setup) |
 | `keymaps.lua` | Every key the review view binds — the diff's and the tree's — onto a buffer handed in, driving actions handed in | stateful (editor) |
 | `panel.lua` | The file tree: build, chain compaction, folding, per-directory tallies | pure |

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -13,6 +13,11 @@
 ---without a second list learning about it. There is deliberately no register to remember to
 ---update, because the one thing that would go wrong is invisible until someone looks at an
 ---unfocused pane.
+---
+---**The muted colours are groups of this module, not colours in a window.** A group that a
+---**muted** window draws gets a twin here, named for the group it blends. The window that
+---mutes links to that twin instead of holding a colour of its own, so the same colour is
+---reachable from outside that window. See `M.muted_group` below.
 local M = {}
 
 local LINKS = {
@@ -130,6 +135,118 @@ function M.groups()
   return out
 end
 
+--- The muted colours ------------------------------------------------------------
+
+---What the name of a blended group starts with.
+---
+---A blended group is named for the group it blends, so its name is derivable from that
+---group alone and no table maps one to the other. The dot keeps the two parts apart: a
+---treesitter capture group carries `@` and dots of its own, and `CodeReviewMuted.@keyword`
+---can only be the twin of `@keyword`. No group this plugin defines starts with
+---`CodeReviewMuted.`, so a twin shadows none of them.
+local MUTED_PREFIX = "CodeReviewMuted."
+
+---The twin of every group that has one, keyed by the group it blends.
+---@type table<string, string>
+local twins = {}
+
+---`Normal`'s background, memoised until the colorscheme changes.
+---@type integer|nil
+local toward = nil
+
+---What a muted colour is pulled toward.
+---
+---A theme that gives `Normal` no background at all has the terminal's behind it. The only
+---knowable fact about that background is which way the theme leans.
+---@return integer
+local function backdrop()
+  if not toward then
+    local normal = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
+    toward = normal.bg or (vim.o.background == "light" and 0xffffff or 0x000000)
+  end
+  return toward
+end
+
+---Pull one colour toward another, channel by channel.
+---@param colour integer 0xRRGGBB
+---@param target integer 0xRRGGBB
+---@param strength number 0 keeps the colour. 1 replaces it with `target`.
+---@return integer
+local function blend(colour, target, strength)
+  local out = 0
+  for _, place in ipairs({ 65536, 256, 1 }) do
+    local from = math.floor(colour / place) % 256
+    local to = math.floor(target / place) % 256
+    out = out + math.floor(from + (to - from) * strength + 0.5) * place
+  end
+  return out
+end
+
+---Write the twin of `group`, or report that `group` has no colour to blend.
+---
+---Only the true-colour attributes are blended. `ctermfg` and `ctermbg` are indices into a
+---palette with no channels to pull, so they are copied without a change.
+---@param group string
+---@return boolean written True if the twin now holds a blend of `group`.
+local function write_twin(group)
+  local ok, def = pcall(vim.api.nvim_get_hl, 0, { name = group, link = false })
+  if not ok or type(def) ~= "table" or (def.fg == nil and def.bg == nil) then
+    return false
+  end
+  local strength = require("codereview.config").get().muted.strength
+  local muted = vim.tbl_extend("force", {}, def)
+  muted.fg = def.fg and blend(def.fg, backdrop(), strength) or nil
+  muted.bg = def.bg and blend(def.bg, backdrop(), strength) or nil
+  return (pcall(vim.api.nvim_set_hl, 0, MUTED_PREFIX .. group, muted))
+end
+
+---The group that holds `group` blended toward the background, computed once.
+---
+---**A group with no colour of its own gets no twin, and that is the feature.** A caller
+---that finds nothing here must draw `group` as it is. That keeps a colorscheme this plugin
+---has never seen merely less muted instead of wrongly coloured. Nothing here reaches for a
+---palette when a lookup is empty, and nothing must.
+---
+---An empty lookup is not remembered as done. A pass that somehow runs before the theme's
+---own groups are linked again costs one more pass, not a review that stays bright until
+---the next colorscheme change.
+---@param group string
+---@return string|nil name The twin's name, or nil if `group` has nothing to blend.
+function M.muted_group(group)
+  if twins[group] then
+    return twins[group]
+  end
+  if not write_twin(group) then
+    return nil
+  end
+  twins[group] = MUTED_PREFIX .. group
+  return twins[group]
+end
+
+---Write every twin again, against the colorscheme that is active now.
+---
+---A twin holds colours the theme decides, and `:colorscheme` clears it with every other
+---global group. So `apply` writes the twins again wherever it writes the links again. A
+---caller that links to a twin needs no part of this: a link holds a name and not a colour,
+---and a link inside a highlight namespace survives `:colorscheme`.
+---
+---Every twin is written again rather than dropped. The diff on screen still carries
+---extmarks that name the capture groups the old theme resolved, and those colours must be
+---right before anything parses again.
+---
+---A group that loses its colour to the new theme keeps its twin, as a link back to itself.
+---The window then draws that group at full brightness, which is what a group with no twin
+---gets. A link that reaches no definition draws nothing at all, so every twin a caller
+---already links to must stay a definition.
+local function recolour_muted()
+  toward = nil
+  for group, twin in pairs(twins) do
+    if not write_twin(group) then
+      pcall(vim.api.nvim_set_hl, 0, twin, { link = group })
+    end
+  end
+end
+
 function M.apply()
   for group, target in pairs(LINKS) do
     vim.api.nvim_set_hl(0, group, { link = target, default = true })
@@ -147,10 +264,13 @@ function M.apply()
   if package.loaded["codereview.syntax"] then
     require("codereview.syntax").clear_hl_cache()
   end
+  -- Last, because a twin blends what the links above resolve to. With no review open there
+  -- are no twins and this costs one empty loop.
+  recolour_muted()
 end
 
 ---Re-link after a colorscheme change, since `nvim_set_hl` definitions are cleared by
----`:colorscheme`.
+---`:colorscheme`. That clears the muted twins too, so `apply` writes them again as well.
 function M.setup()
   M.apply()
   vim.api.nvim_create_autocmd("ColorScheme", {

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1472,11 +1472,12 @@ function M.open(spec)
   })
 
   -- A **muted** window's colours are blends of the theme's, so they cannot outlive it.
-  -- Declared after `hl.setup()`, which is the first thing this function does and which
-  -- re-links the plugin's own groups from its own `ColorScheme` autocommand: the two fire in
-  -- the order they were declared, so the groups this reads have been re-linked by the time
-  -- it reads them. Watched from here rather than from `hl.lua`, which would have to reach
-  -- back up into the module that owns the windows to say it.
+  -- `hl.lua` writes those blends again from its own `ColorScheme` autocommand; what this
+  -- adds is the pass that links a group the new theme gives a colour to at last. Declared
+  -- after `hl.setup()`, which is the first thing this function does: the two fire in the
+  -- order they were declared, so every blend this links to exists by the time it links.
+  -- Watched from here rather than from `hl.lua`, which would have to reach back up into the
+  -- module that owns the windows to say it.
   vim.api.nvim_create_autocmd("ColorScheme", {
     group = V.augroup,
     callback = function()

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -280,86 +280,48 @@ end
 
 --- Muting ---------------------------------------------------------------------
 
----The namespace holding a muted variant of every group a review window draws in.
+---The namespace that points every group a review window draws in at its muted twin.
 ---
 ---One namespace shared by every muted window rather than one each: what is in it is a
 ---function of the colorscheme and the configured strength, not of which window is being
 ---muted. Attaching it is what mutes a window; handing the window the global namespace back
 ---is what brightens it.
+---
+---**The namespace holds links, and no colour of its own.** `hl.lua` owns the blended
+---groups, so the colours a muted window draws are reachable from outside this namespace --
+---which is what keeps one set of them behind every rule that wants them. A link also
+---survives a colorscheme change, because it holds a name and not a colour.
 local NS_MUTED = vim.api.nvim_create_namespace("codereview_muted")
 
----Which groups the namespace already holds a variant for.
+---Which groups the namespace already links to a twin.
 ---@type table<string, boolean>
-local variants = {}
+local linked = {}
 
----`Normal`'s background, memoised until the colorscheme changes.
----@type integer|nil
-local toward = nil
-
----What the muted colours are pulled toward.
+---Link `group` to its muted twin, once.
 ---
----A theme that gives `Normal` no background at all has the terminal's behind it, and the
----only thing knowable about that is which way the theme says it leans.
----@return integer
-local function backdrop()
-  if not toward then
-    local normal = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
-    toward = normal.bg or (vim.o.background == "light" and 0xffffff or 0x000000)
-  end
-  return toward
-end
-
----Pull one colour toward another, channel by channel.
----@param colour integer 0xRRGGBB
----@param target integer 0xRRGGBB
----@param strength number 0 leaves the colour alone, 1 replaces it with `target`
----@return integer
-local function blend(colour, target, strength)
-  local out = 0
-  for _, place in ipairs({ 65536, 256, 1 }) do
-    local from = math.floor(colour / place) % 256
-    local to = math.floor(target / place) % 256
-    out = out + math.floor(from + (to - from) * strength + 0.5) * place
-  end
-  return out
-end
-
----Give `group` a muted variant in the namespace, once.
----
----**A group left without one stays bright, and that is the feature.** A group the namespace
----does not define falls back to its global definition -- measured, not assumed -- so a
----colorscheme this plugin has never heard of, or one whose group carries no colour of its
----own to blend, comes out merely less muted instead of wrongly coloured. Nothing here
----reaches for a palette when a lookup comes back empty, and nothing should.
----
----Only the true-colour attributes are blended. `ctermfg`/`ctermbg` are indices into a
----palette with no channels to pull, so they are carried across untouched.
----
----A lookup that came back with nothing is not remembered as done, so a rebuild that somehow
----ran before the theme's own groups were re-linked costs one pass of muting rather than a
----review that stays bright until the next colorscheme change.
+---**A group left without a link stays bright, and that is the feature.** A group the
+---namespace does not name falls back to its global definition -- measured, not assumed --
+---so a colorscheme this plugin has never heard of, or one whose group carries no colour of
+---its own to blend, comes out merely less muted instead of wrongly coloured. `hl.lua`
+---decides which groups have a twin, and it hands back nothing for the rest.
 ---@param group string
----@param strength number
-local function ensure_variant(group, strength)
-  if variants[group] then
+local function ensure_link(group)
+  if linked[group] then
     return
   end
-  local ok, def = pcall(vim.api.nvim_get_hl, 0, { name = group, link = false })
-  if not ok or type(def) ~= "table" or (def.fg == nil and def.bg == nil) then
+  local twin = hl.muted_group(group)
+  if not twin then
     return
   end
-  variants[group] = true
-  local muted = vim.tbl_extend("force", {}, def)
-  muted.fg = def.fg and blend(def.fg, backdrop(), strength) or nil
-  muted.bg = def.bg and blend(def.bg, backdrop(), strength) or nil
-  pcall(vim.api.nvim_set_hl, NS_MUTED, group, muted)
+  linked[group] = true
+  pcall(vim.api.nvim_set_hl, NS_MUTED, group, { link = twin })
 end
 
 ---How many capture resolutions the namespace was last extended against.
 ---@type integer
 local extended_at = -1
 
----Extend the namespace with every group now in play that it does not hold yet.
+---Extend the namespace with every group now in play that it does not link yet.
 ---
 ---Extended rather than built once, because the set grows while a review is open: a file is
 ---parsed only as its rows come near the window, so which capture groups the replay has
@@ -378,32 +340,27 @@ function M.mute_extend()
   end
   extended_at = syntax.resolutions()
   for _, group in ipairs(hl.groups()) do
-    ensure_variant(group, cfg.strength)
+    ensure_link(group)
   end
   for _, group in pairs(syntax.resolved_groups()) do
-    ensure_variant(group, cfg.strength)
+    ensure_link(group)
   end
 end
 
----Recompute every variant against the colorscheme that is active now.
+---Point every muted window at the colours the theme that is active now decides.
 ---
----A variant is a blend of colours the theme decides, so it means nothing once the theme has
----changed. Driven by the view's `ColorScheme` autocommand, which is declared after the one
----`hl.lua` re-links its own groups from -- so what this reads has already been re-linked.
+---Little is left to do here, and that is the point of the links. `hl.lua` writes every twin
+---again from its own `ColorScheme` autocommand, and a link inside the namespace survives
+---`:colorscheme` and reaches the new colour by name -- measured, not assumed. So no colour
+---is touched from here.
 ---
----Every group the namespace already holds is recomputed rather than dropped: the diff on
----screen still carries extmarks naming the capture groups the old theme resolved, and those
----have to be right before anything reparses.
+---What is left is one more pass over the groups in play. A group the old theme gave no
+---colour to, and the new theme does, gets its link at last.
+---
+---Driven by the view's `ColorScheme` autocommand, which is declared after the one `hl.lua`
+---writes its twins from. The two fire in that order, so every twin this links to exists.
 function M.recolour()
-  local known = variants
-  toward, variants, extended_at = nil, {}, -1
-  local cfg = config.get().muted
-  if not cfg.enabled then
-    return
-  end
-  for group in pairs(known) do
-    ensure_variant(group, cfg.strength)
-  end
+  extended_at = -1
   M.mute_extend()
 end
 

--- a/tests/codereview/muted_spec.lua
+++ b/tests/codereview/muted_spec.lua
@@ -8,7 +8,9 @@
 --
 -- One level lower, and only where there is no higher way to say it, the namespace's own
 -- contents are read: that a variant is derived from the theme that is active now, and that a
--- group this plugin cannot know about has none.
+-- group this plugin cannot know about has none. The namespace holds a link to the group that
+-- holds the colour, so `muted_hl` below reads the colour through it. Read the namespace alone
+-- and you stop at a name, which says nothing about what a cell will show.
 --
 -- Lower still, the cells the reviewer's screen really holds. Those are in `muted_child.lua`,
 -- one process per reading, because `nvim__inspect_cell` tells the truth only on the first
@@ -69,6 +71,20 @@ local function cursorlines()
     end
   end
   return out
+end
+
+---What a muted window really draws `group` in.
+---
+---One hop, because the namespace names a group and that group holds the colour. Reading the
+---namespace alone stops at the name, which says nothing about what a cell will show.
+---@param group string
+---@return table
+local function muted_hl(group)
+  local entry = vim.api.nvim_get_hl(MUTED, { name = group })
+  if not entry.link then
+    return entry
+  end
+  return vim.api.nvim_get_hl(0, { name = entry.link, link = false })
 end
 
 ---@param rgb integer
@@ -353,20 +369,20 @@ describe("a group the plugin cannot know about", function()
   -- with no variant falling back to its global definition is what keeps an unrecognised
   -- theme merely less muted instead of wrongly coloured. `muted_child.lua` reads the cell.
   it("keeps a group the plugin does know about muted beside it", function()
-    local add = vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" })
+    local add = muted_hl("CodeReviewAdd")
     assert.is_truthy(add.bg, "CodeReviewAdd has no muted variant")
   end)
 end)
 
 describe("changing colorscheme", function()
-  local before = vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" }).bg
+  local before = muted_hl("CodeReviewAdd").bg
   local was = vim.api.nvim_get_hl(0, { name = "CodeReviewAdd", link = false }).bg
 
   vim.cmd("colorscheme blue")
 
   local now = vim.api.nvim_get_hl(0, { name = "CodeReviewAdd", link = false }).bg
   local backdrop = vim.api.nvim_get_hl(0, { name = "Normal", link = false }).bg or 0x000000
-  local after = vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" }).bg
+  local after = muted_hl("CodeReviewAdd").bg
 
   -- Without this the case below passes on a theme that happens to paint a changed line the
   -- same colour the last one did, which would prove nothing about recomputing anything.


### PR DESCRIPTION
Prefactor. Nothing changes on screen.

#102 blends every highlight group a review window draws in, and it holds those
blends inside a window highlight namespace. Nothing outside that namespace can
read them. The file fade (#111) needs the same colours, and it needs them as
marks.

So each blend is now a highlight group of its own. `hl.lua` writes it, and the
window namespace links to it instead of holding a copy. One set of blended
colours now sits behind the window rule, and the rule that fades a file will
read that same set.

## The naming rule

A blended group is named `CodeReviewMuted.` plus the group it blends, verbatim:

    CodeReviewAdd            ->  CodeReviewMuted.CodeReviewAdd
    @keyword.function.lua    ->  CodeReviewMuted.@keyword.function.lua

The name is derivable from the group alone, so no table maps one to the other.
`@` and dots are legal in a group name, and only a name that *starts* with `@`
gets the treesitter fallback chain — so a capture group needs no escaping. No
group this plugin defines starts with `CodeReviewMuted.`, so a twin shadows
none of them.

## What the links buy

A link holds a name and not a colour, so it survives `:colorscheme`. The theme
change is the groups' problem alone: `hl.apply` writes every twin again on the
same event that clears them, and the namespace needs no part of it. What the
window rule still does on `ColorScheme` is one more pass, for a group the new
theme gives a colour to at last.

One measured fact shapes the rest. **A link that reaches no definition draws
nothing at all** — it does not fall back to the global group, which is what a
namespace with no entry does. So a group with no blend keeps no entry in the
namespace, and a blend a new theme cannot compute keeps its group as a link
back to the group it blends. Either way that group draws bright, which is the
graceful failure the muting has always had. `docs/design-notes.md` records it.

## What proves the colours did not shift

`muted_spec` passes with no assertion edited, 38 cases. The four painted-cell
readings in `muted_child.lua` are untouched and still report the same six-digit
colours, and so does the muted winbar cell in `split_spec`.

Three reads of the namespace inside `muted_spec` now follow the link it holds,
through a `muted_hl` helper. They are reads and not assertions: the namespace
names a group, and reading it alone stops at the name.

Breaking the one line that links the namespace to the twins reds 6 cases —
5 in `muted_spec`, 1 in `split_spec`:

- a file whose syntax is parsed only after its pane lost focus mutes every one of them
- a group the plugin cannot know about keeps a group the plugin does know about muted beside it
- changing colorscheme recomputes the muted colour against the theme that is active now
- the cell under a reviewer's eye mutes both of them once its pane loses focus
- the cell under a reviewer's eye leaves a group with no variant at its global brightness on a muted background
- the sticky header on a muted pane mutes the file segment with the pane it names the file for

Closes #110