### PR TITLE
feat(view): read the last batch with gb, and turn archived entries off with gA

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,9 +435,11 @@ an answer anywhere but the agent's transcript. `:CodeReviewLastBatch` gives it o
 annotations of the batch that went last, grouped by type exactly as the queue float and the
 payload group them, with the target it went to and when it went in the frame.
 
-It needs no review open — a batch is not a window, and what you asked for is worth checking
-from anywhere. A bare note is listed like anything else, even though it was kept in a
-different store than the annotations with a file behind them.
+`gb` opens that same float from inside a review, in the diff and in the tree, so which
+window you are in never decides whether the key exists. The command needs no review open —
+a batch is not a window, and what you asked for is worth checking from anywhere. A bare note
+is listed like anything else, even though it was kept in a different store than the
+annotations with a file behind them.
 
 It is **read-only**, and that is a statement about the record rather than a feature left
 out. An archived entry says something happened; a surface that let you drop, edit or
@@ -544,6 +546,7 @@ worth a look before we ship this
 | `gr` | Re-read the diff from git |
 | `gp` | Show or hide the file tree |
 | `gl` | Switch between the unified and split layouts |
+| `gb` | Read the last dispatched batch back |
 | `<CR>` | Open the real file here, in a new tab |
 | `gd` | Read this file in your own diff tool — only bound with [`open_diff`](#adapters) wired |
 | `Q` | Review the queue |
@@ -588,6 +591,7 @@ is to stop looking at them, so the useful motion is "the next thing I have not d
 | `<Tab>` | Back to the diff |
 | `gp` | Dismiss the tree, landing back in the diff |
 | `gl` | Switch between the unified and split layouts |
+| `gb` | Read the last dispatched batch back |
 | `q` | Close |
 
 Jumping to a file that was collapsed because it is reviewed expands it: you asked to look
@@ -615,9 +619,9 @@ listing is still there.
 
 ### In the last-batch float
 
-`:CodeReviewLastBatch` lists an annotation the same way — the reserved gutter, the bar in
-its type's colour, the code it inlined and its note — so the two read as one family. What
-is missing is every key that would change something.
+`gb`, or `:CodeReviewLastBatch` from anywhere, lists an annotation the same way — the
+reserved gutter, the bar in its type's colour, the code it inlined and its note — so the two
+read as one family. What is missing is every key that would change something.
 
 | Key | Action |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -465,6 +465,19 @@ Their two highlight groups are their own — `CodeReviewArchived` for the marker
 here, so a colorscheme can say how dim "already sent" looks. `archived = false` turns them
 off wholesale, and the diff then renders exactly as it did before the archive existed.
 
+**`gA` reaches that switch from inside a review**, in the diff and in the tree. On a fresh
+review over code you already annotated they are noise — you are looking for what is wrong
+now, and the diff is covered in what was already said — so one key takes them off, and the
+same key brings them back. It repaints at once and runs in both directions: with
+`archived = false` configured, `gA` turns them on.
+
+It overrides the configured value instead of writing it, so your `setup()` call goes on
+saying what you wrote. The override holds for every review you open afterwards — you press
+the key once, not once per review — and it dies with the Neovim process, so a display
+preference never becomes durable state you forgot you set. Off is off entirely, exactly as
+the flag is: the `untouched` tally leaves the winbar with the entries, and no git is spent
+judging them.
+
 ### Where the agent has and has not been
 
 Each entry of the **last** batch says whether its file has changed since that batch was
@@ -497,8 +510,8 @@ That the scope decides who is judged is why the tally reads `0 untouched` inside
 touched by definition, and the ones you are looking for are the ones it is not showing.
 `branch` and `worktree` are where the number earns its keep.
 
-`CodeReviewTouched` and `CodeReviewUntouched` are the groups, and `archived = false` turns
-the tally off along with everything else.
+`CodeReviewTouched` and `CodeReviewUntouched` are the groups, and `archived = false` — or
+`gA` while you are reviewing — turns the tally off along with everything else.
 
 ### The payload
 
@@ -547,6 +560,7 @@ worth a look before we ship this
 | `gp` | Show or hide the file tree |
 | `gl` | Switch between the unified and split layouts |
 | `gb` | Read the last dispatched batch back |
+| `gA` | Show or hide archived entries, for the rest of the session |
 | `<CR>` | Open the real file here, in a new tab |
 | `gd` | Read this file in your own diff tool — only bound with [`open_diff`](#adapters) wired |
 | `Q` | Review the queue |
@@ -592,6 +606,7 @@ is to stop looking at them, so the useful motion is "the next thing I have not d
 | `gp` | Dismiss the tree, landing back in the diff |
 | `gl` | Switch between the unified and split layouts |
 | `gb` | Read the last dispatched batch back |
+| `gA` | Show or hide archived entries, for the rest of the session |
 | `q` | Close |
 
 Jumping to a file that was collapsed because it is reviewed expands it: you asked to look
@@ -643,7 +658,8 @@ opts = {
   layout = "unified",              -- "unified" or "split"; validated at setup
   spans = true,                    -- emphasise what changed inside a changed line
   archived = true,                 -- draw already-dispatched entries on the diff, dimmed,
-                                   -- and tally the untouched ones on the winbar
+                                   -- and tally the untouched ones on the winbar; `gA`
+                                   -- overrides this for the rest of the session
   muted = { enabled = true,        -- mute the pane that does not have focus; never the tree
             strength = 0.5 },      -- how far its colours are pulled toward the background
   faded = { enabled = true,        -- fade every file except the one the cursor is in

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -97,6 +97,8 @@ Buffer-local, inside the review view:
     gp               Show or hide the file tree
     gl               Switch between the unified and split layouts
     gb               Read the last dispatched batch back
+    gA               Show or hide archived entries, for the rest of the
+                     session -- see |codereview-archived|
     <CR>             Open the real file here, in a new tab
     gd               Read this file in the host's own diff tool --
                      bound only with |codereview-opt-open_diff| wired
@@ -139,6 +141,8 @@ In the file tree:                                         *codereview-tree*
     gp               Dismiss the tree, landing back in the diff
     gl               Switch between the unified and split layouts
     gb               Read the last dispatched batch back
+    gA               Show or hide archived entries, for the rest of the
+                     session -- see |codereview-archived|
     q                Close the review
 
 The tree collapses single-child directory chains, so a monorepo shows
@@ -556,6 +560,15 @@ one, for the same reason |:CodeReviewLastBatch| is read-only. `archived =
 false` turns the whole of this off, and the diff then renders exactly as it
 did before the archive existed.
 
+`gA`, in the diff and in the file tree, reaches the same switch from inside a
+review. It repaints at once, it runs in both directions -- with `archived =
+false` configured it turns them on -- and it overrides the configured value
+rather than writing it, so `setup()` goes on saying what you wrote. The
+override holds for every review opened afterwards and dies with the Neovim
+process: a display preference never becomes durable state you forgot you set.
+Off is off entirely, so the `untouched` tally (|codereview-touched|) leaves
+the winbar with the entries and no `git` is spent judging them.
+
 Touched and untouched                                  *codereview-touched*
 
 Each entry of the *last* batch says whether its file has changed since that
@@ -862,8 +875,9 @@ read rather than every time the view is drawn.
 
 `archived` draws already-dispatched entries on the diff and tallies the
 untouched ones on the winbar (|codereview-archived|, |codereview-touched|).
-It is on by default and coarse on purpose: off is the whole history off --
-nothing drawn, nothing tallied and no `git` spent judging.
+It is on by default and coarse on purpose: off is the whole archive off --
+nothing drawn, nothing tallied and no `git` spent judging. `gA` overrides it
+for the rest of the session, in both directions, and writes nothing here.
 
 `muted` mutes the pane that does not have focus (|codereview-muted|); the
 file tree is never muted. `strength` is how far a colour is pulled toward the

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -59,7 +59,8 @@ files without one fall back to flat diff colours.
         it went to and when it went in the frame. Needs no review view open --
         a batch is not a window. A bare note is listed like anything else,
         though it was kept in a different store. With nothing dispatched yet
-        it says so rather than opening onto nothing.
+        it says so rather than opening onto nothing. Also bound to `gb` in the
+        diff and in the file tree, which opens this same float.
 
         Read-only, and that is a claim about the record: an archived entry
         says something happened, and a surface that let you drop, edit or
@@ -95,6 +96,7 @@ Buffer-local, inside the review view:
     gr               Re-read the diff from git
     gp               Show or hide the file tree
     gl               Switch between the unified and split layouts
+    gb               Read the last dispatched batch back
     <CR>             Open the real file here, in a new tab
     gd               Read this file in the host's own diff tool --
                      bound only with |codereview-opt-open_diff| wired
@@ -136,6 +138,7 @@ In the file tree:                                         *codereview-tree*
     <Tab>            Back to the diff
     gp               Dismiss the tree, landing back in the diff
     gl               Switch between the unified and split layouts
+    gb               Read the last dispatched batch back
     q                Close the review
 
 The tree collapses single-child directory chains, so a monorepo shows
@@ -161,8 +164,8 @@ view open, and a file may lie outside the current scope. Each says which, and
 leaves the float open -- the remedies are nothing, open a review, and change
 scope.
 
-In the last-batch float (|:CodeReviewLastBatch|): q and <Esc> close, and that
-is the whole of it. `x` and <C-s> are bound only to say why they do nothing,
+In the last-batch float (`gb`, or |:CodeReviewLastBatch| from anywhere): q and
+<Esc> close, and that is the whole of it. `x` and <C-s> are bound only to say why they do nothing,
 so the queue float's muscle memory gets a sentence rather than |E21| against a
 |nomodifiable| buffer. An annotation is drawn there exactly as the queue float
 draws one -- the reserved gutter, the bar in its type's colour, the code it

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -379,6 +379,26 @@ and the view's own submit, and the number is read off the view. The view also re
 repaint of its own, so a paint that finds the count moved drops the verdicts and the segment
 with them, rather than reporting a number about a batch that has been overtaken.
 
+**The switch a key overrides is read through an accessor, and the key writes no
+configuration.** `gA` is a runtime override of `archived`. It sits beside the configured
+value in `config`, is unset until the key is pressed, and unset means the configured value.
+Writing that value instead would leave a host's own `setup()` call describing something that
+is no longer true, and it would make a keystroke indistinguishable from a decision the host
+made. It is module state rather than view state because the choice has to outlive a review —
+a reviewer presses the key once, not once per review — and it is deliberately not persisted,
+for the reason the chosen **layout** is not: a display preference must never become durable
+state a reviewer has forgotten they set. What this costs is that every reader of the flag has
+to go through `config.archived()`. A `config.get().archived` left behind anywhere is a
+surface the key silently does not reach.
+
+**Toggling it has to judge before it paints, and a paint alone will not drop the tally.**
+The `untouched` segment is read off the view rather than computed by the winbar, and a paint
+only drops it when the archive has been *written* since the last verdict — which turning the
+switch off is not. So a toggle that merely repaints leaves the number on the bar while
+nothing it counts is on the diff, which is the one state this feature's coarseness exists to
+refuse. `view.toggle_archived` runs the judgement itself, and that is also where the two
+`git` invocations behind the number are skipped when the answer is "nothing drawn".
+
 **`git stash create` mints a commit and does nothing else.** No ref moves, the index is not
 touched and the working tree is not reverted, which is the only reason it is safe to run
 behind a submit. Two consequences worth knowing before reading a snapshot back: a clean

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -36,10 +36,10 @@ M.defaults = {
   ---Each of them says whether its file has been **touched** since its batch went, and the
   ---winbar tallies how many have not.
   ---
-  ---On by default, and coarse on purpose -- off is the whole history off: nothing drawn,
+  ---On by default, and coarse on purpose -- off is the whole archive off: nothing drawn,
   ---nothing tallied, no git spent judging, and the diff renders exactly as it did before
-  ---the archive existed. There is no keymap beside it yet; one can be added if the switch
-  ---proves too blunt.
+  ---the archive existed. `gA` overrides this while a session lasts, in both directions, and
+  ---never writes here -- see `M.archived` below.
   archived = true, ---@type boolean
   ---Draw every **pane** that does not have focus **muted**: its colours pulled toward the
   ---background, so the pane with focus is the bright one and a reviewer never has to press
@@ -262,6 +262,46 @@ function M.get()
     M.options.types = resolve_types(M.options)
   end
   return M.options
+end
+
+--- The archived switch at runtime ----------------------------------------------
+
+---What `gA` has said about **archived** entries, for the rest of this editing session.
+---
+---Beside the configured value rather than written over it. A key that edited `M.options`
+---would leave a host's own `setup()` call describing something that is no longer true, and
+---a reviewer reading their configuration back would be told the wrong thing by the file
+---they wrote themselves.
+---
+---Module-level rather than on the review view, because the choice has to outlive one: a
+---reviewer who pressed the key once is not quietly put back by opening the next review.
+---Deliberately not persisted either, for the reason the chosen **layout** is not -- a
+---display preference must never become durable state a reviewer has forgotten they set.
+---A module local lasts exactly as long as it should: until Neovim exits, after which
+---configuration decides again.
+---@type boolean|nil nil until the key has been pressed, when configuration decides
+local archived_override = nil
+
+---Whether **archived** entries are drawn, tallied and judged at all.
+---
+---Read wherever the flag itself is read. Unset means the configured value, which is what
+---makes `setup()` the answer at the start of every session.
+---@return boolean
+function M.archived()
+  if archived_override == nil then
+    return M.get().archived
+  end
+  return archived_override
+end
+
+---Turn archived entries on or off for the rest of this editing session.
+---
+---Both directions from wherever the switch stands now, so a reviewer whose configuration
+---has them off can turn them on.
+---@return boolean on Whether they are now drawn
+function M.toggle_archived()
+  archived_override = not M.archived()
+  return archived_override
 end
 
 return M

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -114,6 +114,9 @@ function M.diff(buf, view)
     -- From the `g` family the other view-level commands come from, and clear of `gt`/`gT`,
     -- which are how `<CR>`'s new tab is returned from.
     ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
+    -- `gb` for the **batch**, from the same `g` family. It opens the surface the command
+    -- opens, so a reviewer reads one fact off one surface however they asked for it.
+    ["gb"] = { view.last_batch, "Read the last batch back" },
     ["<CR>"] = { view.open_file, "Open the real file here" },
     ["Q"] = { view.review_queue, "Review the queue" },
     -- `gy`, not `Y`: yank is not dead in this buffer the way append is, and pulling a code
@@ -199,6 +202,7 @@ function M.panel(buf, view)
     ["<Tab>"] = { view.toggle_focus, "Focus the diff" },
     ["gp"] = { view.toggle_panel, "Hide the file tree" },
     ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
+    ["gb"] = { view.last_batch, "Read the last batch back" },
     ["R"] = { view.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { view.close, "Close the review" },
   })

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -117,6 +117,9 @@ function M.diff(buf, view)
     -- `gb` for the **batch**, from the same `g` family. It opens the surface the command
     -- opens, so a reviewer reads one fact off one surface however they asked for it.
     ["gb"] = { view.last_batch, "Read the last batch back" },
+    -- `gA` for **archived** entries, and uppercase because `ga` is `:ascii`. It overrides
+    -- the configured switch for the session rather than editing it.
+    ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
     ["<CR>"] = { view.open_file, "Open the real file here" },
     ["Q"] = { view.review_queue, "Review the queue" },
     -- `gy`, not `Y`: yank is not dead in this buffer the way append is, and pulling a code
@@ -203,6 +206,7 @@ function M.panel(buf, view)
     ["gp"] = { view.toggle_panel, "Hide the file tree" },
     ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
     ["gb"] = { view.last_batch, "Read the last batch back" },
+    ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
     ["R"] = { view.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { view.close, "Close the review" },
   })

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -603,7 +603,7 @@ function M.paint(keep_file)
   -- the answer changes on a dispatch this view need not have made -- an **immediate send**
   -- archives a batch of one without emptying anything -- and the read behind it is a
   -- comparison until something has written.
-  V.archived = cfg.archived and require("codereview.archive").by_key(V.root) or {}
+  V.archived = config.archived() and require("codereview.archive").by_key(V.root) or {}
   -- What was judged against an archive that has since been overtaken describes something
   -- else now: an **immediate send** archives a batch of one with no repaint of its own, so
   -- the entries below may belong to a batch nothing has judged. Dropped rather than
@@ -1083,7 +1083,7 @@ local function judge_archive()
   if not V then
     return
   end
-  if not config.get().archived then
+  if not config.archived() then
     -- One switch turns the archive off in the review view outright: nothing drawn, nothing
     -- tallied, and no git spent deciding either.
     V.touched, V.untouched, V.judged = {}, nil, nil
@@ -1531,6 +1531,30 @@ end
 
 function M.toggle_layout()
   view_layout.toggle_layout(V, M)
+end
+
+--- Archived entries -------------------------------------------------------------
+
+-- The switch and the override in front of it are `config`'s, because the choice outlives
+-- this view: every review opened afterwards has to agree with it. What is left here is the
+-- name `keymaps.lua` binds to `gA` in the diff and in the tree, and the repaint that makes
+-- the answer immediate.
+
+---Turn **archived** entries on or off for the rest of the Neovim session.
+---
+---Off is off entirely, which is the switch's own coarseness rather than a middle state
+---invented here: nothing drawn, nothing tallied and no git spent judging, so the
+---`untouched` segment leaves the sticky header with the entries.
+---
+---Judged here rather than left to the paint, which also runs on every resize -- and
+---repainted rather than left to the next reason to repaint, because a reviewer who presses
+---a key is asking about the diff in front of them. Both calls do nothing with no review
+---open, which is a state this key cannot be pressed in but the exported action can be
+---called in: the override is still taken, and the next review opened agrees with it.
+function M.toggle_archived()
+  config.toggle_archived()
+  judge_archive()
+  M.paint()
 end
 
 --- Opening --------------------------------------------------------------------

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1495,6 +1495,16 @@ function M.review_queue()
   queue_float.open(M)
 end
 
+---Read the last dispatched **batch** back, from inside a review.
+---
+---The surface is `archive`'s, and it consults no view: a batch has already gone, so nothing
+---about which window is current could change which one went last. What stays here is the
+---name `keymaps.lua` binds to `gb` in both the diff and the file tree, so the key table does
+---not learn where the body lives -- exactly as `gp` and `gl` are named here.
+function M.last_batch()
+  require("codereview.archive").open()
+end
+
 function M.close()
   if V and vim.api.nvim_tabpage_is_valid(V.tab) then
     -- Closing the tab takes both windows and both scratch buffers with it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
 | `codereview/layout_child.lua` | Spawned by `layout_spec` — deliberately not a spec. |
+| `codereview/archived_child.lua` | Spawned by `render_spec` to archive a batch and turn archived entries off — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
 | `codereview/archive_child.lua` | Spawned by `archive_spec` to dispatch a batch and exit — deliberately not a spec. |
@@ -41,7 +42,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | --- | --- |
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
-| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them — how a winbar is assembled from typed segments, with no review, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, a name carrying a `%`, and a review with no files |
+| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, the flag that removes them and the key that overrides that flag in both directions, for a session — how a winbar is assembled from typed segments, with no review, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, a name carrying a `%`, and a review with no files |
 | `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, each pane's winbar naming its own side of a rename, and the painted cell proving that bar mutes with its pane |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
@@ -52,7 +53,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
 | `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, the four things it refuses, and the key that opens it from the diff and from the tree while the command still opens it from anywhere |
-| `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally, the three things left unjudged, which of three candidate blobs it is judged against, and that the queue's own staleness rule is untouched by any of it |
+| `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally and the two switches that take it away with the entries, the three things left unjudged, which of three candidate blobs it is judged against, and that the queue's own staleness rule is untouched by any of it |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
@@ -128,6 +129,38 @@ so the out-of-core language path is still checked locally without ever failing C
   back" would otherwise be satisfied by nothing coming back at all — the reviewed mark is
   what proves the store the two share is live. Its cases therefore have to run *first*,
   before this process has chosen a layout of its own.
+- **The `gA` cases have to sit at the end of `render_spec`, and what they are keeping clear
+  of is a winbar.** Opening a review is what runs `judge_archive`, and this file archives a
+  batch part-way down — so the first case that opens a review of its own is also the first to
+  put an `N untouched` segment on the **sticky header**, and every case below it then reads a
+  bar one segment longer than the one it was written against. The case that notices is `the
+  sticky header on a pane that has to choose`: at 45 columns the summary sheds its spares
+  first and then from its head, so one more segment pushes the shedding one step further and
+  the `0/N reviewed` tally that case asserts *survives* is exactly what goes. Measured rather
+  than predicted — a bare `view.reconcile()` above that block reds it, and nothing else in the
+  suite, on a bar reading `○ ▾ … → src/newname.lua  +1 -1  2 untouched` with the reviewed
+  tally gone. Nothing in that failure mentions archived entries or the key, which is what
+  makes it expensive: a case about `gA` breaks a case about narrow panes, and the two have
+  nothing to say to each other. Moving the block up the file brings it back, and so does
+  giving any earlier block a review of its own.
+- **A session-lived override can only be caught falling back to configuration once.** `gA`
+  overrides `archived` for the whole process, so "unset means the configured value" is
+  observable only while this process has not yet pressed the key. `render_spec`'s cases for
+  it therefore run last in that file and in one order: the child process first, whose whole
+  claim is what a *new* Neovim starts with, and then the direction a flag alone cannot go —
+  configured off, key on — which is the last case the override is still unset for. Reversed,
+  the configured value sits behind an override that agrees with nothing and both cases pass
+  whatever the accessor does. Same shape as `layout_spec`'s restart cases having to run
+  first. `archived_child.lua` archives a batch as well as pressing the key, for the reason
+  `layout_child.lua` marks a file reviewed: without something the store genuinely carries,
+  "the override did not come back" is satisfied by nothing coming back at all.
+- **The tally is what notices a toggle that forgot to judge.** Turning archived entries off
+  takes them off the diff whatever else the toggle skips, because a paint reads the switch —
+  so every case in `render_spec` passes either way. The winbar is where it shows: the
+  `untouched` segment is read off the view, and a paint drops it only when the *archive* has
+  been written since the last verdict, which turning a switch off is not. Deleting
+  `judge_archive()` from `view.toggle_archived` must red two cases in `touched_spec` and
+  nothing at all in `render_spec`.
 - **`norepo_spec` needs a directory that is genuinely outside a checkout**, and asserts it
   rather than assuming it. If the temp directory ever sits inside a repository, every case
   about a "loose" file silently becomes a test of the ordinary in-repository path.

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
-| `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, and the four things it refuses |
+| `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, the four things it refuses, and the key that opens it from the diff and from the tree while the command still opens it from anywhere |
 | `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally, the three things left unjudged, which of three candidate blobs it is judged against, and that the queue's own staleness rule is untouched by any of it |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |

--- a/tests/codereview/archive_float_spec.lua
+++ b/tests/codereview/archive_float_spec.lua
@@ -179,6 +179,21 @@ local function extent(buf, index)
   return first, last
 end
 
+---Normal-mode mappings bound to a buffer, as a set.
+---
+---Through `vim.keycode` on both sides: the API reports a key in its own notation rather
+---than the one it was bound with, so comparing the strings as written can silently never
+---match.
+---@param buf integer
+---@return table<string, boolean>
+local function bound(buf)
+  local lhs = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+    lhs[vim.keycode(m.lhs)] = true
+  end
+  return lhs
+end
+
 ---A window's title or footer, as one string.
 ---@param win integer
 ---@param field "title"|"footer"
@@ -522,6 +537,90 @@ describe("opened with a review view on screen", function()
   end)
 
   codereview.close()
+end)
+
+--- The key beside the command ---------------------------------------------------
+
+-- `gb` names the **batch**, and it opens the surface the command opens rather than one of
+-- its own: there is one surface for one fact. Bound in the diff and in the tree, so which
+-- window a reviewer is in never decides whether a key exists.
+describe("the key inside a review", function()
+  fresh()
+  queued({ note = "already gone" })
+  dispatch()
+
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+
+  ---The float `gb` opens from one of the review's windows, as rows and frame.
+  ---
+  ---Guarded as a *float* rather than merely as another window: a key that is not bound at
+  ---all leaves focus where it was, and "somewhere other than the diff" is then satisfied by
+  ---the tree — which would read the tree's own rows and close the review with the `q` below.
+  ---@param from integer The window to press it in
+  ---@return string[] rows, string title
+  local function by_key(from)
+    vim.api.nvim_set_current_win(from)
+    h.feed("gb")
+    local win = vim.api.nvim_get_current_win()
+    assert.are_not.same(from, win, "gb opened no window of its own")
+    assert.are_not.same("", vim.api.nvim_win_get_config(win).relative, "gb opened no float")
+    local out = { lines(vim.api.nvim_win_get_buf(win)), chrome(win, "title") }
+    h.feed("q")
+    return out[1], out[2]
+  end
+
+  it("is bound in the diff and in the tree", function()
+    assert.is_true(bound(review.buf)[vim.keycode("gb")] == true, "gb is not bound in the diff")
+    assert.is_true(bound(assert(review.panel_buf))[vim.keycode("gb")] == true, "gb is not bound in the tree")
+  end)
+
+  -- Opening a file from the review is a new tab, and `gt`/`gT` are how a reviewer comes
+  -- back from it. The `g` family this joins may take neither.
+  it("shadows neither of the tab-switching keys", function()
+    for _, buf in ipairs({ review.buf, assert(review.panel_buf) }) do
+      assert.is_nil(bound(buf)[vim.keycode("gt")], "gt is shadowed")
+      assert.is_nil(bound(buf)[vim.keycode("gT")], "gT is shadowed")
+    end
+  end)
+
+  it("opens the same float the command opens, pressed in the diff", function()
+    local rows, title = by_key(review.win)
+    local win, buf = open_float()
+    local commanded, commanded_title = lines(buf), chrome(win, "title")
+    h.feed("q")
+    assert.same(commanded, rows)
+    assert.same(commanded_title, title)
+  end)
+
+  it("opens it from the file tree as well", function()
+    local rows = by_key(assert(review.panel_win, "no file tree"))
+    assert.is_true(vim.tbl_contains(rows, note_row("already gone")), table.concat(rows, "\n"))
+  end)
+
+  it("leaves the review it was pressed in on screen", function()
+    assert.same(review, view.current())
+    assert.is_true(vim.api.nvim_win_is_valid(review.win))
+  end)
+
+  codereview.close()
+end)
+
+-- The plugin binds no global mappings, and this key changes nothing about that: a host
+-- that wants the batch one keystroke away from anywhere maps the command itself.
+describe("the key outside a review", function()
+  it("is bound nowhere globally", function()
+    for _, m in ipairs(vim.api.nvim_get_keymap("n")) do
+      assert.are_not.same(vim.keycode("gb"), vim.keycode(m.lhs), "gb is mapped globally")
+    end
+  end)
+
+  it("leaves the command opening the float with no review open", function()
+    assert.is_false(codereview.is_open())
+    local _, buf = open_float()
+    assert.is_true(vim.tbl_contains(lines(buf), note_row("already gone")), table.concat(lines(buf), "\n"))
+    h.feed("q")
+  end)
 end)
 
 --- Wrapping ----------------------------------------------------------------------

--- a/tests/codereview/archived_child.lua
+++ b/tests/codereview/archived_child.lua
@@ -1,0 +1,58 @@
+-- The first half of render_spec's restart proof: a Neovim that turns archived entries off
+-- and then exits.
+--
+-- Deliberately a separate process. "The override dies with the session" is a claim about
+-- what a *new* Neovim starts with, and no assertion made in the process that pressed the
+-- key can settle it: a module local cleared by hand says nothing about what reached the
+-- disk, and an assertion made here would pass however the override were stored.
+--
+-- It also archives a batch, which the store genuinely does carry. That is what lets the
+-- next session prove the channel between the two is live before concluding the override is
+-- not on it: without it, "the override did not come back" would be satisfied by nothing
+-- coming back at all.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- render_spec with XDG_STATE_HOME and FIXTURE in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+require("codereview").setup({ archived = true, syntax = false })
+
+local config = require("codereview.config")
+local render = require("codereview.render")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+-- Resolved, because the archive is keyed on the root git answers with, and git answers with
+-- symlinks resolved.
+local root = assert(vim.uv.fs_realpath(fixture))
+local path = "src/main.lua"
+
+state.archive_batch({
+  {
+    id = 1,
+    type = "bug",
+    kind = "file",
+    path = path,
+    key = render.file_key(path),
+    note = "from the session that turned them off",
+  },
+}, "agent", root)
+
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+assert(next(V.archived) ~= nil, "the child never drew an archived entry to turn off")
+
+view.toggle_archived()
+assert(config.archived() == false, "the child never reached the off state")
+assert(next(view.current().archived) == nil, "the child is still drawing archived entries")
+assert(config.get().archived == true, "the child wrote the configured value")
+
+-- Printed so a failing render_spec can show what the session that pressed the key believed
+-- it did. `nvim -l` sends this to stderr, not stdout.
+print(("archived off; state file: %s"):format(state.path(root)))
+vim.cmd("qa!")

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -686,3 +686,142 @@ describe("the sticky header on a review with no files", function()
     assert.is_nil(bar():find(icons.expanded, 1, true), bar())
   end)
 end)
+
+--- The key beside the flag -----------------------------------------------------
+
+-- `gA` overrides the flag above for the rest of this Neovim, in both directions.
+--
+-- Last in this file, and deliberately. The override is module state, not view state, so it
+-- outlives every review opened here, and each case below opens a review of its own -- which
+-- makes a tally the winbar had not carried before. Nothing above may inherit either.
+--
+-- The order inside is the order `layout_spec`'s restart cases run in, for the same reason:
+-- "unset means the configured value" is only observable while this process has not yet
+-- pressed the key.
+
+---Normal-mode mappings bound to a buffer, as a set.
+---
+---Through `vim.keycode` on both sides: the API reports a key in its own notation rather
+---than the one it was bound with, so comparing the strings as written can silently never
+---match.
+---@param buf integer
+---@return table<string, boolean>
+local function bound(buf)
+  local lhs = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+    lhs[vim.keycode(m.lhs)] = true
+  end
+  return lhs
+end
+
+describe("a session that turned archived entries off and exited", function()
+  -- Shares this process's throwaway XDG_STATE_HOME and nothing else, and runs with
+  -- `--clean` so no user config and no minimal_init can hand it a different one.
+  local child = vim
+    .system({
+      vim.v.progpath,
+      "--clean",
+      "-l",
+      vim.fs.joinpath(h.root, "tests", "codereview", "archived_child.lua"),
+    }, {
+      cwd = fixture,
+      text = true,
+      env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = fixture },
+    })
+    :wait(60000)
+
+  local function stored()
+    return table.concat(vim.fn.readfile(state.path(root)), "\n")
+  end
+
+  it("exits cleanly", function()
+    assert.same(0, child.code, (child.stderr or "") .. (child.stdout or ""))
+  end)
+
+  -- Without this the case below is vacuous: "the override did not come back" would be
+  -- satisfied by there being no channel between the two sessions at all.
+  it("leaves the batch it archived in the store both sessions share", function()
+    assert.same(1, vim.fn.filereadable(state.path(root)), "no state at " .. state.path(root))
+    assert.is_truthy(stored():find("from the session that turned them off", 1, true), stored())
+  end)
+
+  it("writes nothing about the switch into it", function()
+    assert.is_nil(stored():find("archived", 1, true), stored())
+  end)
+
+  -- Configuration is what decides at the start of every session, so a display preference
+  -- chosen in one cannot quietly become durable state the reviewer forgot they set.
+  it("starts this session from the configured value instead", function()
+    assert.is_true(config.get().archived)
+    assert.is_true(config.archived())
+  end)
+end)
+
+describe("the key beside the flag", function()
+  -- Configured off first, while this process has not pressed the key: unset means the
+  -- configured value, and this is the only moment that can be seen meaning it.
+  config.get().archived = false
+  view.open("branch")
+  local V = assert(view.current(), "no review view opened")
+
+  it("opens drawing nothing archived, because configuration says so", function()
+    assert.same({}, V.archived)
+    assert.same(0, #h.virt_marks(V))
+  end)
+
+  it("is bound in the diff and in the tree", function()
+    assert.is_true(bound(V.buf)[vim.keycode("gA")] == true, "gA is not bound in the diff")
+    assert.is_true(bound(assert(V.panel_buf))[vim.keycode("gA")] == true, "gA is not bound in the tree")
+  end)
+
+  -- The direction a configuration flag alone cannot go: the override runs both ways.
+  it("turns them on when configuration has them off", function()
+    vim.api.nvim_set_current_win(V.win)
+    h.feed("gA")
+    assert.is_true(vim.tbl_count(V.archived) > 0, "nothing archived is projected")
+    assert.is_true(#h.virt_marks(V) > 0, "nothing was drawn beneath the code")
+  end)
+
+  it("leaves the configured value where the host set it", function()
+    assert.is_false(config.get().archived)
+  end)
+
+  -- Back to the shipped default, with the override now standing in front of it.
+  config.get().archived = true
+  local drawn = vim.deepcopy(V.render.marks)
+
+  it("takes them off the diff again", function()
+    vim.api.nvim_set_current_win(V.win)
+    h.feed("gA")
+    assert.same({}, V.archived)
+    assert.same(0, #h.virt_marks(V))
+  end)
+
+  -- Mark for mark, not merely "nothing archived is drawn": the repaint is immediate, and
+  -- what comes back has to be the render that was there before the key was pressed.
+  it("brings them back, and repaints the review either way", function()
+    h.feed("gA")
+    assert.same(drawn, V.render.marks)
+    assert.is_true(#h.virt_marks(V) > 0, "nothing came back")
+  end)
+
+  it("works from the file tree as well", function()
+    local tree = assert(V.panel_win, "no file tree")
+    vim.api.nvim_set_current_win(tree)
+    h.feed("gA")
+    assert.same({}, V.archived)
+    h.feed("gA")
+    assert.same(drawn, V.render.marks)
+  end)
+
+  -- Module state, not view state: it is pressed once rather than once per review.
+  it("agrees with the review opened after it", function()
+    vim.api.nvim_set_current_win(V.win)
+    h.feed("gA")
+    view.open("branch")
+    local W = assert(view.current(), "no review view opened")
+    assert.are_not.same(V.buf, W.buf, "the same review came back")
+    assert.same({}, W.archived)
+    assert.same(0, #h.virt_marks(W))
+  end)
+end)

--- a/tests/codereview/touched_spec.lua
+++ b/tests/codereview/touched_spec.lua
@@ -355,6 +355,37 @@ describe("the configuration flag", function()
   end)
 end)
 
+-- The key that overrides that flag for the session inherits its coarseness whole: the
+-- display never tallies what it does not draw, and it spends no git deciding a number it
+-- will not print. Asserted here rather than in `render_spec`, which owns what the diff
+-- draws: this half is the sticky header's.
+describe("the key beside it", function()
+  local config = require("codereview.config")
+  local V = assert(view.current())
+
+  vim.api.nvim_set_current_win(V.win)
+  h.feed("gA")
+
+  it("takes the tally with the entries", function()
+    assert.is_nil(vim.wo[V.win].winbar:find("untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+
+  it("judges nothing, so nothing is spent deciding", function()
+    assert.same({}, V.touched)
+    assert.is_nil(V.untouched)
+  end)
+
+  it("leaves the configured value where the host set it", function()
+    assert.is_true(config.get().archived)
+  end)
+
+  h.feed("gA")
+
+  it("brings both back together, without re-reading the diff", function()
+    assert.is_truthy(vim.wo[V.win].winbar:find("0 untouched", 1, true), vim.wo[V.win].winbar)
+  end)
+end)
+
 -- Which blob touchedness is judged against, and the only fixture that can tell.
 --
 -- Everything above is clean at HEAD when its batch goes, so the blob the entry was


### PR DESCRIPTION
Two keys onto the review view, in one branch because both add a buffer-local key to the diff **and** to the file tree, and both add an action beside the ones `keymaps` already drives. Splitting them would put two agents in one table literal for nothing.

## `gb` reads the last batch

Every other view-level action already has a key, so reading back what already went out was the one that broke the keyboard's rhythm. `gb` names the **batch** and joins the `g` family the view's other view-level commands live in, where it shadows no motion and takes neither `gt` nor `gT`.

It opens the float `:CodeReviewLastBatch` opens rather than a surface of its own — one surface for one fact — and it is bound in both panes and in the tree, so which window a reviewer is in never decides whether a key exists. The command is untouched and still needs no review open, and the plugin goes on binding no global keys.

## `gA` turns archived entries off for the session

A runtime override of the `archived` flag, in the diff and in the tree.

- It sits **beside** the configured value in `config` rather than writing it, so a host's own `setup()` call goes on saying what the host wrote.
- Unset at startup, and unset means the configured value — configuration decides at the start of every session, and the choice dies with the process rather than becoming durable state a reviewer forgot they set.
- Module state, not view state: pressed once, not once per review, and every review opened afterwards agrees with it.
- Both directions — with `archived = false` configured, the key turns them on.
- Off is off entirely, which is the flag's existing coarseness: nothing drawn, nothing tallied, no git spent judging, so the `untouched` segment leaves the sticky header with the entries.
- Toggling repaints an open review at once, and judges before it paints: a paint drops that segment only when the archive has been *written*, so a toggle that merely repainted would leave the number on the bar with nothing it counts on the diff.

The flag's documentation offered this decision — *"There is no keymap beside it yet; one can be added if the switch proves too blunt."* It has been, so that sentence is gone rather than left to keep offering it. The same paragraph called the archive "history", which CONTEXT.md forbids; that is corrected here and in `doc/codereview.txt`.

## Cases

`gb` sits in `archive_float_spec`, which already owns which batch the float decides went last: bound in the diff and in the tree, the same rows and the same frame as the command, the command still opening it with no review, and nothing mapped globally.

`gA` sits in `render_spec`, beside the flag it mirrors, and its tally case in `touched_spec`, beside the `untouched` count it takes away. `archived_child.lua` archives a batch, presses the key and exits; the session after it finds the batch in the store the two share and the switch back at the configured value — `layout_child`'s shape, for `layout_child`'s reason.

Two design notes and two `tests/README` bullets record what this cost: the accessor every reader of the flag now has to go through, and that only the winbar notices a toggle that forgot to judge.

## Not in scope, deliberately

Persisting the override, a global keymap for either key, a command for `gA`, and any change to how archived entries are drawn or to the **touched** judgement itself.

Closes #124
Closes #125