### PR TITLE
feat(view): leave the file tree bright under every focus

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,16 +29,17 @@ _side_: a diff line's side is already add/del/ctx, and one word must not do two 
 _Avoid_: side, column, window
 
 **Muted**:
-Said of a review window that does not have focus: its colours pulled toward the background
-through a highlight namespace of its own, so the focused window is the bright one and a
-reviewer never has to press a key to find out where they are. Said of a **pane** or of the
-file tree — never of a file, and never of anything drawn *on* the diff. Not _dimmed_: an
-archived **entry** is already drawn dimmed on the diff, and one word must not do two jobs —
-the same collision that kept _side_ reserved for a diff line's add/del/ctx when the split
-layout needed a word for its windows. Not _faded_ either: that is the file the cursor is not
-in. The three are different mechanisms as well as different statements: dimming is a
-highlight group the render chooses per entry, fading is the group a mark carries, muting is
-every group at once in one window.
+Said of a **pane** that does not have focus: its colours pulled toward the background through
+a highlight namespace of its own, so the pane with focus is the bright one and a reviewer
+never has to press a key to find out where they are. Said of a pane and never of the file
+tree: the tree is never muted, it draws in the active colorscheme's own colours under every
+focus, and focus landing in it mutes the panes instead. Never said of a file, and never of
+anything drawn *on* the diff. Not _dimmed_: an archived **entry** is already drawn dimmed on
+the diff, and one word must not do two jobs — the same collision that kept _side_ reserved
+for a diff line's add/del/ctx when the split layout needed a word for its windows. Not
+_faded_ either: that is the file the cursor is not in. The three are different mechanisms as
+well as different statements: dimming is a highlight group the render chooses per entry,
+fading is the group a mark carries, muting is every group at once in one window.
 _Avoid_: dimmed, greyed, faded, inactive
 
 **Faded**:

--- a/README.md
+++ b/README.md
@@ -213,13 +213,19 @@ can see which packages are done without opening them. It follows the diff cursor
 Collapsed directories belong to the review rather than to the tree, so they are exactly as
 you left them when it comes back.
 
-### The window you are in is the bright one
+### The pane you are in is the bright one
 
-A review can hold three windows at once — the before pane, the after pane and the tree —
-and the one without focus is **muted**: its colours pulled toward the background, so where
-you are is on screen instead of something you have to press a key to find out. The
-`cursorline` goes with it, which is what stops the split layout lighting a row in both panes
-while saying nothing about either.
+A review can hold three windows at once — the before pane, the after pane and the tree — and
+the pane without focus is **muted**: its colours pulled toward the background, so where you
+are is on screen instead of something you have to press a key to find out. The `cursorline`
+goes with it, which is what stops the split layout lighting a row in both panes while saying
+nothing about either.
+
+The file tree is never muted. It is the map of the review — the paths, the icons, the
+per-directory tallies and the `+N -M` counts — so it draws in your colorscheme's own colours
+whichever window you are in, with the row for the file you are reading lit. Move into it and
+the panes mute, both of them in the split layout and the one of them in the unified layout,
+so you can see that your keys now act on the tree.
 
 The colours come from your own colorscheme, blended: nothing here has a palette of its own,
 and a group the plugin cannot know about is left bright rather than guessed at, so an
@@ -634,7 +640,7 @@ opts = {
   spans = true,                    -- emphasise what changed inside a changed line
   archived = true,                 -- draw already-dispatched entries on the diff, dimmed,
                                    -- and tally the untouched ones on the winbar
-  muted = { enabled = true,        -- mute every review window that does not have focus
+  muted = { enabled = true,        -- mute the pane that does not have focus; never the tree
             strength = 0.5 },      -- how far its colours are pulled toward the background
   faded = { enabled = true,        -- fade every file except the one the cursor is in
             strength = 0.35 },     -- its own number: this covers every file but one
@@ -652,7 +658,7 @@ without the plugin fighting back. The two exceptions are `CodeReviewAddSpan` and
 `default = true`, so overriding them works the same way.
 
 Two families of groups are computed rather than linked, and they are not yours to set. A
-**muted** window draws through a twin of each group named `CodeReviewMuted.` plus the group
+**muted** pane draws through a twin of each group named `CodeReviewMuted.` plus the group
 it blends — `CodeReviewMuted.CodeReviewAdd`, `CodeReviewMuted.@keyword`. A **faded** file's
 rows are drawn in a twin named `CodeReviewFaded.` plus the same, at `faded.strength` instead
 of `muted.strength`. Each holds that group's own colours pulled that far toward the

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -366,15 +366,21 @@ what reaches the queue and what the payload says are untouched.
 
 See |codereview-highlights| for the two groups it draws with.
 
-The window without focus                                 *codereview-muted*
+The pane you are not in                                  *codereview-muted*
 
 A review holds up to three windows -- the two panes and the file tree -- and
-the one that does not have focus is *muted*: its colours pulled toward the
+the pane that does not have focus is *muted*: its colours pulled toward the
 background, so which window your next keystroke acts on is on screen rather
-than something you press a key to find out. Only the focused window draws a
+than something you press a key to find out. Only the pane with focus draws a
 |cursorline|, which is what stops the split layout lighting a row in both
-panes while saying nothing about either. The tree is in the rule with the
-panes, because it competes with them for focus.
+panes while saying nothing about either.
+
+The file tree is never muted. It is the map of the review, so it draws in
+your colorscheme's own colours whichever window has focus, and the row for
+the file you are reading stays lit. Moving into the tree still mutes the
+panes -- both of them in the split layout, the one of them in the unified
+layout -- so the rule above holds of the panes and says nothing about the
+tree.
 
 Muting is a window-local highlight namespace holding a variant of every group
 in play, each computed by blending that group's colours toward `Normal`'s
@@ -856,8 +862,8 @@ untouched ones on the winbar (|codereview-archived|, |codereview-touched|).
 It is on by default and coarse on purpose: off is the whole history off --
 nothing drawn, nothing tallied and no `git` spent judging.
 
-`muted` mutes every review window that does not have focus
-(|codereview-muted|). `strength` is how far a colour is pulled toward the
+`muted` mutes the pane that does not have focus (|codereview-muted|); the
+file tree is never muted. `strength` is how far a colour is pulled toward the
 background, from 0 to 1. Coarse the same way: off is nothing muted, nothing
 computed and no highlight namespace attached to any window.
 
@@ -914,7 +920,7 @@ that is what keeps code readable inside an emphasised span. Both are still
 `default = true`, so overriding either works the same way as the rest.
 
 Two more families are computed, and neither is yours to set. A **muted**
-window (|codereview-muted|) draws every group through a twin named
+pane (|codereview-muted|) draws every group through a twin named
 `CodeReviewMuted.` plus the group it blends -- `CodeReviewMuted.CodeReviewAdd`,
 `CodeReviewMuted.@keyword`, and so on. A **faded** file (|codereview-faded|)
 carries a twin named `CodeReviewFaded.` plus the same, blended at

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -412,8 +412,8 @@ muted (background only)     { background = 0x001100, foreground = 0xff0000 }
 The first two lines are a window-local highlight namespace doing what `NormalNC` cannot; the
 third is the graceful failure that namespace keeps — a group with no variant in it stays
 bright rather than going wrong. `NormalNC` is adequate only on the file tree, which has
-almost no highlights of its own, and one mechanism for the three windows is worth more than
-that.
+almost no highlights of its own — and the tree is never muted now, so there is nothing left
+there for it to do.
 
 **That namespace holds links, and the link is what makes the blend reachable.** Each entry
 names the group that holds the blended colour — `CodeReviewMuted.` plus the group it blends,

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -41,12 +41,16 @@ M.defaults = {
   ---the archive existed. There is no keymap beside it yet; one can be added if the switch
   ---proves too blunt.
   archived = true, ---@type boolean
-  ---Draw every review window that does not have focus **muted**: its colours pulled toward
-  ---the background, so the focused window is the bright one and a reviewer never has to
-  ---press a key to find out where they are. The file tree is in the rule with the panes,
-  ---because it competes for focus with them, and the `cursorline` goes with it -- only the
-  ---focused window draws one, which is what stops the split layout lighting a row in both
-  ---panes while saying nothing about either.
+  ---Draw every **pane** that does not have focus **muted**: its colours pulled toward the
+  ---background, so the pane with focus is the bright one and a reviewer never has to press
+  ---a key to find out where they are. The `cursorline` goes with it -- only the pane with
+  ---focus draws one, which is what stops the split layout lighting a row in both panes
+  ---while saying nothing about either.
+  ---
+  ---**The file tree is never muted, and its row stays lit.** The tree is the map of the
+  ---review, and a muted map is harder to read for nothing in return: a tree looks nothing
+  ---like a diff, so no colour is needed to tell the two apart. Focus landing in the tree
+  ---still mutes the panes, so the rule above stays true of them.
   ---
   ---On by default, and coarse the way `archived` is: off is nothing muted, nothing
   ---computed and no highlight namespace attached to any window, for a reviewer whose own

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -225,6 +225,10 @@ end
 ---layout toggle rebuilt and a tree dismissed and summoned again join the set on the same
 ---line that gives them their options, rather than by a caller remembering to say so.
 ---
+---Enrolment says two things: which windows `mute` walks, and which windows can move the
+---bright latch. The tree is here for the second. `mute` walks it too, but only to keep it
+---bright -- see there.
+---
 ---Module-level, because `window_opts` is handed a window and nothing else. Windows that
 ---have gone are dropped as they are found, and every read is filtered to the review's own
 ---tab page as well, so a window id Neovim reuses after a review closed cannot inherit a
@@ -269,9 +273,10 @@ function M.window_opts(win)
   vim.wo[win].relativenumber = false
   vim.wo[win].signcolumn = "no"
   vim.wo[win].foldcolumn = "0"
-  -- What a window opens with rather than what it keeps: with muting on, `cursorline`
-  -- becomes a function of focus and `mute` owns it from here. This is what a review window
-  -- looks like with muting off, which is what it looked like before muting existed.
+  -- What a **pane** opens with rather than what it keeps: with muting on, a pane's
+  -- `cursorline` becomes a function of focus and `mute` owns it from here. The file tree
+  -- keeps this one, because `mute` never touches it. With muting off every review window
+  -- keeps it, which is what a review looked like before muting existed.
   vim.wo[win].cursorline = true
   vim.wo[win].list = false
   vim.wo[win].spell = false
@@ -364,7 +369,7 @@ function M.recolour()
   M.mute_extend()
 end
 
----Mute every review window except the one focus last landed in.
+---Mute every **pane** except the one focus last landed in, and leave the file tree bright.
 ---
 ---**The bright one is the review's last-focused window, not the current one.** That is what
 ---makes a float change nothing: the composer, the queue float and the archive float all
@@ -372,6 +377,22 @@ end
 ---would mute the entire review the moment a reviewer started typing a note. The latch moves
 ---only when focus lands on a review window, and a latch naming a window that has gone
 ---answers the after pane -- the same default `focused_pane` takes for a caller in neither.
+---
+---**The file tree is never muted, and it still moves the latch.** A muted map is harder to
+---read than a bright one and buys nothing back: a tree looks nothing like a diff, so no
+---colour is needed to tell the two apart. The tree keeps the other half of the rule --
+---focus landing in it mutes the panes -- so "the muted window is the one I am not in" stays
+---true of the panes, and the tree is not part of that statement. It is named from the
+---`CRView` this is already handed, so no second set of windows is kept and no flag is put
+---on a window.
+---
+---**The tree is set bright rather than passed over.** A window id that carried the
+---namespace at some earlier moment would otherwise keep it.
+---
+---**The tree's `cursorline` is left alone**, so it keeps the one `window_opts` gives it. The
+---rule that lights one row at a time is about the panes: `cursorbind` holds them on the same
+---row, and two lit rows would say nothing about either. The tree is not cursorbound and its
+---lit row follows the diff cursor, so a lit row there names the file being read.
 ---
 ---With muting off this returns having done nothing at all: no namespace is attached to
 ---anything, no colour is computed, and `cursorline` is left as `window_opts` set it.
@@ -383,11 +404,13 @@ function M.mute(V)
   M.mute_extend()
   local bright = (V.focus_win and vim.api.nvim_win_is_valid(V.focus_win)) and V.focus_win or V.win
   for _, win in ipairs(review_windows(V)) do
-    local focused = win == bright
-    -- One lit row means one thing: in the split layout `cursorbind` holds both panes on the
-    -- same row, so two cursorlines say nothing about either.
-    vim.wo[win].cursorline = focused
-    vim.api.nvim_win_set_hl_ns(win, focused and 0 or NS_MUTED)
+    if win == V.panel_win then
+      vim.api.nvim_win_set_hl_ns(win, 0)
+    else
+      local focused = win == bright
+      vim.wo[win].cursorline = focused
+      vim.api.nvim_win_set_hl_ns(win, focused and 0 or NS_MUTED)
+    end
   end
 end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,7 +61,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `faded_spec` | Every file but the one the cursor is in: what a review draws when it opens, the crossing, the hunk that changes nothing, the header left bright, both panes, a repaint that moves the rows, an empty review, the two families of blended groups, the switch — the two traps, `syntax = false` and a scroll past the last paint — and the cells three child processes read |
-| `muted_spec` | The review window without focus: which window is bright, the namespace and the `cursorline` that follow focus, a float changing nothing, a rebuilt pane and a re-summoned tree, the group left bright on purpose, the colorscheme change, the switch — and the cells four child processes read |
+| `muted_spec` | The **pane** without focus: which pane is bright, the namespace and the `cursorline` that follow focus, the file tree never muted — bright with its row lit under every focus, and still muting the panes in both layouts when focus lands in it — a float changing nothing, a rebuilt pane and a re-summoned tree, the group left bright on purpose, the colorscheme change, the switch — and the cells four child processes read |
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colours one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
@@ -255,12 +255,13 @@ so the out-of-core language path is still checked locally without ever failing C
   comes back in a *different* buffer carrying the same mappings, and drives one of them
   through the keys. Without that, a panel that comes back with no keymaps at all passes.
 - **A window option is reasserted downstream, so deleting the line that sets it proves
-  nothing.** `cursorline` is set in `view_layout.window_opts` where a review window is built
-  and then set again, as a function of focus, everywhere focus is decided — so a teeth check
-  that removes it from the helper reds nothing that matters. Break the muting where focus is
-  decided instead: mute against the *current* window rather than the view's latch, and the
-  float cases go red; stop recomputing on `WinEnter`/`WinLeave`, and everything about which
-  window is bright does.
+  nothing — except on the file tree.** `cursorline` is set in `view_layout.window_opts` where
+  a review window is built, and set again on the **panes**, as a function of focus, everywhere
+  focus is decided. So a teeth check that removes it from the helper reds the tree's lit row,
+  which the helper alone gives it, and nothing about the panes at all. Break the muting where
+  focus is decided instead: mute against the *current* window rather than the view's latch,
+  and the float cases go red; stop recomputing on `WinEnter`/`WinLeave`, and everything about
+  which pane is bright does.
 - **No fixture is both tall and multilingual, so one line of the muting has no spec.**
   `view.lua` widens the muted namespace at two moments, and only one of them can be
   measured here. A paint that parses a file is reached by `muted_spec`'s scope change;

--- a/tests/codereview/muted_spec.lua
+++ b/tests/codereview/muted_spec.lua
@@ -1,4 +1,8 @@
--- A review window without focus is **muted**.
+-- A **pane** without focus is **muted**. The file tree never is.
+--
+-- The tree keeps the other half of the rule: focus landing in it still mutes the panes, so
+-- "the muted window is the one I am not in" stays true of the panes and says nothing about
+-- the tree.
 --
 -- Asserted at the altitude a reviewer's editor actually holds it: the highlight namespace
 -- each review window is drawing through, and its `cursorline`. Never the functions that set
@@ -169,25 +173,62 @@ describe("a review in the split layout with the tree open", function()
     assert.is_true(config.get().muted.enabled)
   end)
 
-  it("leaves the focused pane bright and mutes the other two", function()
-    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
+  it("leaves the focused pane bright and mutes the other one", function()
+    assert.same({ after = "bright", before = "muted", tree = "bright" }, arrangement())
   end)
 
-  it("lights one row, in the window that has focus", function()
-    assert.same({ after = true, before = false, tree = false }, cursorlines())
+  it("lights one row in the panes, in the one that has focus", function()
+    assert.same({ after = true, before = false, tree = true }, cursorlines())
   end)
 
   it("moves the brightness with focus, from one pane to the other", function()
     vim.api.nvim_set_current_win(V.before_win)
-    assert.same({ after = "muted", before = "bright", tree = "muted" }, arrangement())
-    assert.same({ after = false, before = true, tree = false }, cursorlines())
+    assert.same({ after = "muted", before = "bright", tree = "bright" }, arrangement())
+    assert.same({ after = false, before = true, tree = true }, cursorlines())
   end)
 
   it("moves it between a pane and the tree, in both directions", function()
     vim.api.nvim_set_current_win(V.panel_win)
     assert.same({ after = "muted", before = "muted", tree = "bright" }, arrangement())
     vim.api.nvim_set_current_win(V.win)
-    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
+    assert.same({ after = "bright", before = "muted", tree = "bright" }, arrangement())
+  end)
+end)
+
+--- The tree, under every focus ----------------------------------------------------
+
+-- Each of the three windows in turn rather than the one a mistake is most likely to be made
+-- in: what is claimed is about the tree and not about which pane is bright.
+describe("the file tree", function()
+  local V = assert(view.current(), "no review view open")
+  local windows = { after = V.win, before = V.before_win, tree = V.panel_win }
+
+  it("is never muted, whichever window has focus", function()
+    local drawn = {}
+    for name, win in pairs(windows) do
+      vim.api.nvim_set_current_win(win)
+      drawn[name] = arrangement().tree
+    end
+    assert.same({ after = "bright", before = "bright", tree = "bright" }, drawn)
+  end)
+
+  it("keeps a lit row, whichever window has focus", function()
+    local lit = {}
+    for name, win in pairs(windows) do
+      vim.api.nvim_set_current_win(win)
+      lit[name] = cursorlines().tree
+    end
+    assert.same({ after = true, before = true, tree = true }, lit)
+  end)
+
+  -- The half of the rule the tree keeps. A tree taken out of the rule whole would leave this
+  -- one arrangement unreachable, and muting nothing at all in the unified layout.
+  it("still mutes both panes of the split layout when focus lands in it", function()
+    vim.api.nvim_set_current_win(V.win)
+    assert.same({ after = "bright", before = "muted", tree = "bright" }, arrangement())
+    vim.api.nvim_set_current_win(V.panel_win)
+    assert.same({ after = "muted", before = "muted", tree = "bright" }, arrangement())
+    assert.same({ after = false, before = false, tree = true }, cursorlines())
   end)
 end)
 
@@ -201,7 +242,7 @@ describe("focus moved with an ordinary window-switch key", function()
     vim.api.nvim_set_current_win(V.win)
     h.feed("<C-w>h")
     assert.same(V.before_win, vim.api.nvim_get_current_win())
-    assert.same({ after = "muted", before = "bright", tree = "muted" }, arrangement())
+    assert.same({ after = "muted", before = "bright", tree = "bright" }, arrangement())
   end)
 
   it("reaches the tree the same way", function()
@@ -259,7 +300,7 @@ describe("a float taking focus", function()
 
   it("leaves every review window exactly as it was", function()
     assert.same(was, arrangement())
-    assert.same({ after = true, before = false, tree = false }, cursorlines())
+    assert.same({ after = true, before = false, tree = true }, cursorlines())
   end)
 
   if composer and vim.api.nvim_win_is_valid(composer) then
@@ -289,7 +330,7 @@ describe("a float taking focus", function()
 
   it("leaves every review window exactly as it was, again", function()
     assert.same(was, arrangement())
-    assert.same({ after = true, before = false, tree = false }, cursorlines())
+    assert.same({ after = true, before = false, tree = true }, cursorlines())
   end)
 
   if float and vim.api.nvim_win_is_valid(float) then
@@ -309,7 +350,7 @@ describe("a float taking focus", function()
 
   it("leaves every review window exactly as it was, a third time", function()
     assert.same(was, arrangement())
-    assert.same({ after = true, before = false, tree = false }, cursorlines())
+    assert.same({ after = true, before = false, tree = true }, cursorlines())
   end)
 
   if archive and vim.api.nvim_win_is_valid(archive) then
@@ -320,22 +361,32 @@ end)
 
 --- Windows the review builds again ------------------------------------------------
 
-describe("a pane rebuilt by a layout toggle", function()
+describe("a layout toggle", function()
   local V = assert(view.current(), "no review view open")
   vim.api.nvim_set_current_win(V.win)
   view.toggle_layout()
 
   it("leaves the unified layout with one pane and the tree", function()
     assert.is_nil(V.before_win)
-    assert.same({ after = "bright", before = nil, tree = "muted" }, arrangement())
+    assert.same({ after = "bright", before = nil, tree = "bright" }, arrangement())
+  end)
+
+  -- The unified layout is where the tree earns the half of the rule it keeps: with one pane
+  -- beside it, a tree out of the rule whole would leave muting nothing to do here at all.
+  it("mutes that one pane when focus lands in the tree", function()
+    vim.api.nvim_set_current_win(V.panel_win)
+    assert.same({ after = "muted", before = nil, tree = "bright" }, arrangement())
+    assert.same({ after = false, tree = true }, cursorlines())
+    vim.api.nvim_set_current_win(V.win)
+    assert.same({ after = "bright", before = nil, tree = "bright" }, arrangement())
   end)
 
   view.toggle_layout()
 
   it("mutes the pane that comes back, without waiting for the next focus change", function()
     assert.is_truthy(V.before_win)
-    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
-    assert.same({ after = true, before = false, tree = false }, cursorlines())
+    assert.same({ after = "bright", before = "muted", tree = "bright" }, arrangement())
+    assert.same({ after = true, before = false, tree = true }, cursorlines())
   end)
 end)
 
@@ -351,10 +402,10 @@ describe("a tree dismissed and summoned again", function()
 
   view.toggle_panel()
 
-  it("mutes the tree that comes back, in a buffer nothing bound anything to before", function()
+  it("comes back bright, with its row lit, in a window built after the review opened", function()
     assert.is_truthy(V.panel_win)
-    assert.same({ after = "bright", before = "muted", tree = "muted" }, arrangement())
-    assert.same({ after = true, before = false, tree = false }, cursorlines())
+    assert.same({ after = "bright", before = "muted", tree = "bright" }, arrangement())
+    assert.same({ after = true, before = false, tree = true }, cursorlines())
   end)
 end)
 


### PR DESCRIPTION
The file tree is never **muted**. It draws in the active colorscheme's own colours and keeps
its row lit, whichever review window has focus.

The tree keeps the other half of the rule: it still decides which **pane** is bright. Focus
landing in it mutes the panes — both of them in the split layout, the one of them in the
unified layout — so "the muted window is the one I am not in" stays true of the panes, and
the tree is not part of that statement.

## What changed

- `view_layout.mute` names the tree from the `CRView` it is already handed. No second set of
  windows is kept and no flag is put on a window.
- The tree is **set bright**, not skipped: the pass hands it the global namespace, so a
  window id that carried the muted namespace at some earlier moment cannot keep it. With
  `muted.enabled = false` the pass still returns early and touches nothing.
- The tree's `cursorline` is left where `window_opts` put it. The one-lit-row rule exists
  because `cursorbind` holds the two panes on the same row; the tree is not cursorbound, and
  its lit row follows the diff cursor, so it names the file being read.
- The tree stays enrolled, so no caller of the shared options helper changes and its own
  module is untouched. No configuration key is added, and the blended groups, the namespace
  and the colorscheme pass are all as they were.

## Documents

The `muted` docstring, the **Muted** entry in `CONTEXT.md`, the `README.md` muting section
and configuration reference, the `codereview-muted` help section and configuration reference,
and the muting spec's row in the tests README all state the new rule. Two more that the
change falsified: the tests README bullet on `cursorline` being reasserted downstream, which
is now true of the panes only, and the trailing clause of the `NormalNC` note in the design
notes. The measurement itself is untouched.

## Spec

`muted_spec` states the new rule: the tree bright under every focus, its row lit under every
focus, and the tree still moving the bright latch in both layouts. Its child process is
unchanged — it mutes a pane by moving focus into the tree, and that still mutes.

Red before the implementation, 15 failures; green after it, `make all` at exit 0 with 1280
passing.

Closes #117