### PR TITLE
feat(view): fade every file except the one under the cursor

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,12 +32,26 @@ _Avoid_: side, column, window
 Said of a review window that does not have focus: its colours pulled toward the background
 through a highlight namespace of its own, so the focused window is the bright one and a
 reviewer never has to press a key to find out where they are. Said of a **pane** or of the
-file tree — never of anything drawn *on* the diff. Not _dimmed_: an archived **entry** is
-already drawn dimmed on the diff, and one word must not do two jobs — the same collision
-that kept _side_ reserved for a diff line's add/del/ctx when the split layout needed a word
-for its windows. The two are also different mechanisms: dimming is a highlight group the
-render chooses per entry, muting is every group at once in one window.
+file tree — never of a file, and never of anything drawn *on* the diff. Not _dimmed_: an
+archived **entry** is already drawn dimmed on the diff, and one word must not do two jobs —
+the same collision that kept _side_ reserved for a diff line's add/del/ctx when the split
+layout needed a word for its windows. Not _faded_ either: that is the file the cursor is not
+in. The three are different mechanisms as well as different statements: dimming is a
+highlight group the render chooses per entry, fading is the group a mark carries, muting is
+every group at once in one window.
 _Avoid_: dimmed, greyed, faded, inactive
+
+**Faded**:
+Said of a file the cursor is not in: the colours of its rows pulled toward the background, so
+the file being read has a visible boundary and the file just left stops competing with it.
+Said of a *file* and never of a window or of an **entry**, and the unit is the file and never
+the **hunk** — a cursor crossing from one hunk to the next inside one file changes nothing on
+screen. A faded file keeps its header row bright and its hunk headers fade with its body.
+Drawn by changing which group a mark carries, never by a foreground laid over the file: a
+foreground above the syntax replay would win where a parser painted and lose where none did.
+Not _muted_, which is a **pane** without focus, and not _dimmed_, which is an archived entry.
+The blend is the muting's, at a strength of its own.
+_Avoid_: muted, dimmed, greyed, inactive, unfocused
 
 **Filler**:
 A blank row emitted in one pane where the other has no counterpart — a pure addition, a

--- a/README.md
+++ b/README.md
@@ -230,6 +230,25 @@ you were last in, not the window with the cursor in it.
 `muted = { enabled = false }` turns it off whole; `strength` is one number from 0 to 1
 saying how far toward the background a colour goes.
 
+### The file you are in is the only one at full strength
+
+Every other file in the review is **faded**: the colours of its rows pulled toward the
+background, so the file you are reading has a boundary and the file you just left stops
+competing with it. Cross into another file and the fade follows the cursor. Move from one
+hunk to the next inside one file and nothing changes at all — the unit is the file.
+
+A faded file keeps its header row bright, with its path, its `+N -M` and its note count, so
+the review reads as bright headers over quiet bodies with one file at full strength. Its
+hunk headers fade with its body.
+
+The colours are the muting's, blended from your own colorscheme at a strength of its own,
+and a faded file keeps its syntax structure rather than flattening to one tone: what changes
+is which group each mark carries, never the order they are drawn in. A group your theme
+gives no colour of its own is left bright, exactly as it is in a muted window.
+
+`faded = { enabled = false }` turns it off whole; `strength` is its own number, and it is
+gentler than the muting's by default because this covers every file but one.
+
 ### The file you are in, on the winbar
 
 A file's header row scrolls off the top as soon as you read past the first screenful of it.
@@ -617,6 +636,8 @@ opts = {
                                    -- and tally the untouched ones on the winbar
   muted = { enabled = true,        -- mute every review window that does not have focus
             strength = 0.5 },      -- how far its colours are pulled toward the background
+  faded = { enabled = true,        -- fade every file except the one the cursor is in
+            strength = 0.35 },     -- its own number: this covers every file but one
   panel = { enabled = true, width = 34, position = "left" },
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
             collapsed = "▸", expanded = "▾", change_bar = "▌" },
@@ -630,13 +651,15 @@ without the plugin fighting back. The two exceptions are `CodeReviewAddSpan` and
 `CodeReviewDelSpan`, which take `DiffText`'s background and set no foreground — still
 `default = true`, so overriding them works the same way.
 
-A **muted** window draws through a computed twin of each group, named `CodeReviewMuted.`
-plus the group it blends — `CodeReviewMuted.CodeReviewAdd`, `CodeReviewMuted.@keyword`.
-Each holds that group's own colours pulled `muted.strength` of the way toward the
-background, and each is written again on every colorscheme change, so setting one yourself
-is overwritten. Set `muted.strength`, or the group the twin is named for. A group your
-theme gives no colour of its own gets no twin, and a muted window draws it at full
-brightness.
+Two families of groups are computed rather than linked, and they are not yours to set. A
+**muted** window draws through a twin of each group named `CodeReviewMuted.` plus the group
+it blends — `CodeReviewMuted.CodeReviewAdd`, `CodeReviewMuted.@keyword`. A **faded** file's
+rows are drawn in a twin named `CodeReviewFaded.` plus the same, at `faded.strength` instead
+of `muted.strength`. Each holds that group's own colours pulled that far toward the
+background, and each is written again on every colorscheme change, so setting one yourself is
+overwritten. Set the strength, or the group the twin is named for. A group your theme gives
+no colour of its own gets no twin in either family, and is drawn at full brightness — muted
+or faded, that is the same rule.
 
 ## Adapters
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -393,6 +393,30 @@ review behind them looks exactly as you left it.
     muted = { strength = 0.25 }      -- subtler; 1 is all the way to the
                                      -- background, 0 is not at all
 
+The file you are not in                                  *codereview-faded*
+
+Every file in the review except the one the cursor is in is *faded*: the
+colours of its rows pulled toward the background, so the file you are reading
+has a boundary and the file you just left stops competing with it. Crossing
+into another file moves the fade with the cursor. The unit is the file and
+never the hunk, so moving from one hunk to the next inside one file changes
+nothing on screen.
+
+A faded file keeps its header row bright -- the path, the `+N -M` and the note
+count stay readable, because the fade exists to help you find a place rather
+than to hide the map. Its hunk headers fade with its body.
+
+The fade changes which highlight group each mark carries and nothing else, so
+faded code keeps its syntax structure instead of flattening to one tone, and
+the order things are drawn in is exactly what it was. The colours are the
+muting's arithmetic on your own colorscheme, at a strength of its own, and a
+group the plugin cannot know about is left bright -- the same rule as above.
+A cursor in no file fades nothing.
+
+    faded = { enabled = false }      -- every file at full strength
+    faded = { strength = 0.5 }       -- stronger; its own number, and gentler
+                                     -- than `muted.strength` by default
+
 ==============================================================================
 6. ANNOTATIONS                                      *codereview-annotations*
 
@@ -807,6 +831,7 @@ Defaults: >
       spans = true,
       archived = true,
       muted = { enabled = true, strength = 0.5 },
+      faded = { enabled = true, strength = 0.35 },
       panel = { enabled = true, width = 34, position = "left" },
       icons = {
         reviewed = "✓", annotated = "●", unreviewed = "○",
@@ -835,6 +860,12 @@ nothing drawn, nothing tallied and no `git` spent judging.
 (|codereview-muted|). `strength` is how far a colour is pulled toward the
 background, from 0 to 1. Coarse the same way: off is nothing muted, nothing
 computed and no highlight namespace attached to any window.
+
+`faded` fades every file except the one the cursor is in (|codereview-faded|).
+`strength` is the same number for a different rule, and gentler by default
+because the fade covers every file but one where the muting covers a window.
+Coarse the same way: off is nothing emitted, no colour computed, and the diff
+drawn exactly as it was before this existed.
 
 ==============================================================================
 10. HIGHLIGHTS                                        *codereview-highlights*
@@ -882,15 +913,17 @@ languages you have installed. A background alone composes with the replay, and
 that is what keeps code readable inside an emphasised span. Both are still
 `default = true`, so overriding either works the same way as the rest.
 
-One more family is computed, and it is not yours to set. A **muted** window
-(|codereview-muted|) draws every group through a twin named `CodeReviewMuted.`
-plus the group it blends -- `CodeReviewMuted.CodeReviewAdd`,
-`CodeReviewMuted.@keyword`, and so on. Each holds the group's own colours
-pulled `muted.strength` of the way toward the background, and each is written
-again on every colorscheme change, so a definition of your own is overwritten.
-Set `muted.strength`, or the group the twin is named for, instead. A group the
-active theme gives no colour of its own gets no twin, and a muted window draws
-it at full brightness.
+Two more families are computed, and neither is yours to set. A **muted**
+window (|codereview-muted|) draws every group through a twin named
+`CodeReviewMuted.` plus the group it blends -- `CodeReviewMuted.CodeReviewAdd`,
+`CodeReviewMuted.@keyword`, and so on. A **faded** file (|codereview-faded|)
+carries a twin named `CodeReviewFaded.` plus the same, blended at
+`faded.strength` rather than at `muted.strength`. Each holds the group's own
+colours pulled that far toward the background, and each is written again on
+every colorscheme change, so a definition of your own is overwritten. Set the
+strength, or the group the twin is named for, instead. A group the active
+theme gives no colour of its own gets no twin in either family, and is drawn
+at full brightness.
 
 ==============================================================================
 11. PERSISTENCE                                     *codereview-persistence*

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -148,6 +148,18 @@ It is also why `syntax_spec` asserts the map against the render on screen, and a
 the marks still cover their own tokens after a repaint that moved rows, rather than merely
 asserting that a map exists.
 
+**That map exists only when highlighting is on, so nothing outside `syntax.lua` may depend
+on it.** It holds a span per file — `first` and `last` — which is exactly what anything
+wanting to know where a file is drawn reaches for first, and it is the wrong answer twice
+over. It is nil for a reviewer with `syntax = false`, so a rule built on it silently does
+nothing for them while every case that runs with highlighting on still passes. And its span
+covers a file's *line* rows only: the header row above them and the hunk header before the
+first of them are outside it. What records where a file is drawn is the render —
+`file_rows`, the header row of every file, so a file runs from its own header to the row
+before the next one. The **faded** file rule takes its spans from there, and
+`faded_spec` runs one case with `syntax = false` for this reason alone: gate the fade on
+`syntax_rows` and that case is the only one in the suite that goes red.
+
 **Extmark emission is bounded by the viewport, and the render is not.** A 300-file review
 produces 271,000 marks, and writing all of them into a buffer is 141 ms of a 384 ms
 repaint — paid on every resize, expansion, reviewed toggle, scope change and queued
@@ -420,6 +432,33 @@ facts here were measured, not assumed:
   have *no* entry in the namespace, and a blend the new theme cannot compute keeps its
   group as a link back to the group it blends. Either way that group draws bright. An entry
   that points at a group the theme wiped draws a hole.
+
+**A highlight namespace colours a whole window, so it cannot colour one part of one.** That
+is the whole reason the two quiet states are two mechanisms rather than one. A **muted**
+window's unit *is* the window, so it is a namespace: attach it and every group the window
+draws is answered at once, including the groups the plugin cannot enumerate. A **faded**
+file's unit is a file inside a pane, which no namespace can express, so the fade changes
+which group each *mark* carries — the blended twin of the group the row would have carried
+anyway, emitted in its place.
+
+**The fade renames a mark. It does not add one, and it does not change the priority order.**
+One grey foreground laid over a faded file at a priority above the syntax replay is the
+obvious shape and the wrong one: it wins where a parser painted and loses where none did, so
+the result changes with the parsers a reader happens to have installed. This project already
+refused that shape once, for the intra-line **span** emphasis, which is why those groups set
+a background and no foreground. Renaming leaves every composition rule above this one true.
+
+**What a crossing re-emits is keyed to the file the emission drew, not to the crossing
+latch.** They are the same answer almost always, and the exceptions are what a fade built on
+the latch fails on. The latch (`V.current_file`) starts nil and moves only on a crossing; a
+*paint* asks the live question and can park the cursor in a third file without the latch
+hearing anything — a layout toggle whose anchor round trip lands elsewhere does exactly
+that. So the rows on screen can already be drawn bright for a file the latch has never
+named, and re-emitting "the file left" against the latch leaves that file bright for good.
+The view therefore records which file the painted bands were emitted bright, beside the
+bands themselves and dropped with them, for the same reason: what a mark means is decided by
+the emission it came from. Both traps in `faded_spec` caught this, and neither was written
+for it.
 
 **Which review window is bright is the review's last-focused one, not the current one.** The
 composer, the queue float and the archive float all take focus out of every review window, so

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -21,6 +21,7 @@ change there is felt through.
 | `delivery.lua` | Where a batch is going, how that is chosen, and the submit that empties the queue only on dispatch | stateful (target, queue) |
 | `diff.lua` | Unified-diff parsing, and the intra-line spans within a paired line | pure |
 | `drafts.lua` | Note text abandoned in a composer, keyed by absolute path, in a store of its own | stateful (disk) |
+| `fade.lua` | The **faded** file rule: which rows one file's fade covers, and which group a faded row carries in place of its own | stateful (editor) |
 | `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes | stateful (git) |
 | `hl.lua` | The highlight groups: `default = true` links into whatever colorscheme is active, and the blended twin of each group a **muted** window draws | stateful (editor) |
 | `init.lua` | The public surface a host reaches: `setup`, the user commands, `annotate(type)` | stateful (setup) |
@@ -41,7 +42,7 @@ change there is felt through.
 
 - **Require nothing**: `diff`, `drafts`, `panel`, `queue`, `types`.
 - **Above them**, in that order: `git`, `payload`, `render`; then `state`, `config`; then
-  `archive`, `delivery`, `keymaps`, `syntax`; then `composer`, `hl`, `queue_float`,
+  `archive`, `delivery`, `keymaps`, `syntax`; then `composer`, `hl`, `fade`, `queue_float`,
   `view_layout`; then `view_panel`.
 - **The hubs**: `view` requires thirteen of the modules above, `annotate` nine. A change that
   is not local to a leaf almost certainly reaches one of them.

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -58,6 +58,25 @@ M.defaults = {
   ---the active colorscheme's -- an unrecognised theme is muted in its own colours or, for a
   ---group the plugin cannot know about, left bright rather than replaced.
   muted = { enabled = true, strength = 0.5 }, ---@type { enabled: boolean, strength: number }
+  ---Draw every file except the one the cursor is in **faded**: the colours of its rows
+  ---pulled toward the background, so the file being read has a visible boundary and the
+  ---file just left stops competing with it. The unit is the file and never the hunk, so a
+  ---cursor moving from one hunk to the next inside one file changes nothing on screen.
+  ---
+  ---A faded file keeps its header row bright, and its hunk headers fade with its body: the
+  ---header is the one row that names the file, and this exists to help a reviewer find a
+  ---place rather than to hide the map.
+  ---
+  ---On by default, and coarse the way `muted` is: off is nothing emitted, no colour
+  ---computed, and the diff drawn exactly as it was before this existed. There is no keymap
+  ---beside it.
+  ---
+  ---`strength` is its own, and deliberately gentler than `muted.strength`: the fade covers
+  ---every file but one, where the window rule covers the panes a reviewer is not in, and a
+  ---blend that reads as quiet over a pane reads as washed out over a whole review. Both
+  ---numbers pull the active colorscheme's own colours, so an unrecognised theme fades in
+  ---its own colours or, for a group the plugin cannot know about, stays bright.
+  faded = { enabled = true, strength = 0.35 }, ---@type { enabled: boolean, strength: number }
   panel = {
     enabled = true,
     width = 34,
@@ -182,18 +201,22 @@ local function validate_boolean(name, value)
   end
 end
 
----Reject the switch beside this one written as a bare boolean.
+---Reject a switch with a strength beside it written as a bare boolean.
 ---
----`spans` and `archived` are bare booleans and `muted` is a table, so `muted = false` is the
----natural mistake to make. Without this it is an index error raised from inside a window
----helper the next time a review opens, rather than a sentence at `setup()` naming the line
----to change.
+---`spans` and `archived` are bare booleans and `muted` and `faded` are tables, so
+---`muted = false` is the natural mistake to make. Without this it is an index error raised
+---from inside a window helper the next time a review opens, rather than a sentence at
+---`setup()` naming the line to change. Named for the switch it is checking, because two
+---copies of this sentence would be two chances to word it differently.
+---@param name string
 ---@param value any
-local function validate_muted(value)
+local function validate_blend(name, value)
   if type(value) ~= "table" then
     error(
-      ("codereview.setup: `muted` must be a table — got %s; write `muted = { enabled = false }`"):format(
-        vim.inspect(value)
+      ("codereview.setup: `%s` must be a table — got %s; write `%s = { enabled = false }`"):format(
+        name,
+        vim.inspect(value),
+        name
       ),
       0
     )
@@ -205,13 +228,11 @@ end
 ---In the same voice as the switches above. A number outside 0..1 is not a stronger effect
 ---but an arithmetic accident: past 1 the blend overshoots the background and comes back out
 ---the other side, which is a colour nobody asked for rather than a louder version of one.
+---@param name string
 ---@param value any
-local function validate_strength(value)
+local function validate_strength(name, value)
   if type(value) ~= "number" or value < 0 or value > 1 then
-    error(
-      ("codereview.setup: `muted.strength` must be a number between 0 and 1 — got %s"):format(vim.inspect(value)),
-      0
-    )
+    error(("codereview.setup: `%s` must be a number between 0 and 1 — got %s"):format(name, vim.inspect(value)), 0)
   end
 end
 
@@ -221,9 +242,12 @@ function M.setup(opts)
   validate_layout(M.options.layout)
   validate_boolean("spans", M.options.spans)
   validate_boolean("archived", M.options.archived)
-  validate_muted(M.options.muted)
+  validate_blend("muted", M.options.muted)
   validate_boolean("muted.enabled", M.options.muted.enabled)
-  validate_strength(M.options.muted.strength)
+  validate_strength("muted.strength", M.options.muted.strength)
+  validate_blend("faded", M.options.faded)
+  validate_boolean("faded.enabled", M.options.faded.enabled)
+  validate_strength("faded.strength", M.options.faded.strength)
   M.options.types = resolve_types(M.options)
   return M.options
 end

--- a/lua/codereview/fade.lua
+++ b/lua/codereview/fade.lua
@@ -1,0 +1,125 @@
+---Every file except the one the cursor is in is **faded**.
+---
+---What lives here is the rule: which rows one file's fade covers, and which group a row of a
+---faded file carries in place of the one it would carry anyway. The marks themselves are
+---emitted by `view.lua`, which owns them, and which file the cursor is in is asked there too
+----- that is a fact about the diff and its anchor map, and this module is one caller of it.
+---
+---**The fade changes which group a mark carries. It does not change the priority order.** A
+---faded file's rows are emitted in the blended variants of the groups they would carry
+---anyway. The alternative is one grey foreground laid over the file above the syntax replay,
+---and this project already refused that shape for the intra-line **span** emphasis: a
+---foreground above the replay wins where a parser painted and loses where none did, so the
+---result changes with the parsers a reader has installed. Leaving the bands alone is also
+---what keeps the composition rules in the design notes true.
+---
+---**It is marks, and not a highlight namespace.** A namespace colours a whole window, so it
+---cannot fade one file inside a **pane**. The **muted** window rule is a namespace because
+---its unit *is* the window. The two mechanisms answer two different questions, and they
+---share nothing but the blends in `hl.lua` -- which is what stops them drifting apart in
+---colour while each keeps a strength of its own.
+local config = require("codereview.config")
+local hl = require("codereview.hl")
+
+local M = {}
+
+---Whether anything fades at all.
+---
+---Off means no mark is renamed and no colour is computed, so the diff is drawn exactly as it
+---was before this existed.
+---@return boolean
+function M.enabled()
+  return config.get().faded.enabled
+end
+
+---The group a faded row carries in place of `group`.
+---
+---**A group the active theme gives no colour of its own is emitted as itself.** `hl.lua`
+---hands back nothing for it, and the row is then drawn in the group it would have carried
+---anyway -- a file merely not faded rather than one drawn in a colour nobody chose.
+---@param group string
+---@return string
+function M.group(group)
+  return hl.blended("faded", group) or group
+end
+
+---One mark's options, with the groups that colour its own row faded.
+---
+---`hl_group` and `line_hl_group` are what a mark puts on the row it sits on, and they are
+---what the fade renames. The virtual lines hanging under a row are left as they are: they
+---are the **queue**'s entries and the **archive**'s, drawn beneath the code rather than on
+---it, and what a faded file does to those is #112's question.
+---
+---A copy, never the render's own table: the same mark is emitted again whenever the fade
+---moves, and it has to start from the group it was built with.
+---@param opts table
+---@return table
+function M.opts(opts)
+  if not (opts.hl_group or opts.line_hl_group) then
+    return opts
+  end
+  local out = vim.tbl_extend("force", {}, opts)
+  out.hl_group = opts.hl_group and M.group(opts.hl_group) or nil
+  out.line_hl_group = opts.line_hl_group and M.group(opts.line_hl_group) or nil
+  return out
+end
+
+---The rows one file's fade covers: its body, and never its header row.
+---
+---**Taken from the render, which records the header row of every file.** A file runs from
+---its own header to the row before the next file's, and its fade starts one row after that
+---header. Its hunk headers are inside the body and fade with it.
+---
+---What keeps a header row bright is `M.rows` below, which exempts every one of them. Leaving
+---the header out here is the economy beside that rule rather than the rule: a crossing
+---re-emits the two bodies whose fade changed, and a header carries the same group either
+---way, so there is nothing there to write again. Deleting the `+ 1` reds no case.
+---
+---The row map the syntax replay builds holds a span per file as well, and it must not be
+---used here. That map is built only when highlighting is on, so a fade reading it would do
+---nothing at all for a reviewer with `syntax = false`.
+---@param rendered CRRender
+---@param fi integer
+---@return integer first, integer last 1-indexed and inclusive; `first > last` when there is no body
+function M.body(rendered, fi)
+  local header = rendered.file_rows[fi]
+  if not header then
+    return 1, 0
+  end
+  local next_header = rendered.file_rows[fi + 1]
+  return header + 1, (next_header and next_header - 1) or #rendered.lines
+end
+
+---Which rows of a render are faded, as one question a caller asks per row.
+---
+---Built once per emission and asked per mark, so the rule is decided against the file the
+---cursor is in *now* rather than against whatever it was when a band was last painted. That
+---is what makes rows scrolled into after a crossing arrive faded.
+---
+---Nothing is faded when the switch is off, and nothing is faded when the cursor is in no
+---file: an empty review shows every file at full strength rather than every file faded.
+---
+---Both **panes** are answered by one of these. They hold the same rows and the same header
+---rows, so the two images stay comparable row for row.
+---
+---**Every file's header row is exempt, not only the current file's.** The header is the one
+---row that names the file, and the fade exists to help a reviewer find a place rather than to
+---hide the map. This is the line that says so.
+---@param rendered CRRender
+---@param current integer|nil File index the cursor is in
+---@return (fun(row: integer): boolean)|nil faded nil when nothing fades
+function M.rows(rendered, current)
+  if not M.enabled() or not current then
+    return nil
+  end
+  local first, last = M.body(rendered, current)
+  local headers = {}
+  for _, row in pairs(rendered.file_rows) do
+    headers[row] = true
+  end
+  return function(row)
+    return not headers[row] and (row < first or row > last)
+  end
+end
+
+return M

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -14,10 +14,11 @@
 ---update, because the one thing that would go wrong is invisible until someone looks at an
 ---unfocused pane.
 ---
----**The muted colours are groups of this module, not colours in a window.** A group that a
----**muted** window draws gets a twin here, named for the group it blends. The window that
----mutes links to that twin instead of holding a colour of its own, so the same colour is
----reachable from outside that window. See `M.muted_group` below.
+---**The blended colours are groups of this module, not colours in a window.** A group that
+---a **muted** window draws, or that a **faded** file's row carries, gets a twin here, named
+---for the group it blends. The window that mutes links to that twin instead of holding a
+---colour of its own, and the fade emits it in place of the group the row would carry, so the
+---same arithmetic answers both. See `M.blended` below.
 local M = {}
 
 local LINKS = {
@@ -135,26 +136,44 @@ function M.groups()
   return out
 end
 
---- The muted colours ------------------------------------------------------------
+--- The blended colours ----------------------------------------------------------
 
----What the name of a blended group starts with.
+---@alias CRBlendFamily "muted"|"faded"
+
+---The families of blended groups: what each one's members are named, and how far each pulls.
 ---
----A blended group is named for the group it blends, so its name is derivable from that
----group alone and no table maps one to the other. The dot keeps the two parts apart: a
----treesitter capture group carries `@` and dots of its own, and `CodeReviewMuted.@keyword`
----can only be the twin of `@keyword`. No group this plugin defines starts with
----`CodeReviewMuted.`, so a twin shadows none of them.
-local MUTED_PREFIX = "CodeReviewMuted."
+---A blended group is named for the group it blends, so its name is derivable from that group
+---and its family alone, and no table maps one to the other. The dot keeps the two parts
+---apart: a treesitter capture group carries `@` and dots of its own, and
+---`CodeReviewMuted.@keyword` can only be the twin of `@keyword`. No group this plugin
+---defines starts with either prefix, so a twin shadows none of them.
+---
+---**Two families, one blend.** A **muted** window and a **faded** file pull the same colours
+---toward the same background, and each has its own strength because the two cover very
+---different amounts of the screen: the window rule answers for the panes a reviewer is not
+---in, the fade for every file but one. A second copy of the arithmetic is how the two would
+---drift apart in colour, which is what one family with a strength of its own avoids.
+---
+---`option` names the table in the configuration each family takes its strength from, so a
+---family knows where its number comes from and nothing else has to.
+---@type table<CRBlendFamily, { prefix: string, option: string }>
+local FAMILIES = {
+  muted = { prefix = "CodeReviewMuted.", option = "muted" },
+  faded = { prefix = "CodeReviewFaded.", option = "faded" },
+}
 
----The twin of every group that has one, keyed by the group it blends.
----@type table<string, string>
+---The twin of every group that has one, per family, keyed by the group it blends.
+---@type table<CRBlendFamily, table<string, string>>
 local twins = {}
+for family in pairs(FAMILIES) do
+  twins[family] = {}
+end
 
 ---`Normal`'s background, memoised until the colorscheme changes.
 ---@type integer|nil
 local toward = nil
 
----What a muted colour is pulled toward.
+---What a blended colour is pulled toward, whichever family asks.
 ---
 ---A theme that gives `Normal` no background at all has the terminal's behind it. The only
 ---knowable fact about that background is which way the theme leans.
@@ -182,45 +201,48 @@ local function blend(colour, target, strength)
   return out
 end
 
----Write the twin of `group`, or report that `group` has no colour to blend.
+---Write `family`'s twin of `group`, or report that `group` has no colour to blend.
 ---
 ---Only the true-colour attributes are blended. `ctermfg` and `ctermbg` are indices into a
 ---palette with no channels to pull, so they are copied without a change.
+---@param family CRBlendFamily
 ---@param group string
 ---@return boolean written True if the twin now holds a blend of `group`.
-local function write_twin(group)
+local function write_twin(family, group)
   local ok, def = pcall(vim.api.nvim_get_hl, 0, { name = group, link = false })
   if not ok or type(def) ~= "table" or (def.fg == nil and def.bg == nil) then
     return false
   end
-  local strength = require("codereview.config").get().muted.strength
-  local muted = vim.tbl_extend("force", {}, def)
-  muted.fg = def.fg and blend(def.fg, backdrop(), strength) or nil
-  muted.bg = def.bg and blend(def.bg, backdrop(), strength) or nil
-  return (pcall(vim.api.nvim_set_hl, 0, MUTED_PREFIX .. group, muted))
+  local strength = require("codereview.config").get()[FAMILIES[family].option].strength
+  local twin = vim.tbl_extend("force", {}, def)
+  twin.fg = def.fg and blend(def.fg, backdrop(), strength) or nil
+  twin.bg = def.bg and blend(def.bg, backdrop(), strength) or nil
+  return (pcall(vim.api.nvim_set_hl, 0, FAMILIES[family].prefix .. group, twin))
 end
 
----The group that holds `group` blended toward the background, computed once.
+---The group that holds `group` blended at `family`'s strength, computed once.
 ---
 ---**A group with no colour of its own gets no twin, and that is the feature.** A caller
 ---that finds nothing here must draw `group` as it is. That keeps a colorscheme this plugin
----has never seen merely less muted instead of wrongly coloured. Nothing here reaches for a
----palette when a lookup is empty, and nothing must.
+---has never seen merely less muted, or merely less faded, instead of wrongly coloured.
+---Nothing here reaches for a palette when a lookup is empty, and nothing must.
 ---
 ---An empty lookup is not remembered as done. A pass that somehow runs before the theme's
 ---own groups are linked again costs one more pass, not a review that stays bright until
 ---the next colorscheme change.
+---@param family CRBlendFamily
 ---@param group string
 ---@return string|nil name The twin's name, or nil if `group` has nothing to blend.
-function M.muted_group(group)
-  if twins[group] then
-    return twins[group]
+function M.blended(family, group)
+  local known = twins[family]
+  if known[group] then
+    return known[group]
   end
-  if not write_twin(group) then
+  if not write_twin(family, group) then
     return nil
   end
-  twins[group] = MUTED_PREFIX .. group
-  return twins[group]
+  known[group] = FAMILIES[family].prefix .. group
+  return known[group]
 end
 
 ---Write every twin again, against the colorscheme that is active now.
@@ -237,12 +259,15 @@ end
 ---A group that loses its colour to the new theme keeps its twin, as a link back to itself.
 ---The window then draws that group at full brightness, which is what a group with no twin
 ---gets. A link that reaches no definition draws nothing at all, so every twin a caller
----already links to must stay a definition.
-local function recolour_muted()
+---already links to must stay a definition -- and a mark already emitted in a twin's name is
+---the same case as a namespace linking to one.
+local function recolour_twins()
   toward = nil
-  for group, twin in pairs(twins) do
-    if not write_twin(group) then
-      pcall(vim.api.nvim_set_hl, 0, twin, { link = group })
+  for family, known in pairs(twins) do
+    for group, twin in pairs(known) do
+      if not write_twin(family, group) then
+        pcall(vim.api.nvim_set_hl, 0, twin, { link = group })
+      end
     end
   end
 end
@@ -265,12 +290,13 @@ function M.apply()
     require("codereview.syntax").clear_hl_cache()
   end
   -- Last, because a twin blends what the links above resolve to. With no review open there
-  -- are no twins and this costs one empty loop.
-  recolour_muted()
+  -- are no twins and this costs one empty loop per family.
+  recolour_twins()
 end
 
 ---Re-link after a colorscheme change, since `nvim_set_hl` definitions are cleared by
----`:colorscheme`. That clears the muted twins too, so `apply` writes them again as well.
+---`:colorscheme`. That clears the blended twins too, of both families, so `apply` writes
+---them again as well.
 function M.setup()
   M.apply()
   vim.api.nvim_create_autocmd("ColorScheme", {

--- a/lua/codereview/syntax.lua
+++ b/lua/codereview/syntax.lua
@@ -147,7 +147,8 @@ end
 ---@param map table<integer, { row: integer, col: integer }>
 ---@param ref string|nil
 ---@param lang string
-local function apply_side(view, ns, buf, file, side, map, ref, lang)
+---@param group_of (fun(group: string): string)|nil What the caller wants a token drawn in
+local function apply_side(view, ns, buf, file, side, map, ref, lang, group_of)
   if vim.tbl_isempty(map) then
     return
   end
@@ -181,7 +182,7 @@ local function apply_side(view, ns, buf, file, side, map, ref, lang)
     if slot then
       pcall(vim.api.nvim_buf_set_extmark, buf, ns, slot.row - 1, slot.col + c.cs, {
         end_col = slot.col + c.ce,
-        hl_group = c.hl,
+        hl_group = group_of and group_of(c.hl) or c.hl,
         priority = render.PRIORITY.syntax,
       })
     end
@@ -282,9 +283,15 @@ end
 ---Safe to call repeatedly. The row map is inverted once per paint, each file's captures are
 ---memoised, and `syntax_painted` stops already-painted files from having their extmarks
 ---emitted twice per render -- so a call with nothing new near the window is a lookup.
+---
+---`group_for` is asked, per file, what that file's tokens should be drawn in. It is how a
+---**faded** file's code keeps its syntax structure while receding with the rest of the file,
+---and the rule behind it lives with the caller: this module knows which file it is painting
+---and nothing about where the cursor is.
 ---@param view CRView
 ---@param ns integer
-function M.apply(view, ns)
+---@param group_for (fun(fi: integer): (fun(group: string): string)|nil)|nil
+function M.apply(view, ns, group_for)
   if not config.get().syntax or not view.render then
     return
   end
@@ -306,13 +313,14 @@ function M.apply(view, ns)
     if near and not file.binary and not view.syntax_painted[file.path] then
       local lang = M.lang_for(file.path)
       if lang then
+        local group_of = group_for and group_for(fi) or nil
         -- An untracked file has no committed pre-image; its "after" is the working tree.
         local after_ref = file.status == "U" and nil or view.scope.after
-        apply_side(view, ns, view.buf, file, "after", maps.after, after_ref, lang)
+        apply_side(view, ns, view.buf, file, "after", maps.after, after_ref, lang, group_of)
         -- Each image paints onto the pane that shows it. With one pane, that is the same
         -- buffer twice, which is what the unified layout has always done.
         local before_buf = split and view.before_buf or view.buf
-        apply_side(view, ns, before_buf, file, "before", maps.before, view.scope.before, lang)
+        apply_side(view, ns, before_buf, file, "before", maps.before, view.scope.before, lang, group_of)
       end
       view.syntax_painted[file.path] = true
     end

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -22,6 +22,7 @@ local config = require("codereview.config")
 local git = require("codereview.git")
 local render = require("codereview.render")
 local hl = require("codereview.hl")
+local fade = require("codereview.fade")
 local delivery = require("codereview.delivery")
 local queue_float = require("codereview.queue_float")
 local view_layout = require("codereview.view_layout")
@@ -60,6 +61,7 @@ local NS = vim.api.nvim_create_namespace("codereview")
 ---@field current_file integer|nil        File index the diff cursor is in; the crossing latch
 ---@field panel_render CRPanelRender|nil
 ---@field painted_bands table<integer, boolean>|nil  Row bands whose marks have been emitted
+---@field painted_file integer|nil        File index those bands were emitted bright; the fade's latch
 ---@field syntax_cache table<string, CRCapture[]|false>  `path|side` -> captures; false to skip it
 ---@field syntax_painted table<string, boolean>|nil      Path -> already replayed onto this render
 ---@field syntax_rows table<integer, CRFileRows>|nil     File index -> where its lines are drawn
@@ -394,21 +396,47 @@ local function lower_bound(marks, row)
 end
 
 ---Emit every mark one pane's render put on rows `first`..`last`, 1-indexed and inclusive.
+---
+---`faded` decides which of those rows are drawn in the blended groups rather than in the
+---ones the render gave them. Asked per mark and never remembered, so a row emitted long
+---after a crossing carries what the fade says now.
 ---@param buf integer
 ---@param rendered CRRender
 ---@param first integer
 ---@param last integer
-local function emit_rows(buf, rendered, first, last)
+---@param faded (fun(row: integer): boolean)|nil
+local function emit_rows(buf, rendered, first, last, faded)
   local marks = rendered.marks
   for i = lower_bound(marks, first - 1), #marks do
     local m = marks[i]
     if m.row > last - 1 then
       return
     end
+    local opts = m.opts
+    if faded and faded(m.row + 1) then
+      opts = fade.opts(opts)
+    end
     -- An end_col past the end of a line is a hard error; a mis-measured header should
     -- lose its colour, not abort the whole repaint.
-    pcall(vim.api.nvim_buf_set_extmark, buf, NS, m.row, m.col, m.opts)
+    pcall(vim.api.nvim_buf_set_extmark, buf, NS, m.row, m.col, opts)
   end
+end
+
+---How the replay's groups are renamed on one file's rows, or nil when that file is bright.
+---
+---Handed to `syntax.apply` rather than asked for from inside it: the replay knows which file
+---it is painting, and the rule for which file is faded lives out here with the cursor.
+---@param fi integer
+---@return (fun(group: string): string)|nil
+local function faded_replay(fi)
+  if not fade.enabled() then
+    return nil
+  end
+  local current = M.current_file()
+  if not current or fi == current then
+    return nil
+  end
+  return fade.group
 end
 
 ---Emit the marks for the rows near the window, in every pane there is.
@@ -430,6 +458,20 @@ local function paint_bands()
   local syntax = require("codereview.syntax")
   local band = syntax.VIEWPORT_MARGIN
   local lo, hi = syntax.viewport(V)
+  -- Once for the whole pass, and for both panes: they hold the same rows and the same header
+  -- rows, so one answer keeps the two images comparable row for row. Asked live rather than
+  -- read off `V.current_file`, for the reason the winbar asks live: a paint can run between
+  -- two crossings -- a resize, a fold, a layout toggle -- and park the cursor in a third file
+  -- without the latch hearing a thing.
+  local current = M.current_file()
+  local faded = fade.rows(V.render, current)
+  -- Which file the rows on screen were emitted bright, kept beside the bands that hold them
+  -- and for the same reason: what a mark means is decided by the emission it came from, and a
+  -- crossing has to know what the rows already painted were painted for. Taken here only when
+  -- a paint has just dropped it -- a band emitted while a crossing is pending is put right by
+  -- the `refade` a tick later, and moving this would tell that `refade` there was nothing to
+  -- do.
+  V.painted_file = V.painted_file or current
   V.painted_bands = V.painted_bands or {}
   for b = math.floor((lo - 1) / band), math.floor((hi - 1) / band) do
     if not V.painted_bands[b] then
@@ -437,11 +479,72 @@ local function paint_bands()
       -- Both panes draw the same rows, so one set of bands answers for both: a band is
       -- emitted into both or into neither, which is what keeps the two images comparable
       -- row for row wherever a reviewer has scrolled.
-      emit_rows(V.buf, V.render, b * band + 1, (b + 1) * band)
+      emit_rows(V.buf, V.render, b * band + 1, (b + 1) * band, faded)
       if V.before_render then
-        emit_rows(V.before_buf, V.before_render, b * band + 1, (b + 1) * band)
+        emit_rows(V.before_buf, V.before_render, b * band + 1, (b + 1) * band, faded)
       end
     end
+  end
+end
+
+---Emit the rows of the files whose fade has just changed, and no others.
+---
+---Only two files change on a crossing: the one the rows on screen were emitted for, and the
+---one the cursor is in now. Their bodies are dropped and written again in the groups the fade
+---decides now -- the header rows are not touched at all, because a header carries the same
+---group faded or bright.
+---
+---**The file left is the one the emission drew bright, not the one the crossing latch names.**
+---The two differ wherever a paint has parked the cursor without a crossing: the latch is
+---still on the file being read before it, and the rows on screen are already drawn for the
+---file it landed in. Re-emitting against the latch would leave that third file bright.
+---
+---Bounded by the bands a paint has reached, as every emission here is: a row the reviewer
+---has never been near holds nothing to replace, and it arrives faded when it is painted.
+---The replay is dropped for those files and run again for the same reason -- its marks were
+---cleared with the rest, and a file too far from the window to be repainted is one whose
+---flag is left down for the next scroll.
+---@param entered integer|nil The file the cursor is in now
+local function refade(entered)
+  local left = V.painted_file
+  V.painted_file = entered
+  if not (V.render and V.painted_bands and fade.enabled()) then
+    return
+  end
+  local syntax = require("codereview.syntax")
+  local band = syntax.VIEWPORT_MARGIN
+  local faded = fade.rows(V.render, entered)
+  local changed = {}
+  if left then
+    changed[#changed + 1] = left
+  end
+  if entered and entered ~= left then
+    changed[#changed + 1] = entered
+  end
+  for _, fi in ipairs(changed) do
+    local first, last = fade.body(V.render, fi)
+    if first <= last then
+      vim.api.nvim_buf_clear_namespace(V.buf, NS, first - 1, last)
+      if V.before_render then
+        vim.api.nvim_buf_clear_namespace(V.before_buf, NS, first - 1, last)
+      end
+      for b = math.floor((first - 1) / band), math.floor((last - 1) / band) do
+        if V.painted_bands[b] then
+          local from, to = math.max(first, b * band + 1), math.min(last, (b + 1) * band)
+          emit_rows(V.buf, V.render, from, to, faded)
+          if V.before_render then
+            emit_rows(V.before_buf, V.before_render, from, to, faded)
+          end
+        end
+      end
+      local file = V.files[fi]
+      if file and V.syntax_painted then
+        V.syntax_painted[file.path] = nil
+      end
+    end
+  end
+  if config.get().syntax then
+    syntax.apply(V, NS, faded_replay)
   end
 end
 
@@ -491,8 +594,9 @@ function M.paint(keep_file)
   end
   -- The namespaces above were just cleared, so nothing this records still exists. Dropped
   -- here rather than in `paint_bands` for the reason `syntax_painted` is dropped by the
-  -- paint: what a band means is decided by the render it was emitted from.
-  V.painted_bands = {}
+  -- paint: what a band means is decided by the render it was emitted from. The file those
+  -- bands were emitted bright goes with them, and `paint_bands` takes it again below.
+  V.painted_bands, V.painted_file = {}, nil
 
   view_panel.paint_panel(V, M)
 
@@ -520,7 +624,7 @@ function M.paint(keep_file)
   local syntax = require("codereview.syntax")
   syntax.repainted(V)
   if config.get().syntax then
-    syntax.apply(V, NS)
+    syntax.apply(V, NS, faded_replay)
   end
   -- A pass that parsed a file resolved capture groups nothing knew about before it, and a
   -- **muted** window needs a variant of each or the tokens it just gained come out bright.
@@ -635,6 +739,10 @@ local function follow_file()
   update_winbar()
   update_before_winbar()
   view_panel.sync_panel(V, M)
+  -- The third thing hanging off the crossing, and the only one that writes to the diff: the
+  -- file the rows on screen were drawn bright is faded, and the file entered is brightened.
+  -- Nothing else on screen moves, so nothing else is emitted again.
+  refade(index)
 end
 
 ---Everything a moved cursor comes due for, in the order it comes due.
@@ -655,7 +763,7 @@ function M.cursor_moved()
   end
   paint_bands()
   if config.get().syntax then
-    require("codereview.syntax").apply(V, NS)
+    require("codereview.syntax").apply(V, NS, faded_replay)
   end
   -- Whatever that pass resolved, muted in the pane that does not have focus -- which is
   -- usually not the pane the scroll happened in. Cheap when it resolved nothing new: one

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -309,7 +309,7 @@ local function ensure_link(group)
   if linked[group] then
     return
   end
-  local twin = hl.muted_group(group)
+  local twin = hl.blended("muted", group)
   if not twin then
     return
   end

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/archive_child.lua` | Spawned by `archive_spec` to dispatch a batch and exit — deliberately not a spec. |
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
 | `codereview/muted_child.lua` | Spawned four times by `muted_spec`, one painted cell each — deliberately not a spec. |
+| `codereview/faded_child.lua` | Spawned three times by `faded_spec`, one painted cell each — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `codereview/winbar_child.lua` | Spawned three times by `split_spec` to read one cell of a pane's winbar — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
@@ -58,6 +59,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
+| `faded_spec` | Every file but the one the cursor is in: what a review draws when it opens, the crossing, the hunk that changes nothing, the header left bright, both panes, a repaint that moves the rows, an empty review, the two families of blended groups, the switch — the two traps, `syntax = false` and a scroll past the last paint — and the cells three child processes read |
 | `muted_spec` | The review window without focus: which window is bright, the namespace and the `cursorline` that follow focus, a float changing nothing, a rebuilt pane and a re-summoned tree, the group left bright on purpose, the colorscheme change, the switch — and the cells four child processes read |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
@@ -77,8 +79,8 @@ interchangeable, and the assertions know which one they are looking at.
   binary, gitignored, and a file with no trailing newline on either side. Used by
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
   `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `queue_float_spec`,
-  `split_spec`, `layout_spec`, `open_diff_spec`, `archive_spec`, `touched_spec` and
-  `interactive_spec`. Its
+  `split_spec`, `layout_spec`, `open_diff_spec`, `archive_spec`, `touched_spec`,
+  `faded_spec` and `interactive_spec`. Its
   dirty working tree is what makes a snapshot worth minting, so `archive_spec` builds a
   second copy and resets it to get a clean one. It already covers everything the split layout has
   to render, including the files that exist on only one side and the additions between
@@ -93,9 +95,9 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mkbig.sh`** — files of a given size, half of every file rewritten. It takes counts as
   well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and 200), so a caller
   asks for the height it needs rather than for a second script. `perf.lua` builds a 60-file,
-  12k-line repository and a 300-file, 60k-line one per run; `bounded_spec` builds a 6-file
-  one, about 1,800 rendered rows, which is the only fixture in the suite taller than a
-  window and the margin around it. Nothing built from it is committed. It costs about a
+  12k-line repository and a 300-file, 60k-line one per run; `bounded_spec` and `faded_spec`
+  each build a 6-file one, about 1,800 rendered rows, which is the only fixture in the suite
+  taller than a window and the margin around it. Nothing built from it is committed. It costs about a
   third of a second, which is why it is no longer kept out of `make test` — what is slow is
   opening a review on it at the sizes the report uses, not building it.
 
@@ -313,12 +315,35 @@ so the out-of-core language path is still checked locally without ever failing C
   window are written into a pane's buffer, so every extmark assertion elsewhere in the suite
   runs on a fixture small enough to sit inside that band and passes whether or not anything
   is bounded — the same trap as "centring is unobservable in a window taller than its
-  buffer". `bounded_spec` is the one spec that builds `mkbig`, and its first case guards
-  that the render really is taller than one paint can reach. Two of its cases judge against
+  buffer". `bounded_spec` builds `mkbig` for it, and its first case guards that the render
+  really is taller than one paint can reach — as does the last block of `faded_spec`, which
+  needs the same height for the same reason. Two of its cases judge against
   figures the implementation cannot move — how many of the render's marks reached the buffer
   at all, and whether the last file's marks did — because the rest derive their expectations
   from `syntax.viewport`, and a case that asks the bound where the bound is goes quiet when
   the bound goes away.
+- **A fade built on the replay's row map passes every case that runs with highlighting on.**
+  That map holds a span per file, which is what anything asking "where is this file drawn"
+  reaches for first — and it is built only when `syntax` is on, so a rule reading it does
+  nothing at all for a reviewer who turned highlighting off. A file's rows come from the
+  render's `file_rows` instead. `faded_spec` opens one review with `syntax = false` for this
+  reason alone: gating the fade on `V.syntax_rows` reds those two cases and nothing else in
+  the suite.
+- **A fade that renames rows once passes everything except a scroll.** Emission is bounded by
+  the viewport, so the rows on screen at the moment of a crossing are not the rows a reviewer
+  will be looking at a second later. Renaming what can be seen when a paint or a crossing runs
+  satisfies every case made against a fixture that fits on screen; the rows scrolled into
+  afterwards then arrive as the render drew them. `faded_spec`'s last block builds `mkbig`,
+  crosses into the second file, and scrolls to the end of that same file so the margin below
+  the window reaches into the third without the cursor ever leaving the second — the one case
+  that reds when the fade is decided per paint rather than per mark.
+- **A fade keyed to the crossing latch leaves a third file bright.** `V.current_file` starts
+  nil and moves only on a crossing, while a *paint* asks the live question and can park the
+  cursor somewhere the latch never hears about — a layout toggle does it. So "the file left"
+  taken from the latch names a file that was already faded, and the file the rows on screen
+  were really drawn for stays bright. The view records what the emission drew, beside the
+  bands. Both traps above caught this while it was being written, and neither was written
+  for it.
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.

--- a/tests/codereview/faded_child.lua
+++ b/tests/codereview/faded_child.lua
@@ -1,0 +1,94 @@
+-- One painted cell of a review, read in a process of its own.
+--
+-- Deliberately a separate process, and deliberately one cell. `nvim__inspect_cell` reports
+-- a cell's real foreground and background only on the **first** call a process makes; every
+-- call after it returns attributes belonging to something else entirely -- measured rather
+-- than assumed, and recorded in `muted_child.lua` beside it. So the whole point of this file
+-- is to make exactly one such call, in one arrangement, and print what it saw.
+--
+-- A group name cannot tell a faded row from a bright one, which is why this exists at all:
+-- the cell is the only reading that says the colour really moved.
+--
+-- The screen is 80x24 because that is the grid a headless Neovim keeps whatever `columns`
+-- and `lines` are set to: a window drawn past column 80 is drawn into cells no assertion can
+-- read.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- faded_spec with FIXTURE, CURSOR and FADED in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.termguicolors = true
+vim.o.columns = 80
+vim.o.lines = 24
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+-- Colours the arithmetic is exact on: every channel is even, so a blend halfway to a black
+-- background is a colour with no rounding in it.
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
+vim.api.nvim_set_hl(0, "@keyword", { fg = 0xee0000 })
+
+require("codereview").setup({
+  layout = "unified",
+  syntax = true,
+  -- The window rule is off, so nothing but the fade can pull a colour toward the background
+  -- here. Its strength is deliberately not the fade's either: a fade that read the number
+  -- beside it would print a colour this cell can tell apart.
+  muted = { enabled = false, strength = 0.25 },
+  faded = { enabled = vim.env.FADED ~= "0", strength = 0.5 },
+})
+
+local view = require("codereview.view")
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+
+-- The first token the replay painted on an *added* line of a file the cursor is **not** in,
+-- so one cell carries both halves of the question: the line's own background under a
+-- foreground from a higher priority band, on a row the fade covers.
+local current = assert(view.current_file(), "the cursor is in no file")
+local row, col, target
+local painted = vim.api.nvim_buf_get_extmarks(V.buf, vim.api.nvim_create_namespace("codereview"), 0, -1, {
+  details = true,
+})
+for _, m in ipairs(painted) do
+  local group = m[4].hl_group
+  local anchor = V.render.anchors[m[2] + 1]
+  if (group == "@keyword" or group == "CodeReviewFaded.@keyword") and anchor and anchor.kind == "line" then
+    local ln = V.files[anchor.file].hunks[anchor.hunk].lines[anchor.line]
+    if ln.side == "add" and anchor.file ~= current then
+      row, col, target = m[2] + 1, m[3], anchor.file
+      break
+    end
+  end
+end
+assert(row, "no keyword was painted on an added line of another file -- did the replay run?")
+
+if vim.env.CURSOR == "in" then
+  -- Onto that file's *header* row, not onto the token's own: the focused window draws a
+  -- `cursorline`, and a reading taken on the lit row would be a reading of that instead.
+  -- Driven through the event a reviewer's keystroke raises, because neither
+  -- `nvim_win_set_cursor` nor a `normal!` motion raises `CursorMoved` under `nvim -l`.
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[target], 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+  assert(view.current_file() == target, "the cursor never reached the file under test")
+end
+
+vim.cmd("redraw!")
+local pos = vim.fn.screenpos(V.win, row, col + 1)
+assert(pos.row > 0 and pos.col > 0, "the row under test is off screen")
+local cell = vim.api.nvim__inspect_cell(1, pos.row - 1, pos.col - 1)
+local attrs = cell[2] or {}
+
+-- `nvim -l` sends print to stderr, not stdout, so faded_spec reads both.
+print(
+  ("cell %s fg=%s bg=%s at %d,%d"):format(
+    cell[1],
+    attrs.foreground and ("%06x"):format(attrs.foreground) or "none",
+    attrs.background and ("%06x"):format(attrs.background) or "none",
+    pos.row,
+    pos.col
+  )
+)
+vim.cmd("qa!")

--- a/tests/codereview/faded_spec.lua
+++ b/tests/codereview/faded_spec.lua
@@ -1,0 +1,691 @@
+-- Every file except the one the cursor is in is **faded**.
+--
+-- Asserted at the altitude a reviewer's diff really holds it: the marks the review draws in
+-- the plugin's namespace, read off the buffer with the helper `render_spec`, `spans_spec` and
+-- `bounded_spec` already use, and filtered by the group each mark carries. Movement is the
+-- cursor and the `CursorMoved` autocommand a keystroke raises, never a call to the function
+-- that emits.
+--
+-- Only this plugin's own groups are judged bright or faded. A treesitter capture the active
+-- theme gives no colour of its own is emitted as itself by design -- `@spell` is one in this
+-- fixture -- and counting that as "left bright" would be counting the nil contract as a
+-- defect. What the replay does under the fade is asserted on the captures that do have a
+-- colour, by name.
+--
+-- Two blocks exist for traps rather than for behaviour. One opens a review with
+-- `syntax = false`, which fails for a fade that took its row spans from the replay's row map:
+-- that map is built only when highlighting is on. One scrolls into rows no paint had reached
+-- at the moment of the crossing, which fails for a fade that renamed the rows it could see
+-- once instead of renaming a row as it is emitted.
+--
+-- Lower still, the cells the reviewer's screen really holds. Those are in `faded_child.lua`,
+-- one process per reading, because `nvim__inspect_cell` tells the truth only on the first
+-- call a process makes -- see the header there. A group name cannot tell a faded row from a
+-- bright one, so nothing above this line can.
+local h = require("tests.helpers")
+
+local fade = require("codereview.fade")
+local hl = require("codereview.hl")
+local syntax = require("codereview.syntax")
+local view = require("codereview.view")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+-- Colours with even channels, so a blend a quarter of the way to a black background has no
+-- rounding in it and the numbers below can be read at a glance.
+vim.o.termguicolors = true
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
+-- A group with a name and no colour at all: the one thing the blend cannot compute, and the
+-- case it must hand back nothing for. Defined before any review has blended anything.
+vim.api.nvim_set_hl(0, "FadedSpecColourless", {})
+
+---What the name of every blended group in the fade's family starts with.
+local FADED = "CodeReviewFaded."
+
+---@param group string
+---@return boolean
+local function is_faded(group)
+  return group:sub(1, #FADED) == FADED
+end
+
+---Every highlight group the diff drew on rows `first`..`last` of `buf`, as a set.
+---@param buf integer
+---@param first integer 1-indexed
+---@param last integer 1-indexed, inclusive
+---@return table<string, boolean>
+local function drawn(buf, first, last)
+  local out = {}
+  last = math.min(last, vim.api.nvim_buf_line_count(buf))
+  for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, h.NS, { first - 1, 0 }, { last - 1, -1 }, { details = true })) do
+    local group = m[4].hl_group or m[4].line_hl_group
+    if group then
+      out[group] = true
+    end
+  end
+  return out
+end
+
+---Those of `groups` that this plugin defines, split by whether the fade renamed them.
+---@param groups table<string, boolean>
+---@return string[] faded, string[] bright
+local function own(groups)
+  local faded, bright = {}, {}
+  for group in pairs(groups) do
+    if is_faded(group) then
+      faded[#faded + 1] = group
+    elseif group:sub(1, #"CodeReview") == "CodeReview" then
+      bright[#bright + 1] = group
+    end
+  end
+  table.sort(faded)
+  table.sort(bright)
+  return faded, bright
+end
+
+---The rows one file's body occupies, taken from the render and from nothing else.
+---
+---Written out here rather than asked of `fade.lua`: the span is the trap, and a case that
+---asked the code under test where a file starts would agree with it whatever it answered.
+---@param V CRView
+---@param fi integer
+---@return integer first, integer last
+local function body(V, fi)
+  local next_header = V.render.file_rows[fi + 1]
+  return V.render.file_rows[fi] + 1, (next_header and next_header - 1) or #V.render.lines
+end
+
+---Every plugin group on one file's body, split the same way.
+---@param V CRView
+---@param fi integer
+---@param buf integer|nil Defaults to the after pane
+---@return string[] faded, string[] bright
+local function file_groups(V, fi, buf)
+  return own(drawn(buf or V.buf, body(V, fi)))
+end
+
+---Put the cursor on `row` and raise the event a reviewer's keystroke would.
+---
+---Neither `nvim_win_set_cursor` nor a `normal!` motion raises `CursorMoved` under a headless
+---Neovim -- see tests/README.md -- so a case that only moved the cursor would be asserting
+---against a crossing that never happened.
+---@param V CRView
+---@param row integer
+local function move_to(V, row)
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+end
+
+--- What a review draws when it opens ----------------------------------------------
+
+require("codereview").setup({
+  layout = "unified",
+  syntax = true,
+  muted = { enabled = true, strength = 0.5 },
+  faded = { enabled = true, strength = 0.25 },
+})
+view.open("branch")
+
+describe("a review opened with the cursor in its first file", function()
+  local V = assert(view.current(), "no review view open")
+
+  it("is on by default", function()
+    assert.is_true(require("codereview.config").defaults.faded.enabled)
+  end)
+
+  it("has more than one file to tell apart", function()
+    assert.is_true(#V.files > 1, ("%d file(s)"):format(#V.files))
+    assert.same(1, view.current_file())
+  end)
+
+  it("draws the file the cursor is in at full strength", function()
+    local faded, bright = file_groups(V, 1)
+    assert.same({}, faded)
+    assert.is_true(#bright > 0, "the first file's body carries no marks at all")
+  end)
+
+  it("fades the body of every other file", function()
+    for fi = 2, #V.files do
+      local faded, bright = file_groups(V, fi)
+      assert.same({}, bright, ("file %d, %s"):format(fi, V.files[fi].path))
+      assert.is_true(#faded > 0, ("file %d, %s, carries no marks at all"):format(fi, V.files[fi].path))
+    end
+  end)
+
+  -- The header row is the one row that names the file, and the fade exists to help a reviewer
+  -- find a place rather than to hide the map.
+  it("keeps every file's header row bright, with its path, its stat and its note count", function()
+    for fi = 1, #V.files do
+      local row = V.render.file_rows[fi]
+      local faded, bright = own(drawn(V.buf, row, row))
+      assert.same({}, faded, ("file %d, %s"):format(fi, V.files[fi].path))
+      assert.is_true(vim.tbl_contains(bright, "CodeReviewFileHeader"), table.concat(bright, ", "))
+    end
+    -- The stat and the note count ride on the after pane's header rows, and this fixture has
+    -- both. Read across the file headers rather than one, since not every file carries them.
+    local seen = {}
+    for fi = 1, #V.files do
+      local row = V.render.file_rows[fi]
+      for group in pairs(drawn(V.buf, row, row)) do
+        seen[group] = true
+      end
+    end
+    assert.is_true(seen.CodeReviewStatAdd, "no file header carries its stat")
+  end)
+
+  it("fades a faded file's hunk headers with its body", function()
+    local main = assert(h.file_index(V, "src/main.lua"))
+    local groups = drawn(V.buf, body(V, main))
+    assert.is_true(groups[FADED .. "CodeReviewHunkHeader"], "the hunk header is not faded")
+    assert.is_nil(groups.CodeReviewHunkHeader)
+  end)
+
+  -- The replay sits at a higher priority band than the diff's own marks, and it is what
+  -- carries the structure of the code. A fade that reached the line background and not the
+  -- tokens would leave a faded file's code as loud as the file being read.
+  it("fades the tokens the treesitter replay painted, and no others", function()
+    local main = assert(h.file_index(V, "src/main.lua"))
+    assert.is_true(drawn(V.buf, body(V, main))[FADED .. "@keyword"], "the replay's tokens are not faded")
+    assert.is_true(drawn(V.buf, body(V, 1))["@keyword"], "the file being read has no replayed token")
+    assert.is_nil(drawn(V.buf, body(V, 1))[FADED .. "@keyword"])
+  end)
+end)
+
+--- The crossing ------------------------------------------------------------------
+
+describe("the cursor crossing into another file", function()
+  local V = assert(view.current(), "no review view open")
+  local main = assert(h.file_index(V, "src/main.lua"))
+
+  move_to(V, assert(h.line_row(V, "src/main.lua")))
+
+  it("really crossed", function()
+    assert.same(main, view.current_file())
+    assert.same(main, V.current_file)
+  end)
+
+  it("clears the fade from the file entered", function()
+    local faded, bright = file_groups(V, main)
+    assert.same({}, faded)
+    assert.is_true(#bright > 0, "the file entered carries no marks at all")
+  end)
+
+  it("fades the file left", function()
+    local faded, bright = file_groups(V, 1)
+    assert.same({}, bright)
+    assert.is_true(#faded > 0, "the file left carries no marks at all")
+  end)
+
+  it("leaves every file it did not cross faded", function()
+    for fi = 2, #V.files do
+      if fi ~= main then
+        local faded, bright = file_groups(V, fi)
+        assert.same({}, bright, ("file %d, %s"):format(fi, V.files[fi].path))
+        assert.is_true(#faded > 0, ("file %d, %s"):format(fi, V.files[fi].path))
+      end
+    end
+  end)
+end)
+
+describe("the cursor moving from one hunk to the next inside one file", function()
+  local V = assert(view.current(), "no review view open")
+
+  ---Every mark the diff carries, id and all: what is drawn, and what emitted it.
+  ---@return table[]
+  local function marks()
+    return vim.api.nvim_buf_get_extmarks(V.buf, h.NS, 0, -1, { details = true })
+  end
+
+  local was = marks()
+  local from = vim.api.nvim_win_get_cursor(V.win)[1]
+  local routes = assert(h.file_index(V, "src/routes.lua"))
+  -- Two rows inside one file, which is what makes this a claim about the fade rather than
+  -- about a cursor that never moved. The window is taller than this fixture, so neither row
+  -- scrolls it and no new band comes due.
+  local first, last = body(V, routes)
+  move_to(V, first)
+  local inside = marks()
+  move_to(V, last)
+
+  it("moved the cursor, twice, without leaving the file", function()
+    assert.is_true(first ~= from and last ~= first, ("%d, %d, %d"):format(from, first, last))
+    assert.same(routes, view.current_file())
+  end)
+
+  it("changes nothing that is drawn", function()
+    assert.same(inside, marks())
+  end)
+
+  -- The extmark ids are what says nothing was emitted again: a fade that re-emitted on every
+  -- `CursorMoved` would draw the same groups on the same rows under new ids.
+  it("emits nothing again to do it", function()
+    local ids = {}
+    for _, m in ipairs(inside) do
+      ids[#ids + 1] = m[1]
+    end
+    local now = {}
+    for _, m in ipairs(marks()) do
+      now[#now + 1] = m[1]
+    end
+    assert.same(ids, now)
+  end)
+
+  it("did emit again for the crossing that got here", function()
+    local ids = {}
+    for _, m in ipairs(was) do
+      ids[m[1]] = true
+    end
+    local fresh = 0
+    for _, m in ipairs(inside) do
+      fresh = fresh + (ids[m[1]] and 0 or 1)
+    end
+    assert.is_true(fresh > 0, "the crossing into this file emitted nothing")
+  end)
+end)
+
+--- Both panes --------------------------------------------------------------------
+
+describe("the split layout", function()
+  local V = assert(view.current(), "no review view open")
+  view.toggle_layout()
+  local main = assert(h.file_index(V, "src/main.lua"))
+  move_to(V, assert(h.line_row(V, "src/main.lua")))
+
+  it("holds two panes of the same height, and the same header rows", function()
+    assert.is_not_nil(V.before_render)
+    assert.same(#V.render.lines, #V.before_render.lines)
+    assert.same(V.render.file_rows, V.before_render.file_rows)
+  end)
+
+  it("fades the same files in both panes, so the two images stay comparable", function()
+    for fi = 1, #V.files do
+      local after_faded, after_bright = file_groups(V, fi, V.buf)
+      local before_faded, before_bright = file_groups(V, fi, V.before_buf)
+      assert.same({}, fi == main and after_faded or after_bright, ("after pane, file %d"):format(fi))
+      assert.same({}, fi == main and before_faded or before_bright, ("before pane, file %d"):format(fi))
+    end
+  end)
+
+  -- The guard the case above is worth little without. The before pane draws filler wherever a
+  -- file exists on the after side only, so "nothing bright in it" holds for a pane that drew
+  -- nothing at all -- and this fixture has three such files. `src/routes.lua` is carried by
+  -- both images, and it is not the file being read.
+  it("really drew the before pane that was read", function()
+    local routes = assert(h.file_index(V, "src/routes.lua"))
+    assert.is_true(routes ~= main, "the guard is reading the file the cursor is in")
+    local faded, bright = file_groups(V, routes, V.before_buf)
+    assert.is_true(#faded > 0, "the before pane drew nothing for a file it holds")
+    assert.same({}, bright)
+  end)
+
+  view.toggle_layout()
+
+  it("comes back to one pane with the fade where it was", function()
+    assert.is_nil(V.before_win)
+    local faded, bright = file_groups(V, main)
+    assert.same({}, faded)
+    assert.is_true(#bright > 0, "the file being read carries no marks at all")
+  end)
+end)
+
+--- A repaint that moves the rows --------------------------------------------------
+
+describe("a file collapsed above the one being read", function()
+  local V = assert(view.current(), "no review view open")
+  local routes = assert(h.file_index(V, "src/routes.lua"))
+  local before_collapse = V.render.file_rows[routes]
+
+  -- Collapse `src/main.lua`, which is above it, and then read `src/routes.lua` at the row it
+  -- has now. Every row below the collapse has moved, so a fade left over from the render it
+  -- was emitted from would now be sitting on somebody else's code.
+  move_to(V, assert(h.line_row(V, "src/main.lua")))
+  view.toggle_expand()
+  move_to(V, V.render.file_rows[routes] + 1)
+
+  it("moved the rows below it", function()
+    assert.is_true(V.render.file_rows[routes] < before_collapse, "nothing moved, so nothing is being measured")
+    assert.same(routes, view.current_file())
+  end)
+
+  it("draws the file being read at full strength at its new rows", function()
+    local faded, bright = file_groups(V, routes)
+    assert.same({}, faded)
+    assert.is_true(#bright > 0, "the file being read carries no marks at all")
+  end)
+
+  it("leaves the collapsed file needing no rule of its own", function()
+    local main = assert(h.file_index(V, "src/main.lua"))
+    local _, bright = file_groups(V, main)
+    assert.same({}, bright)
+  end)
+
+  view.toggle_expand()
+end)
+
+--- A review with nothing in it -----------------------------------------------------
+
+describe("a review with no files", function()
+  local V = assert(view.current(), "no review view open")
+  -- A revspec whose two ends are the same commit: a review that opened on a real scope and
+  -- has nothing in it, which is the only way to reach an empty one -- `open` refuses.
+  view.set_scope("HEAD..HEAD")
+
+  it("really has no files, and no file under the cursor", function()
+    assert.same(0, #V.files)
+    assert.is_nil(view.current_file())
+  end)
+
+  it("fades nothing", function()
+    local faded = own(drawn(V.buf, 1, math.max(1, #V.render.lines)))
+    assert.same({}, faded)
+  end)
+
+  view.set_scope("branch")
+end)
+
+--- The colours behind it ------------------------------------------------------------
+
+describe("the two families of blended groups", function()
+  it("gives the fade a strength of its own", function()
+    local faded = assert(hl.blended("faded", "CodeReviewAdd"), "the fade has no blend of a changed line")
+    local muted = assert(hl.blended("muted", "CodeReviewAdd"), "the window rule has no blend of a changed line")
+    local theme = vim.api.nvim_get_hl(0, { name = "CodeReviewAdd", link = false }).bg
+    local one = vim.api.nvim_get_hl(0, { name = faded, link = false }).bg
+    local other = vim.api.nvim_get_hl(0, { name = muted, link = false }).bg
+    assert.is_true(one ~= other, ("both families blend a changed line to %s"):format(tostring(one)))
+    -- Both pulled from the same colour toward the same background, and the fade less far:
+    -- it covers every file but one, where the window rule covers a pane.
+    assert.is_true(one < theme and other < one, ("theme %s, faded %s, muted %s"):format(theme, one, other))
+  end)
+
+  -- Nobody is to "fix" this by giving the fade a palette of its own. A group with no blend
+  -- emitted as itself is what keeps an unrecognised theme merely less faded instead of
+  -- wrongly coloured, and there is no higher place to say it: the render carries no mark in
+  -- a colourless group, so no reading of the buffer can reach this.
+  it("hands back nothing for a group the theme gives no colour", function()
+    assert.is_nil(hl.blended("faded", "FadedSpecColourless"))
+    assert.same("FadedSpecColourless", fade.group("FadedSpecColourless"))
+  end)
+
+  it("hands back a blend for a group it does colour, beside it", function()
+    assert.same(FADED .. "CodeReviewAdd", fade.group("CodeReviewAdd"))
+  end)
+end)
+
+--- With highlighting off ------------------------------------------------------------
+
+-- The trap case. The replay builds a row map that holds a span per file, and it is built
+-- only when highlighting is on -- so a fade taking its spans from there does nothing at all
+-- here, and every case above still passes.
+describe("a review opened with syntax off", function()
+  require("codereview").setup({ layout = "unified", syntax = false, faded = { enabled = true, strength = 0.25 } })
+  view.close()
+  view.open("branch")
+  local V = assert(view.current(), "no review view open")
+  local main = assert(h.file_index(V, "src/main.lua"))
+  move_to(V, assert(h.line_row(V, "src/main.lua")))
+
+  it("really has no highlighting, and no row map behind it", function()
+    assert.same({}, h.syntax_marks(V))
+    assert.is_nil(V.syntax_rows)
+  end)
+
+  it("fades every file but the one the cursor is in anyway", function()
+    local faded, bright = file_groups(V, main)
+    assert.same({}, faded)
+    assert.is_true(#bright > 0, "the file being read carries no marks at all")
+    for fi = 1, #V.files do
+      if fi ~= main then
+        local other_faded, other_bright = file_groups(V, fi)
+        assert.same({}, other_bright, ("file %d, %s"):format(fi, V.files[fi].path))
+        assert.is_true(#other_faded > 0, ("file %d, %s"):format(fi, V.files[fi].path))
+      end
+    end
+  end)
+
+  it("still fades the file left when the cursor crosses", function()
+    move_to(V, assert(h.line_row(V, "src/routes.lua")))
+    local _, bright = file_groups(V, main)
+    assert.same({}, bright)
+  end)
+end)
+
+--- With the switch off ---------------------------------------------------------------
+
+describe("a review opened with the fade off", function()
+  require("codereview").setup({ layout = "unified", syntax = true, faded = { enabled = false } })
+  view.close()
+  view.open("branch")
+  local V = assert(view.current(), "no review view open")
+
+  ---Every group the render gave a row, as `row:col:group`, sorted.
+  ---@param rendered CRRender
+  ---@return string[]
+  local function asked_for(rendered)
+    local out = {}
+    for _, m in ipairs(rendered.marks) do
+      local group = m.opts.hl_group or m.opts.line_hl_group
+      if group then
+        out[#out + 1] = ("%d:%d:%s"):format(m.row, m.col, group)
+      end
+    end
+    table.sort(out)
+    return out
+  end
+
+  ---Every group the buffer really carries, in the same shape. The replay's marks are left
+  ---out: they are not the render's, and they are not bounded the same way.
+  ---@return string[]
+  local function drew()
+    local out = {}
+    for _, m in ipairs(h.extmarks(V)) do
+      local group = m[4].hl_group or m[4].line_hl_group
+      if group and m[4].priority ~= require("codereview.render").PRIORITY.syntax then
+        out[#out + 1] = ("%d:%d:%s"):format(m[2], m[3], group)
+      end
+    end
+    table.sort(out)
+    return out
+  end
+
+  move_to(V, assert(h.line_row(V, "src/main.lua")))
+
+  it("crossed into another file, which would have faded the first", function()
+    assert.same(h.file_index(V, "src/main.lua"), view.current_file())
+  end)
+
+  -- Not "no faded group appears", which holds for a fade that ran and found nothing to
+  -- rename. Every mark the render asked for, drawn in the group it asked for.
+  it("draws the diff exactly as the render asked, mark for mark", function()
+    local asked = asked_for(V.render)
+    assert.is_true(#asked > 0, "the render asked for nothing")
+    assert.same(asked, drew())
+  end)
+
+  it("computes no blend of its own either", function()
+    -- Named for this block alone, so nothing earlier can have blended it already.
+    vim.api.nvim_set_hl(0, "FadedSpecOffGroup", { fg = 0x00ee00 })
+    assert.is_false(fade.enabled())
+    assert.same({}, vim.api.nvim_get_hl(0, { name = FADED .. "FadedSpecOffGroup" }))
+  end)
+end)
+
+--- Rows no paint had reached ----------------------------------------------------------
+
+-- The second trap case, and the one fixture in this file taller than a window and the margin
+-- around it: emission is bounded by the viewport, so a fade that renamed the rows it could
+-- see at the moment of the crossing leaves everything scrolled into afterwards bright.
+describe("scrolling into rows nothing had painted when the cursor crossed", function()
+  view.close()
+  h.cd_fixture("mkbig", "6", "200")
+  require("codereview").setup({ layout = "unified", syntax = true, faded = { enabled = true, strength = 0.25 } })
+  view.open("branch")
+  local V = assert(view.current(), "no review view open")
+  local BAND = syntax.VIEWPORT_MARGIN
+
+  ---Put the window on `row` as a reviewer's scroll would, and raise the event with it.
+  ---@param row integer
+  local function scroll_to(row)
+    vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+    vim.api.nvim_win_call(V.win, function()
+      vim.cmd("normal! zz")
+    end)
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+  end
+
+  local first, last = body(V, 3)
+
+  it("renders more rows than one paint can reach", function()
+    local _, hi = syntax.viewport(V)
+    assert.is_true(#V.render.lines > hi * 2, ("%d rows against a reach of %d"):format(#V.render.lines, hi))
+    assert.is_true(#V.files >= 4, ("%d files"):format(#V.files))
+  end)
+
+  -- Into the second file, and no further. What is asserted afterwards is about the third,
+  -- which is far below anything this crossing can have painted.
+  scroll_to(V.render.file_rows[2] + 1)
+
+  it("crossed into the second file", function()
+    assert.same(2, view.current_file())
+  end)
+
+  it("left the third file's rows with nothing drawn on them at all", function()
+    assert.is_true(first > (select(2, syntax.viewport(V))) + BAND, ("row %d is within reach"):format(first))
+    assert.same({}, drawn(V.buf, first, last))
+  end)
+
+  -- Down to the last row of the second file, so the margin below the window reaches into the
+  -- third without the cursor ever leaving the second. No crossing happens here: what emits
+  -- those rows is the paint that follows the scroll.
+  scroll_to(select(2, body(V, 2)))
+
+  it("scrolled without crossing out of the file being read", function()
+    assert.same(2, view.current_file())
+  end)
+
+  it("emits the rows it reached", function()
+    assert.is_true(next(drawn(V.buf, first, last)) ~= nil, "the scroll emitted nothing onto the third file")
+  end)
+
+  it("brings them in faded", function()
+    local faded, bright = own(drawn(V.buf, first, last))
+    assert.same({}, bright)
+    assert.is_true(#faded > 0, "the third file's rows carry no marks of the plugin's at all")
+  end)
+end)
+
+--- A colorscheme the review was not blended against ------------------------------------
+
+-- Last of the in-process blocks, because it replaces every colour the ones above read.
+describe("changing colorscheme", function()
+  local function bg(group)
+    return vim.api.nvim_get_hl(0, { name = group, link = false }).bg
+  end
+
+  local before = bg(FADED .. "CodeReviewAdd")
+  local was = bg("CodeReviewAdd")
+
+  vim.cmd("colorscheme blue")
+
+  local now = bg("CodeReviewAdd")
+  local backdrop = bg("Normal") or 0x000000
+  local after = bg(FADED .. "CodeReviewAdd")
+
+  -- Without this the case below passes on a theme that happens to paint a changed line the
+  -- same colour the last one did, which would prove nothing about recomputing anything.
+  it("is a change the theme really made", function()
+    assert.is_true(was ~= now, ("both themes give a changed line %s"):format(tostring(now)))
+  end)
+
+  it("recomputes the faded colour against the theme that is active now", function()
+    assert.is_true(before ~= after, "the faded colour is the one the old theme was blended into")
+    assert.is_true(after ~= now, "the faded colour is the new theme's, unfaded")
+    local theme, back, faded = now, backdrop, after
+    for _, place in ipairs({ 65536, 256, 1 }) do
+      local one = math.floor(theme / place) % 256
+      local two = math.floor(back / place) % 256
+      local mine = math.floor(faded / place) % 256
+      local lo, hi = math.min(one, two), math.max(one, two)
+      assert.is_true(
+        mine >= lo and mine <= hi,
+        ("%d is not between the theme's %d and the background's %d"):format(mine, one, two)
+      )
+    end
+  end)
+end)
+
+--- The cells a reviewer's screen holds ---------------------------------------------------
+
+-- One child per reading, because `nvim__inspect_cell` is only honest on the first call a
+-- process makes. Each opens the same review over this spec's first fixture, in the unified
+-- layout at 80x24, and reads the first token the treesitter replay painted on an *added* line
+-- of a file the cursor is not in -- one cell carrying a changed line's background under a
+-- foreground from a higher priority band, which is the only shape that can tell a fade that
+-- reaches the diff from one that reaches nothing but the empty space.
+describe("the cell under a reviewer's eye", function()
+  ---@param env table<string, string>
+  ---@return string
+  local function child(env)
+    local run = vim
+      .system({
+        vim.v.progpath,
+        "--clean",
+        "-l",
+        vim.fs.joinpath(h.root, "tests", "codereview", "faded_child.lua"),
+      }, {
+        cwd = fixture,
+        text = true,
+        env = vim.tbl_extend("force", {
+          FIXTURE = fixture,
+          XDG_STATE_HOME = vim.fn.tempname() .. "-state",
+          GIT_CONFIG_GLOBAL = "/dev/null",
+          GIT_CONFIG_SYSTEM = "/dev/null",
+        }, env),
+      })
+      :wait(60000)
+    -- `nvim -l` sends print to stderr, so read both streams rather than guessing.
+    local out = (run.stdout or "") .. (run.stderr or "")
+    assert(run.code == 0, out)
+    return vim.trim(out)
+  end
+
+  local elsewhere = child({})
+  local inside = child({ CURSOR = "in" })
+  local off = child({ FADED = "0" })
+
+  it("pulls both the changed line's background and the replay's foreground halfway to the background", function()
+    assert.same("cell l fg=770000 bg=002200", (elsewhere:gsub(" at %d+,%d+$", "")))
+  end)
+
+  it("gives the same cell back at full strength once the cursor crosses into its file", function()
+    assert.same("cell l fg=ee0000 bg=004400", (inside:gsub(" at %d+,%d+$", "")))
+  end)
+
+  -- What gives the first reading its teeth: without this it is only known to differ from a
+  -- bright cell, not to be a blend of one.
+  it("paints exactly what it painted before the fade existed when the switch is off", function()
+    assert.same("cell l fg=ee0000 bg=004400", (off:gsub(" at %d+,%d+$", "")))
+  end)
+end)
+
+--- A configuration mistake ----------------------------------------------------------------
+
+-- Last, because it deliberately leaves a bad value in the options: the switches beside this
+-- one are bare booleans, so `faded = false` is the mistake worth catching loudly.
+describe("the switch written the way the coarse ones are", function()
+  local ok, err = pcall(require("codereview").setup, { faded = false })
+
+  it("fails at setup rather than inside the emission later", function()
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("faded = { enabled = false }", 1, true), tostring(err))
+  end)
+
+  it("rejects a strength that is not a fraction of the way to the background", function()
+    local bad, why = pcall(require("codereview").setup, { faded = { strength = 4 } })
+    assert.is_false(bad)
+    assert.is_truthy(tostring(why):find("faded.strength", 1, true), tostring(why))
+  end)
+
+  require("codereview").setup({ layout = "unified", syntax = true })
+end)

--- a/tests/codereview/syntax_spec.lua
+++ b/tests/codereview/syntax_spec.lua
@@ -75,9 +75,16 @@ describe("replaying captures onto the diff", function()
     end
   end)
 
+  -- A **faded** file's tokens are replayed in the blended twin of the same group, which is
+  -- that group's own name behind the family's prefix -- so the check is made on the name
+  -- underneath it. What must never appear either way is a name no colorscheme can reach.
+  local FADED = "CodeReviewFaded."
+
   it("uses @-prefixed treesitter groups a colorscheme can colour", function()
     for _, m in ipairs(marks) do
-      assert.same("@", m[4].hl_group:sub(1, 1))
+      local group = m[4].hl_group
+      local bare = group:sub(1, #FADED) == FADED and group:sub(#FADED + 1) or group
+      assert.same("@", bare:sub(1, 1), group)
     end
   end)
 


### PR DESCRIPTION
A review holds many files and drew every one of them at full strength. The **sticky header** says which file the cursor is in, and it cannot make that file stand out. So a reviewer found the boundary of a file by scrolling until the colours changed meaning.

Every file except the one the cursor is in is now **faded**. Its header row stays bright. The review reads as bright headers over quiet bodies, with one file at full strength.

## How

**The fade changes which group a mark carries. It leaves the priority order alone.** A faded row is emitted in the blended variant of the group it would carry anyway. One grey foreground above the syntax replay was the other option, and this project already refused that shape for the intra-line **span** emphasis: such a foreground wins where a parser painted and loses where none did, so the result changes with the parsers a reader has installed.

**It is marks, not a highlight namespace.** A namespace colours a whole window, so it cannot fade one file inside a **pane**. The **muted** window rule stays a namespace because its unit *is* the window. The two share only the blended colours from #113, so neither drifts from the other, and each keeps a strength of its own.

**Every file's header row is exempt, not only the current file's.** The header is the one row that names a file.

**A file's rows come from the render.** The row map that the syntax replay builds holds a span per file as well, and it exists only while highlighting is on. A fade built on it would do nothing for a reviewer with `syntax = false`, and every test that runs with highlighting on would still pass.

## What #112 inherits

#111 was told to leave three interactions alone and to report what falls out of them. Here is what the code does today. All three are already the wanted behaviour, and **not one of them is asserted**. That is the same shape as the winbar's muting in #108: true by construction, invisible in any test, and one edit away from silently changing.

- **A queued note inside a faded file stays bright.** A note is drawn as a virtual line, and its colours sit in the chunks of that mark rather than in `hl_group` or `line_hl_group`. The fade substitutes only those two fields and returns early when a mark carries neither.
- **An archived entry inside a faded file keeps its own dimness.** Same reason, same mechanism. So *already sent* and *not the file I am in* stay two statements, which is the rule this project keeps for **stale** and **touched** as well.
- **A faded file inside a muted pane is faded once, not twice.** The muted namespace links only the groups `hl.groups()` names, and the faded family is not among them. A faded row therefore finds no entry in that namespace, and an absent entry falls back to its global definition. A *dead link* would draw nothing at all, which is why this distinction matters.

## Verification

`make all`: 32 spec files, 1226 tests, 0 failures, 0 errors. The trunk holds 1180, so this adds 46 cases.

`faded_spec` carries the two traps that catch implementations which look correct: one review opened with `syntax = false`, and one that scrolls into rows nothing had painted when the cursor crossed.

## One thing to know about this commit

The agent that wrote this work lost its session twice at the commit step, on `ENOTFOUND` and then on `Connection closed mid-response`. The coordinator ran the suite, read the diff, and committed the work rather than risk a third loss of it. The code is the agent's. The commit message and this description are the coordinator's, and the mutation checks the agent ran before it died are not recorded here, because it died before it reported them. #112 should treat the three interactions above as unverified claims read from the code, and pin them.

Closes #111
