### PR TITLE
test: pin the three quiet states that meet inside a faded file

### DIFF
--- a/lua/codereview/fade.lua
+++ b/lua/codereview/fade.lua
@@ -48,7 +48,10 @@ end
 ---`hl_group` and `line_hl_group` are what a mark puts on the row it sits on, and they are
 ---what the fade renames. The virtual lines hanging under a row are left as they are: they
 ---are the **queue**'s entries and the **archive**'s, drawn beneath the code rather than on
----it, and what a faded file does to those is #112's question.
+---it, and their colours are in the chunks of that mark rather than in either field. So a
+---queued entry inside a faded file stays bright, and an archived one keeps the dimness it
+---already has -- which is how *already sent* and *not the file I am in* stay two statements.
+---The early return below is what says so, and `quiet_spec` is what pins it.
 ---
 ---A copy, never the render's own table: the same mark is emitted again whenever the fade
 ---moves, and it has to start from the group it was built with.

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # timing report at two siz
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 1,115 cases in ~6 seconds.
+The whole suite is about 1,245 cases in ~5 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -32,6 +32,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
 | `codereview/muted_child.lua` | Spawned four times by `muted_spec`, one painted cell each — deliberately not a spec. |
 | `codereview/faded_child.lua` | Spawned three times by `faded_spec`, one painted cell each — deliberately not a spec. |
+| `codereview/quiet_child.lua` | Spawned eight times by `quiet_spec`, one painted cell each, where two quiet states meet — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `codereview/winbar_child.lua` | Spawned three times by `split_spec` to read one cell of a pane's winbar — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
@@ -61,6 +62,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `faded_spec` | Every file but the one the cursor is in: what a review draws when it opens, the crossing, the hunk that changes nothing, the header left bright, both panes, a repaint that moves the rows, an empty review, the two families of blended groups, the switch — the two traps, `syntax = false` and a scroll past the last paint — and the cells three child processes read |
 | `muted_spec` | The review window without focus: which window is bright, the namespace and the `cursorline` that follow focus, a float changing nothing, a rebuilt pane and a re-summoned tree, the group left bright on purpose, the colorscheme change, the switch — and the cells four child processes read |
+| `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colours one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float |
@@ -80,7 +82,7 @@ interchangeable, and the assertions know which one they are looking at.
   `diff_spec`, `render_spec`, `syntax_spec`, `annotate_spec`, `payload_spec`, `state_spec`,
   `viewless_spec`, `capture_spec`, `delivery_spec`, `queue_jump_spec`, `queue_float_spec`,
   `split_spec`, `layout_spec`, `open_diff_spec`, `archive_spec`, `touched_spec`,
-  `faded_spec` and `interactive_spec`. Its
+  `faded_spec`, `quiet_spec` and `interactive_spec`. Its
   dirty working tree is what makes a snapshot worth minting, so `archive_spec` builds a
   second copy and resets it to get a clean one. It already covers everything the split layout has
   to render, including the files that exist on only one side and the additions between
@@ -344,6 +346,30 @@ so the out-of-core language path is still checked locally without ever failing C
   were really drawn for stays bright. The view records what the emission drew, beside the
   bands. Both traps above caught this while it was being written, and neither was written
   for it.
+- **Two quiet states that meet are invisible to the spec of either one.** A queued entry and
+  an archived one inside a faded file keep their own colours because the fade renames
+  `hl_group` and `line_hl_group` and returns early for a mark carrying neither — an entry's
+  colours are in the chunks of its virtual lines. A faded file inside a muted pane is faded
+  once because the muted namespace links the groups `hl.groups()` names, and the faded family
+  is not among them. Both were true from the day the fade landed and neither was measured:
+  making the fade rename an entry's chunks reds seven cases, **all** of them in `quiet_spec`,
+  and linking the faded family into the muted namespace reds two, both there. Nothing else in
+  the suite notices either cut.
+- **An absent namespace entry and a dead link draw different things.** A group a namespace
+  does not name falls back to its global definition and draws it; a link that reaches no
+  definition draws nothing at all. So "the muted namespace holds no entry for
+  `CodeReviewFaded.CodeReviewAdd`" is only half the claim, and the half a cell cannot show:
+  `quiet_spec` reads the global definition beside it and asserts it holds a colour and is not
+  itself a link. `hl.lua` writes a twin that loses its colour back as a link to the group it
+  blends for the same reason.
+- **Two blends can only be counted apart when the two strengths differ.** A cell says how far
+  a colour was pulled, not how many times it was pulled, so with `muted.strength` equal to
+  `faded.strength` a file faded once and a file merely muted print the same number — and
+  "faded once, not twice" then passes for a fade that never ran. `quiet_spec` and
+  `quiet_child.lua` run the window rule at 0.25 and the fade at 0.5, which gives one token
+  four readings that are all different: `ec0000` on `004400` bright, `760000` on `002200`
+  faded, `b10000` on `003300` muted, and `590000` on `001a00` had the two stacked. Their
+  channels divide by four so all three blends are exact.
 - **The tree fixture is structural.** `panel_spec` asserts on compaction and per-directory
   tallies, so adding or omitting one file changes what it expects. Regenerate with
   `mktree.sh` rather than hand-editing a fixture repo.

--- a/tests/codereview/quiet_child.lua
+++ b/tests/codereview/quiet_child.lua
@@ -1,0 +1,188 @@
+-- One painted cell where two of the review's quiet states meet, read in a process of its own.
+--
+-- Deliberately a separate process, and deliberately one cell. `nvim__inspect_cell` reports
+-- a cell's real foreground and background only on the **first** call a process makes; every
+-- call after it returns attributes belonging to something else entirely -- measured rather
+-- than assumed, and recorded in `muted_child.lua` beside it. So the whole point of this file
+-- is to make exactly one such call, in one arrangement, and print what it saw.
+--
+-- A group name cannot tell a faded row from a bright one, and it cannot tell one blend from
+-- two. The cell is the only reading that says where a colour really ended up.
+--
+-- The screen is 80x24 because that is the grid a headless Neovim keeps whatever `columns`
+-- and `lines` are set to: a window drawn past column 80 is drawn into cells no assertion can
+-- read.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- quiet_spec with FIXTURE, CELL, CURSOR, FOCUS and MUTED in its environment, and it must NOT
+-- load tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.termguicolors = true
+vim.o.columns = 80
+vim.o.lines = 24
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+-- Colours the arithmetic is exact on: every channel divides by four, so a blend halfway to a
+-- black background and a blend a quarter of the way are both colours with no rounding in
+-- them -- and so is one laid over the other.
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
+vim.api.nvim_set_hl(0, "@keyword", { fg = 0xec0000 })
+-- What the marker of a queued entry draws in, through `CodeReviewBug`, and what the marker
+-- of an archived one draws in, through `CodeReviewArchived`. Two colours of their own, so a
+-- reading of either says which of the two it read.
+vim.api.nvim_set_hl(0, "DiagnosticError", { fg = 0x00ec00, bg = 0x440044 })
+vim.api.nvim_set_hl(0, "Comment", { fg = 0x0000ec, bg = 0x444400 })
+
+require("codereview").setup({
+  layout = "unified",
+  syntax = true,
+  -- Two strengths that cannot be mistaken for each other. A cell blended once at either of
+  -- them, and a cell blended at both, are three different colours -- which is what lets one
+  -- reading say how many times a colour was pulled toward the background.
+  muted = { enabled = vim.env.MUTED ~= "0", strength = 0.25 },
+  faded = { enabled = true, strength = 0.5 },
+  -- One type, with an ASCII marker: the cell under test then holds a character this file can
+  -- name, where the shipped icons are glyphs of a font nothing here has.
+  types = { { name = "bug", key = "b", icon = "!", hl = "CodeReviewBug", label = "Bugs" } },
+  compose = function(_, on_accept)
+    on_accept(nil, "a note inside a faded file")
+  end,
+  send = function()
+    return true
+  end,
+})
+
+local annotate = require("codereview.annotate")
+local view = require("codereview.view")
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+
+-- The file every reading is taken inside. Not the first file of the review, so the cursor
+-- has somewhere else to be.
+local PATH = "src/main.lua"
+
+---@return integer
+local function target()
+  for i, f in ipairs(V.files) do
+    if f.path == PATH then
+      return i
+    end
+  end
+  error(PATH .. " is not in this review")
+end
+
+---The rows of `PATH` carrying a diff line of one side, lowest first.
+---@param side string
+---@return integer[]
+local function rows_of(side)
+  local rows = {}
+  for row, a in pairs(V.render.anchors) do
+    if a.kind == "line" and V.files[a.file].path == PATH then
+      local ln = V.files[a.file].hunks[a.hunk].lines[a.line]
+      if ln.side == side then
+        rows[#rows + 1] = row
+      end
+    end
+  end
+  table.sort(rows)
+  return rows
+end
+
+---Put the cursor on `row` and raise the event a reviewer's keystroke would.
+---
+---Driven through that event because neither `nvim_win_set_cursor` nor a `normal!` motion
+---raises `CursorMoved` under `nvim -l`.
+---@param row integer
+local function move_to(row)
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+end
+
+-- Every step below reports itself through `vim.notify`, and `nvim -l` prints that to the
+-- stream the reading is read from. Silenced here so this process prints exactly one line.
+vim.notify = function() end
+
+-- One entry already dispatched and one still queued, each on a row of its own inside the
+-- file under test, so one reading can be taken of each. The archived one goes first: a
+-- submit empties the queue, and what is queued afterwards stays queued.
+local archived_row = assert(rows_of("ctx")[1], "no context line to put an archived entry on")
+move_to(archived_row)
+annotate.annotate("bug")
+view.submit()
+
+local queued_row = assert(rows_of("add")[1], "no added line to put a queued entry on")
+move_to(queued_row)
+annotate.annotate("bug")
+
+if vim.env.CURSOR == "in" then
+  -- Onto that file's *header* row, not onto one of its code rows: the focused window draws a
+  -- `cursorline`, and a reading taken on the lit row would be a reading of that instead.
+  move_to(V.render.file_rows[target()])
+  assert(view.current_file() == target(), "the cursor never reached the file under test")
+else
+  move_to(V.render.file_rows[1])
+  assert(view.current_file() == 1, "the cursor never left the file under test")
+  assert(target() ~= 1, "the file under test is the file the cursor is in")
+end
+
+local tree = assert(V.panel_win, "no file tree")
+vim.api.nvim_set_current_win(vim.env.FOCUS == "tree" and tree or V.win)
+
+---Where on screen the cell under test is.
+---
+---A queued entry and an archived one are drawn as virtual lines hanging under the row they
+---are about, and a virtual line has no buffer position to ask `screenpos` for. So the row
+---the entry belongs to is located, and the line under it is the one read. The marker sits
+---three columns in, whatever the width of the icon after it.
+---@return integer row, integer col Both 1-indexed screen positions
+local function cell_at()
+  local cell = vim.env.CELL or "code"
+  if cell ~= "code" then
+    local anchor = cell == "archived" and archived_row or queued_row
+    local pos = vim.fn.screenpos(V.win, anchor, 1)
+    assert(pos.row > 0 and pos.col > 0, "the annotated row is off screen")
+    return pos.row + 1, pos.col + 3
+  end
+  -- The first token the replay painted on an *added* line of the file under test, so one
+  -- cell carries both halves of the question: the line's own background under a foreground
+  -- from a higher priority band.
+  local painted = vim.api.nvim_buf_get_extmarks(V.buf, vim.api.nvim_create_namespace("codereview"), 0, -1, {
+    details = true,
+  })
+  for _, m in ipairs(painted) do
+    local group = m[4].hl_group
+    local a = V.render.anchors[m[2] + 1]
+    if
+      (group == "@keyword" or group == "CodeReviewFaded.@keyword")
+      and a
+      and a.kind == "line"
+      and V.files[a.file].path == PATH
+      and V.files[a.file].hunks[a.hunk].lines[a.line].side == "add"
+    then
+      local pos = vim.fn.screenpos(V.win, m[2] + 1, m[3] + 1)
+      assert(pos.row > 0 and pos.col > 0, "the row under test is off screen")
+      return pos.row, pos.col
+    end
+  end
+  error("no keyword was painted on an added line of " .. PATH .. " -- did the replay run?")
+end
+
+vim.cmd("redraw!")
+local row, col = cell_at()
+local cell = vim.api.nvim__inspect_cell(1, row - 1, col - 1)
+local attrs = cell[2] or {}
+
+-- `nvim -l` sends print to stderr, not stdout, so quiet_spec reads both.
+print(
+  ("cell %s fg=%s bg=%s at %d,%d"):format(
+    cell[1],
+    attrs.foreground and ("%06x"):format(attrs.foreground) or "none",
+    attrs.background and ("%06x"):format(attrs.background) or "none",
+    row,
+    col
+  )
+)
+vim.cmd("qa!")

--- a/tests/codereview/quiet_spec.lua
+++ b/tests/codereview/quiet_spec.lua
@@ -1,0 +1,326 @@
+-- Where the review's three quiet states meet.
+--
+-- **Faded** is a file the cursor is not in. **Dimmed** is an archived **entry** drawn on the
+-- diff. **Muted** is a review window without focus. Two of them meet inside a faded file --
+-- an entry drawn there, and a faded file drawn in a pane that has lost focus -- and each
+-- meeting already behaves as it should. Each of them holds by construction rather than by
+-- intent, and until this file none of them was asserted anywhere.
+--
+-- That is the shape #108 met in the winbar: a behaviour nothing announces the end of. The
+-- fade renames `hl_group` and `line_hl_group` and returns early for a mark that carries
+-- neither, so it never reaches the chunks an entry's virtual lines are drawn from. The muted
+-- namespace links the groups `hl.groups()` names, and the faded family is not among them, so
+-- a faded row finds no entry there and falls back to its global definition. Neither fact is
+-- written down in a line anyone would think to keep.
+--
+-- Asserted at the cell, in `quiet_child.lua`, one process per reading -- a group name cannot
+-- tell a faded row from a bright one, and it cannot tell one blend from two. The blocks in
+-- this process assert the mechanism each reading rests on, which is the only level that can
+-- say *why* a colour stayed where it is.
+--
+-- The one thing no cell can show: `CodeReviewFaded.CodeReviewAdd` is absent from the muted
+-- namespace and is a definition with a colour in it, not a link reaching nothing. An absent
+-- entry falls back and draws; a dead link draws nothing at all. The claim rests on that
+-- difference, so both halves are read here.
+local h = require("tests.helpers")
+
+local annotate = require("codereview.annotate")
+local view = require("codereview.view")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkfixture")
+
+-- Colours with even channels, so a blend has no rounding in it and the numbers can be read
+-- at a glance.
+vim.o.termguicolors = true
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
+
+---What the name of every blended group in the fade's family starts with.
+local FADED = "CodeReviewFaded."
+
+-- The plugin's own namespace, by name: `nvim_create_namespace` hands back the id a name
+-- already has, so this is a lookup rather than a second namespace.
+local MUTED = vim.api.nvim_create_namespace("codereview_muted")
+
+-- The file every entry below is put in, and the file the cursor spends most of this spec
+-- outside of. Not the first file of the review, so the cursor has somewhere else to be.
+local PATH = "src/main.lua"
+
+require("codereview").setup({
+  layout = "unified",
+  syntax = true,
+  -- Two strengths that cannot be mistaken for each other, for the reason the child gives:
+  -- one blend, the other blend and both blends are three different colours.
+  muted = { enabled = true, strength = 0.25 },
+  faded = { enabled = true, strength = 0.5 },
+  types = { { name = "bug", key = "b", icon = "!", hl = "CodeReviewBug", label = "Bugs" } },
+  compose = function(_, on_accept)
+    on_accept(nil, "a note inside a faded file")
+  end,
+  send = function()
+    return true
+  end,
+})
+
+view.open("branch")
+local V = assert(view.current(), "no review view open")
+
+---Every highlight group the diff drew on rows `first`..`last`, as a set.
+---@param first integer 1-indexed
+---@param last integer 1-indexed, inclusive
+---@return table<string, boolean>
+local function drawn(first, last)
+  local out = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_extmarks(V.buf, h.NS, { first - 1, 0 }, { last - 1, -1 }, { details = true })) do
+    local group = m[4].hl_group or m[4].line_hl_group
+    if group then
+      out[group] = true
+    end
+  end
+  return out
+end
+
+---The plugin's groups on one file's body, split by whether the fade renamed them.
+---
+---The span is written out from the render rather than asked of `fade.lua`: a case that asked
+---the code under test where a file starts would agree with it whatever it answered.
+---@param fi integer
+---@return string[] faded, string[] bright
+local function file_groups(fi)
+  local next_header = V.render.file_rows[fi + 1]
+  local first = V.render.file_rows[fi] + 1
+  local last = (next_header and next_header - 1) or #V.render.lines
+  local faded, bright = {}, {}
+  for group in pairs(drawn(first, last)) do
+    if group:sub(1, #FADED) == FADED then
+      faded[#faded + 1] = group
+    elseif group:sub(1, #"CodeReview") == "CodeReview" then
+      bright[#bright + 1] = group
+    end
+  end
+  table.sort(faded)
+  table.sort(bright)
+  return faded, bright
+end
+
+---The rows of `PATH` carrying a diff line of one side, lowest first.
+---@param side string
+---@return integer[]
+local function rows_of(side)
+  local rows = {}
+  for row, a in pairs(V.render.anchors) do
+    if a.kind == "line" and V.files[a.file].path == PATH then
+      local ln = V.files[a.file].hunks[a.hunk].lines[a.line]
+      if ln.side == side then
+        rows[#rows + 1] = row
+      end
+    end
+  end
+  table.sort(rows)
+  return rows
+end
+
+---Put the cursor on `row` and raise the event a reviewer's keystroke would.
+---
+---Neither `nvim_win_set_cursor` nor a `normal!` motion raises `CursorMoved` under a headless
+---Neovim -- see tests/README.md -- so a case that only moved the cursor would be asserting
+---against a crossing that never happened.
+---@param row integer
+local function move_to(row)
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+end
+
+local target = assert(h.file_index(V, PATH))
+
+-- One entry already dispatched and one still queued, each on a row of its own inside the file
+-- under test. The archived one goes first: a submit empties the queue, and what is queued
+-- afterwards stays queued.
+local archived_row = assert(rows_of("ctx")[1], "no context line to put an archived entry on")
+move_to(archived_row)
+annotate.annotate("bug")
+view.submit()
+
+local queued_row = assert(rows_of("add")[1], "no added line to put a queued entry on")
+move_to(queued_row)
+annotate.annotate("bug")
+
+-- Out of that file, into the first, which is what fades it.
+move_to(V.render.file_rows[1])
+
+--- An entry inside a faded file ----------------------------------------------------
+
+describe("a queued entry and an archived one inside a faded file", function()
+  -- Without these the block below reads a bright file and calls the answer a fade rule.
+  it("really is inside a file the cursor is not in, and that file really is faded", function()
+    assert.is_true(target ~= 1, "the file under test is the file the cursor is in")
+    assert.same(1, view.current_file())
+    local faded, bright = file_groups(target)
+    assert.same({}, bright)
+    assert.is_true(#faded > 0, "the file under test carries no marks at all")
+  end)
+
+  it("draws both of them, on rows of their own", function()
+    assert.is_true(archived_row ~= queued_row, ("both entries are on row %d"):format(queued_row))
+    assert.same(2, #h.virt_marks(V), "the review is not drawing exactly two entries")
+  end)
+
+  -- The mechanism the whole claim rests on. An entry hangs *under* the row it is about, and
+  -- its colours are in that mark's chunks. The fade renames `hl_group` and `line_hl_group`,
+  -- which is what a mark puts on the row it sits on, and returns early for a mark that
+  -- carries neither.
+  it("puts no group of its own on the row it hangs under, so the fade has nothing to rename", function()
+    for _, m in ipairs(h.virt_marks(V)) do
+      assert.is_nil(m[4].hl_group)
+      assert.is_nil(m[4].line_hl_group)
+    end
+  end)
+
+  it("draws the queued one in its annotation type's group and the archived one in the archive's", function()
+    local groups = h.virt_groups(V)
+    assert.is_true(groups.CodeReviewBug, "the queued entry does not carry its type's group")
+    assert.is_true(groups.CodeReviewArchived, "the archived entry does not carry the archive's group")
+    assert.is_true(groups.CodeReviewArchivedNote, "the archived entry's prose does not carry the archive's group")
+  end)
+
+  -- *Already sent* and *not the file I am in* stay two statements, which is the rule this
+  -- project keeps for **stale** and **touched** as well.
+  it("blends neither of them", function()
+    local blended = {}
+    for group in pairs(h.virt_groups(V)) do
+      if group:sub(1, #FADED) == FADED then
+        blended[#blended + 1] = group
+      end
+    end
+    assert.same({}, blended)
+  end)
+
+  it("draws exactly what it draws with the cursor inside that same file", function()
+    local away = h.virt_groups(V)
+    move_to(V.render.file_rows[target])
+    assert.same(target, view.current_file())
+    local inside = h.virt_groups(V)
+    move_to(V.render.file_rows[1])
+    assert.same(1, view.current_file())
+    assert.same(away, inside)
+    assert.same(away, h.virt_groups(V))
+  end)
+end)
+
+--- A faded row and the muted namespace ---------------------------------------------
+
+describe("the groups a faded row carries and the namespace a muted pane draws through", function()
+  -- The guard every case below needs: with nothing in the namespace at all, "the faded family
+  -- is not in it" holds over an empty table.
+  it("links the group that faded row's colour is blended from", function()
+    assert.is_truthy(vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" }).link, "the namespace links nothing")
+  end)
+
+  it("draws a faded changed line in the fade's twin of that group, not in the group itself", function()
+    local faded, bright = file_groups(target)
+    assert.is_true(vim.tbl_contains(faded, FADED .. "CodeReviewAdd"), table.concat(faded, ", "))
+    assert.same({}, bright)
+  end)
+
+  it("holds no entry for the twin, so a muted pane leaves it alone", function()
+    assert.same({}, vim.api.nvim_get_hl(MUTED, { name = FADED .. "CodeReviewAdd" }))
+  end)
+
+  -- What the case above is worth nothing without, and what no cell reading can show. An
+  -- absent entry falls back to the twin's global definition and draws it; a link reaching
+  -- nothing draws nothing at all. Nobody is to "fix" the absence by adding a link.
+  it("leaves a definition with a colour in it to fall back to, not a dead link", function()
+    local def = vim.api.nvim_get_hl(0, { name = FADED .. "CodeReviewAdd", link = false })
+    assert.is_truthy(def.bg, "the fade's twin of a changed line holds no colour")
+    assert.is_nil(def.link)
+  end)
+end)
+
+--- The cells a reviewer's screen holds ----------------------------------------------
+
+-- One child per reading, because `nvim__inspect_cell` is only honest on the first call a
+-- process makes. Each opens the same review over this spec's fixture, in the unified layout
+-- at 80x24, puts one archived entry and one queued entry inside `src/main.lua`, and reads one
+-- cell of it: the marker of either entry, or the first token the replay painted on an added
+-- line of the code around them.
+--
+-- The fade pulls a colour half of the way to the background and the window rule a quarter of
+-- the way, so the four numbers a changed line's token can hold are all different: `ec0000` on
+-- `004400` bright, `760000` on `002200` faded, `b10000` on `003300` muted, and `590000` on
+-- `001a00` had it been both.
+describe("the cell under a reviewer's eye", function()
+  ---@param env table<string, string>
+  ---@return string
+  local function child(env)
+    local run = vim
+      .system({
+        vim.v.progpath,
+        "--clean",
+        "-l",
+        vim.fs.joinpath(h.root, "tests", "codereview", "quiet_child.lua"),
+      }, {
+        cwd = fixture,
+        text = true,
+        env = vim.tbl_extend("force", {
+          FIXTURE = fixture,
+          XDG_STATE_HOME = vim.fn.tempname() .. "-state",
+          GIT_CONFIG_GLOBAL = "/dev/null",
+          GIT_CONFIG_SYSTEM = "/dev/null",
+        }, env),
+      })
+      :wait(60000)
+    -- `nvim -l` sends print to stderr, so read both streams rather than guessing.
+    local out = (run.stdout or "") .. (run.stderr or "")
+    assert(run.code == 0, out)
+    return (vim.trim(out):gsub(" at %d+,%d+$", ""))
+  end
+
+  local code_away = child({ CELL = "code", CURSOR = "out" })
+  local code_inside = child({ CELL = "code", CURSOR = "in" })
+  local code_muted = child({ CELL = "code", CURSOR = "out", FOCUS = "tree" })
+  local current_muted = child({ CELL = "code", CURSOR = "in", FOCUS = "tree" })
+  local note_away = child({ CELL = "note", CURSOR = "out" })
+  local note_inside = child({ CELL = "note", CURSOR = "in" })
+  local gone_away = child({ CELL = "archived", CURSOR = "out" })
+  local gone_inside = child({ CELL = "archived", CURSOR = "in" })
+
+  -- The two readings every claim below is measured against: the same token of the same file,
+  -- at full strength and faded. Without them a bright entry is only known to be bright, not
+  -- to be bright on a screen where anything receded at all.
+  it("fades the code of a file the cursor is not in, and leaves the file it is in alone", function()
+    assert.same("cell l fg=760000 bg=002200", code_away)
+    assert.same("cell l fg=ec0000 bg=004400", code_inside)
+  end)
+
+  it("keeps a queued entry inside that faded file at full strength", function()
+    assert.same("cell ! fg=00ec00 bg=440044", note_away)
+  end)
+
+  it("gives it exactly the colour it has in a file that is not faded", function()
+    assert.same(note_inside, note_away)
+  end)
+
+  -- The archive's own dimness, and no second blend over it: *already sent* and *not the file
+  -- I am in* stay two statements.
+  it("leaves an archived entry inside that faded file the dimness it already has", function()
+    assert.same("cell ! fg=0000ec bg=444400", gone_away)
+  end)
+
+  it("gives that one exactly the colour it has in a file that is not faded too", function()
+    assert.same(gone_inside, gone_away)
+  end)
+
+  -- The window rule answers alone. Two blends over each other would read `590000` on
+  -- `001a00` here.
+  it("fades a file once when its pane has lost focus, not twice", function()
+    assert.same(code_away, code_muted)
+  end)
+
+  -- And the window rule is untouched by any of it: the file the cursor *is* in still mutes
+  -- with its pane. Without this the case above holds for a namespace that reaches nothing.
+  it("mutes the file the cursor is in when that pane loses focus", function()
+    assert.same("cell l fg=b10000 bg=003300", current_muted)
+    assert.is_true(current_muted ~= code_inside, "the muted pane is no dimmer than the focused one")
+  end)
+end)


### PR DESCRIPTION
Three quiet states now meet inside a **faded** file, and all three already behaved the way #109 wants. Each held by construction rather than by intent, and not one of them was asserted. This slice pins them. It corrects nothing, because every confirmation agreed with the code.

## What was confirmed, and how

- **A queued entry inside a faded file stays bright.** The mark that draws it carries `virt_lines` and neither `hl_group` nor `line_hl_group`, so `fade.opts` returns it untouched. Read at the cell: the marker of a queued entry inside a faded file prints `fg=00ec00 bg=440044`, which is its annotation type's colour unblended, on the same screen where that file's code prints `fg=760000 bg=002200`.
- **An archived entry inside a faded file keeps the dimness it already has.** Same mark, same early return. Its marker prints `fg=0000ec bg=444400` — the archive's own colour — and prints the same with the cursor inside that file. So *already sent* and *not the file I am in* stay two statements.
- **A faded file inside a muted pane is faded once.** `mute_extend` links the groups `hl.groups()` and `syntax.resolved_groups()` name, and the faded family is in neither. The same token of the same file prints `fg=760000 bg=002200` whether its pane has focus or not, while the file the cursor **is** in prints `fg=b10000 bg=003300` once that pane loses focus — so the namespace does reach the buffer, and it leaves the faded rows alone.

**No claim proved false.** Nothing about how any of the three states is drawn was changed.

## How it is asserted

At the painted cell, in `quiet_child.lua`, one process per reading. A group name cannot tell a faded row from a bright one, and it cannot tell one blend from two.

The window rule runs at 0.25 and the fade at 0.5, so one token of one changed line has four readings that are all different: `ec0000` on `004400` bright, `760000` on `002200` faded, `b10000` on `003300` muted, and `590000` on `001a00` had the two stacked. With one strength for both, "faded once" and "merely muted" would print the same number and the case would pass for a fade that never ran.

Every reading has a control on the same screen. The two `code` readings say what a faded row and a bright row look like in this arrangement, so a bright entry is known to be bright on a screen where something did recede. The muted reading of the current file is what says the namespace reaches that pane at all.

The blocks that run in process assert the mechanism each reading rests on, including the one thing no cell can show: `CodeReviewFaded.CodeReviewAdd` is absent from the muted namespace **and** is a definition holding a colour, not a link reaching nothing. An absent entry falls back and draws; a dead link draws nothing at all, and the claim rests on that difference.

## The cuts

Each was applied alone and the whole suite run against it. 17 cases were added; every one is reached.

| Cut | Red |
| --- | --- |
| `fade.opts` renames the chunks of an entry's virtual lines | **7, all in `quiet_spec`**: the type and archive groups, the two "blends neither" cases, and the four entry cell readings |
| `mute_extend` links `CodeReviewFaded.` beside every group | **2, both in `quiet_spec`**: the namespace case, and the cell, at `fg=590000 bg=001a00` |
| `attach_notes` gives the entry's mark a `line_hl_group` | 3, all in `quiet_spec`: the mechanism case and two cell controls |
| `fade.rows` returns nil | 15: 10 in `faded_spec`, 5 in `quiet_spec` |
| No window is given the muted namespace | 15: 13 in `muted_spec`, 1 in `split_spec`, 1 in `quiet_spec` |
| `hl.blended` names a twin without writing it | 9: 3 in `faded_spec`, 2 in `muted_spec`, 1 in `split_spec`, 3 in `quiet_spec` |
| `ensure_link` links nothing | 8: 5 in `muted_spec`, 1 in `split_spec`, 2 in `quiet_spec` |
| `note_virt` ignores the archive | 26 across six specs, 4 of them in `quiet_spec` |

The first two are the measurement this slice exists for. Both cuts change behaviour a reviewer would see immediately, and before this branch the whole suite stayed green under either one.

## Verification

`make all`: 33 spec files, 1,243 cases, 0 failures, 0 errors. The trunk holds 1,226. The suite still runs in about five seconds.

Closes #112
