### PR TITLE
refactor(view): assemble the winbar from typed segments

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -57,21 +57,36 @@ works too, and takes effect on the next redraw: measured in a prototype, not ass
 group the namespace does not define falls back to its global definition, so what is not in
 it stays bright.
 
-**The winbar draws in `WinBar`/`WinBarNC` and in nothing of the plugin's own.** The bar is
-plain text: it carries no `%#Group#` markup and cannot, because every `%` on it is escaped
-(see below). So the **sticky header** mutes with its window through those two built-in
-groups and needs nothing added to the muted set — which is also the whole of what keeps the
-two features from colliding, and is why `split_spec` asserts the painted cell of a muted
-pane's bar rather than trusting that the two happen to agree.
+**The winbar draws in `WinBar`/`WinBarNC` and in nothing of the plugin's own.** No segment
+on it carries a `%#Group#` today, so the **sticky header** mutes with its window through
+those two built-in groups and needs nothing added to the muted set — which is also the whole
+of what keeps the two features from colliding, and is why `split_spec` asserts the painted
+cell of a muted pane's bar rather than trusting that the two happen to agree. This used to
+be a rule the escaping *enforced*, and it is now only a fact about what the bar is built
+from: chrome may carry a group (see below), so the first segment that takes one leaves this
+paragraph out of date and the muted set with something to say about the winbar.
 
-**The winbar is padded by hand, in display columns, and every `%` in it is escaped.** The
-statusline's `%=` would right-align the review summary for free and cannot be used: the bar
-carries a path a reviewer's repository chose, and a `%f` in one would be read as a
-statusline item and expanded into something else — so the whole bar is escaped on the way
-out, `%=` included. What is left is arithmetic, and it counts columns rather than bytes.
-Almost everything on that bar is multibyte — the file icons, the chevron, the `·`
-separators, a rename's `→` — so a bar padded by `#` lands a dozen columns short of the pane
-and every ASCII assertion in the suite still passes. The renamed file is what catches it.
+**Every name on the winbar is escaped, per segment, and the bar is padded by hand in display
+columns.** A bar is built from typed segments — chrome, which the plugin wrote and may carry
+a highlight group, or a literal, which is a name the plugin did not choose — and
+`render.bar` doubles every `%` in a literal. The rule is the same one the wholesale escape
+held: the bar carries a path a reviewer's repository chose, and a `%f` in one would be read
+as a statusline item and expanded into something else. What moved is where it is applied, so
+that a caller cannot pass a path unescaped by accident: a segment has to say which kind it
+is, and the kind that takes a name is the kind that escapes it. The statusline's `%=` would
+now be possible, and would still buy nothing — see below.
+
+**The ruler for that bar is `render.bar_width`, and it measures what is drawn.** Two things
+separate a bar's string from its columns, and they pull opposite ways. Almost everything on
+the bar is multibyte — the file icons, the chevron, the `·` separators, a rename's `→` — so
+a bar padded by `#` lands a dozen columns short of the pane while every ASCII assertion in
+the suite still passes; the renamed file is what catches it. The mirror of that is a
+highlight marker: `%#Group#` is characters in the string and no columns at all on the
+screen, so a bar measured with its markers in drifts the other way, by the width of every
+one of them. Both are why the padding is arithmetic rather than `%=` — the fitting rule has
+to know how many columns the path may keep, which is the same measurement either way, and a
+bar that padded itself would take its own width out of reach of every assertion that reads
+it.
 
 **What the sticky header sheds on a narrow pane is decided by what it now says twice.** The
 summary drops the plugin's own name, the review's line totals and the queue's note count

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -30,7 +30,7 @@ change there is felt through.
 | `payload.lua` | The queue rendered as the message an agent receives; `@ref`s resolved at submit time | pure |
 | `queue.lua` | The queue itself — module-level, not per-view, so reopening a view scatters nothing | stateful (memory) |
 | `queue_float.lua` | The float over the queue: an entry as a run of bar-marked rows, and the keys that drop, jump, copy and submit | stateful (float) |
-| `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named | pure |
+| `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named, and how a winbar is assembled from typed segments | pure |
 | `state.lua` | Persisted review progress, and the blob comparisons over it — staleness, and touchedness kept in a function of its own | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -16,6 +16,12 @@
 ---carries, how a rename is spelled in each layout and which files have a pre-image side are
 ---rules rather than formats, and two copies of them would answer differently on the first
 ---file only one of the two authors had in mind.
+---
+---And, for the same reason and the same surface, how a winbar is *assembled*: `bar` takes
+---an ordered list of typed segments and returns the string a bar is set to, escaping every
+---name the plugin did not choose. That a repository's own file name can never be read as a
+---statusline item is a rule as well, and it is the one this module holds at the highest
+---point it can be held at. What the bar *says* stays with the view.
 local M = {}
 
 ---@class CRAnchor
@@ -303,6 +309,100 @@ function M.file_label(file, opts)
     stat = stat,
     right = notes > 0 and ("%s  [%d note%s]"):format(stat, notes, notes == 1 and "" or "s") or stat,
   }
+end
+
+--- The winbar ------------------------------------------------------------------
+
+-- How a bar is assembled, beside what a file on it is called. A winbar is a statusline, so
+-- what reaches it is markup rather than text, and a bar is therefore built from segments
+-- that each say what they are: chrome, which the plugin wrote and may carry a highlight
+-- group, or a literal, which is a name the plugin did not choose and is escaped.
+--
+-- The view keeps saying *what* the bar says; what is here is *how a bar is assembled
+-- safely*, which is a rule and not a format -- the same reason `file_label` is here.
+
+---@class CRBarSegment
+---@field kind "chrome"|"literal"
+---@field text string
+---@field hl string|nil          Highlight group; chrome only, and nil draws in the bar's own
+
+---Chrome: a piece of the bar the plugin itself wrote.
+---
+---The one kind that is not escaped, which is what lets it carry statusline markup at all --
+---a highlight group being the only markup this bar has any use for. `hl` is how to ask for
+---one, and it ends where the segment does, so a group one segment carries never runs on
+---into the next.
+---@param text string
+---@param hl string|nil
+---@return CRBarSegment
+function M.chrome(text, hl)
+  return { kind = "chrome", text = text, hl = hl }
+end
+
+---A literal: text drawn exactly as it stands, whoever chose it.
+---
+---Every `%` in it is doubled, and **this is the rule the whole seam exists for**. A path is
+---a name the reviewer's repository chose, and a `%f` in one would otherwise be read as a
+---statusline item and expanded into something else -- the window's own file name, in that
+---case, which is not even the file the bar is naming. The same holds for every other name
+---the plugin did not choose: a **scope**'s label, a **target**'s short name, a base
+---revision.
+---
+---A segment has to say which kind it is precisely so this cannot be forgotten. There is no
+---way onto the bar that does not go through one of these two functions, and the one that
+---takes a name is the one that escapes it.
+---@param text string
+---@return CRBarSegment
+function M.literal(text)
+  return { kind = "literal", text = text }
+end
+
+---@param seg CRBarSegment
+---@return "chrome"|"literal"
+local function kind_of(seg)
+  local kind = type(seg) == "table" and seg.kind
+  assert(kind == "chrome" or kind == "literal", "a winbar segment must say whether it is chrome or a literal")
+  return kind
+end
+
+---One winbar, from the segments it is made of.
+---@param segments CRBarSegment[]
+---@return string
+function M.bar(segments)
+  local out = {}
+  for i, seg in ipairs(segments) do
+    if kind_of(seg) == "literal" then
+      out[i] = (seg.text:gsub("%%", "%%%%"))
+    elseif seg.hl then
+      out[i] = ("%%#%s#%s%%*"):format(seg.hl, seg.text)
+    else
+      out[i] = seg.text
+    end
+  end
+  return table.concat(out)
+end
+
+---How many columns those segments take on the screen.
+---
+---The ruler everything that pads or fits a bar measures with, and it measures what is
+---*drawn* rather than what is written. Two things separate the two, and they pull opposite
+---ways: an escaped `%` is two characters and one column, and a highlight marker is several
+---characters and no columns at all. A bar padded by the length of a string holding either
+---one lands short of its pane -- which is the byte-versus-column trap the padding already
+---walked into once, arriving from the other side.
+---@param segments CRBarSegment[]
+---@return integer
+function M.bar_width(segments)
+  local width = 0
+  for _, seg in ipairs(segments) do
+    local text = seg.text
+    if kind_of(seg) == "chrome" and text:find("%", 1, true) then
+      -- `%#Group#` and the `%*` that ends one, whichever way they got here.
+      text = text:gsub("%%#[^#]*#", ""):gsub("%%%*", "")
+    end
+    width = width + vim.fn.strdisplaywidth(text)
+  end
+  return width
 end
 
 ---Build the view.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -122,6 +122,13 @@ end
 -- header row, so it takes the left -- and it is written where the summary already was
 -- rather than over it, because a bar that answered *which file* by dropping *which review*
 -- would have moved the problem rather than solved it.
+--
+-- What a bar is *made of* is `render.lua`'s: an ordered list of segments, each saying
+-- whether the plugin wrote it or whether it is a name the plugin did not choose, and
+-- `render.bar` is what turns that list into the string a winbar is set to. Everything here
+-- decides *which* segments there are. `render.bar_width` is the ruler for all of it, and the
+-- only one: it measures what a bar draws, which is neither its byte length nor its
+-- character count.
 
 local SEP = " · "
 -- One blank column at each edge, and at least two between the halves, so the two never
@@ -136,28 +143,35 @@ end
 
 ---Lay one winbar out: `left` against the left margin, `right` against the right edge.
 ---
----Padded with spaces rather than with the statusline's `%=`, because every `%` in this bar
----is escaped on the way out -- a path is a name a reviewer's repository chose, and `%f` in
----one would otherwise be read as a statusline item and expanded into something else. The
----padding is counted in display columns and not in bytes: the summary's separators, the
----file icons and a rename's arrow are all multibyte, so a bar padded by `#` drifts left by
----two columns for every one of them, and does it on the very first path with an accent.
+---Padded with spaces rather than with the statusline's `%=`. The escape that used to rule
+---`%=` out is per segment now, so chrome could carry one -- but it would replace a single
+---subtraction and take the bar's own width away with it, and what the fitting rule below
+---needs is how many columns the path may keep, which is this arithmetic either way.
+---
+---The padding is counted in display columns and never in bytes: the summary's separators,
+---the file icons and a rename's arrow are all multibyte, so a bar padded by `#` drifts left
+---by two columns for every one of them, and does it on the very first path with an accent.
 ---@param width integer Columns the winbar has
----@param left string
----@param right string Empty to leave the bar left-aligned, as it is with nothing to align
----@return string
+---@param left CRBarSegment[]
+---@param right CRBarSegment[] Empty to leave the bar left-aligned, as it is with nothing to align
+---@return CRBarSegment[]
 local function lay_out(width, left, right)
-  if right == "" then
-    return (" "):rep(MARGIN) .. left
+  local out = { render.chrome((" "):rep(MARGIN)) }
+  vim.list_extend(out, left)
+  if #right == 0 then
+    return out
   end
-  local pad = width - 2 * MARGIN - cols(left) - cols(right)
-  return (" "):rep(MARGIN) .. left .. (" "):rep(math.max(GAP, pad)) .. right .. (" "):rep(MARGIN)
+  local pad = width - 2 * MARGIN - render.bar_width(left) - render.bar_width(right)
+  out[#out + 1] = render.chrome((" "):rep(math.max(GAP, pad)))
+  vim.list_extend(out, right)
+  out[#out + 1] = render.chrome((" "):rep(MARGIN))
+  return out
 end
 
 ---@param win integer
----@param bar string
-local function set_winbar(win, bar)
-  vim.wo[win].winbar = bar:gsub("%%", "%%%%")
+---@param segments CRBarSegment[]
+local function set_winbar(win, segments)
+  vim.wo[win].winbar = render.bar(segments)
 end
 
 ---What the review summary says, one segment per `·`.
@@ -201,18 +215,27 @@ local function summary_segments()
   return out
 end
 
----The summary as one string, minus whatever a narrow pane has made it drop.
+---The summary as segments, minus whatever a narrow pane has made it drop.
+---
+---Literals, every one of them. Two carry names the plugin did not choose -- the **scope**'s
+---label and the **target**'s short name -- and the rest cost nothing by being escaped, since
+---a format the plugin wrote holds no `%` left by the time it has been formatted. Escaping
+---one segment too many draws exactly what was asked for; escaping one too few is how a
+---branch called `100%-done` stops being a branch name. The separators are the plugin's own.
 ---@param segments { text: string, spare: boolean|nil }[]
 ---@param dropped table<integer, boolean>|nil
----@return string
+---@return CRBarSegment[]
 local function join(segments, dropped)
-  local kept = {}
+  local out = {}
   for i, seg in ipairs(segments) do
     if not (dropped and dropped[i]) then
-      kept[#kept + 1] = seg.text
+      if #out > 0 then
+        out[#out + 1] = render.chrome(SEP)
+      end
+      out[#out + 1] = render.literal(seg.text)
     end
   end
-  return table.concat(kept, SEP)
+  return out
 end
 
 ---How the render would name the file the cursor is in, or nil when it is in none.
@@ -242,10 +265,18 @@ end
 ---Split into the part that may be cut and the parts that may not: the icon, the chevron and
 ---the stat are a handful of columns each and say what no number of columns of path can, so
 ---when a pane runs out of room the path is what gives them up.
+---
+---Literals, the icons included: a host chooses those, so they are not text the plugin wrote.
+---The path stays a bare string rather than a segment because it is the one part the fitting
+---rule cuts, and `render.keep_tail` takes text.
 ---@param label CRFileLabel
----@return { head: string, path: string, tail: string }
+---@return { head: CRBarSegment[], path: string, tail: CRBarSegment[] }
 local function file_segment(label)
-  return { head = ("%s %s "):format(label.icon, label.chevron), path = label.name, tail = "  " .. label.right }
+  return {
+    head = { render.literal(("%s %s "):format(label.icon, label.chevron)) },
+    path = label.name,
+    tail = { render.literal("  " .. label.right) },
+  }
 end
 
 ---Fit the file and the summary into `room` columns, and say what each is left holding.
@@ -263,9 +294,9 @@ end
 ---it does: a bar that had shed the scope to spell out two more directory names would have
 ---kept the least of what it was holding.
 ---@param room integer Columns, margins already taken off
----@param file { head: string, path: string, tail: string }
+---@param file { head: CRBarSegment[], path: string, tail: CRBarSegment[] }
 ---@param segments { text: string, spare: boolean|nil }[]
----@return string left, string right
+---@return CRBarSegment[] left, CRBarSegment[] right
 local function fit(room, file, segments)
   -- The order they go in: the spares, then the rest from the head.
   local order, spares = {}, {}
@@ -285,7 +316,10 @@ local function fit(room, file, segments)
   local summary, path_room
   local function measure()
     summary = join(segments, dropped)
-    path_room = room - cols(file.head) - cols(file.tail) - (summary ~= "" and GAP + cols(summary) or 0)
+    path_room = room
+      - render.bar_width(file.head)
+      - render.bar_width(file.tail)
+      - (#summary > 0 and GAP + render.bar_width(summary) or 0)
   end
   measure()
 
@@ -306,7 +340,9 @@ local function fit(room, file, segments)
   shed(#spares, cols(file.path))
   shed(#order, floor)
 
-  return file.head .. render.keep_tail(file.path, path_room) .. file.tail, summary
+  local left = vim.list_extend({}, file.head)
+  left[#left + 1] = render.literal(render.keep_tail(file.path, path_room))
+  return vim.list_extend(left, file.tail), summary
 end
 
 ---The after pane's winbar: the file under the cursor, and the review summary beside it.
@@ -323,7 +359,7 @@ local function update_winbar()
     -- No file under the cursor -- an empty review. The summary has the bar to itself,
     -- exactly as it did before there was anything to share it with, rather than a segment
     -- advertising a file that is not there.
-    set_winbar(V.win, lay_out(width, join(segments), ""))
+    set_winbar(V.win, lay_out(width, join(segments), {}))
     return
   end
   local left, right = fit(width - 2 * MARGIN, file_segment(label), segments)
@@ -342,8 +378,9 @@ local function update_before_winbar()
     return
   end
   local rev = V.scope.before
-  -- `:0` is git's name for the index, and a name nobody reads as one.
-  local left = ("Before · %s"):format(rev == ":0" and "index" or rev)
+  -- `:0` is git's name for the index, and a name nobody reads as one. The revision itself is
+  -- a name the repository chose, so it is a literal beside chrome rather than one string.
+  local left = { render.chrome("Before · "), render.literal(rev == ":0" and "index" or rev) }
   local width = vim.api.nvim_win_get_width(V.before_win)
   -- A file that exists only on the after side has no pre-image path to name, exactly as its
   -- header row on this pane has none: the revision keeps the bar to itself and says so by
@@ -353,9 +390,9 @@ local function update_before_winbar()
   -- The revision is what this pane exists to name and is never cut for the path's sake: on
   -- a pane too narrow to hold both, a base revision half spelled out is worse than none of
   -- the path, which the after pane is naming anyway.
-  local room = width - 2 * MARGIN - GAP - cols(left)
+  local room = width - 2 * MARGIN - GAP - render.bar_width(left)
   path = (path ~= "" and room >= 2) and render.keep_tail(path, room) or ""
-  set_winbar(V.before_win, lay_out(width, left, path))
+  set_winbar(V.before_win, lay_out(width, left, path ~= "" and { render.literal(path) } or {}))
 end
 
 ---Write one pane's render into its buffer: the lines, and nothing else.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -135,6 +135,9 @@ local SEP = " · "
 -- read as one sentence.
 local MARGIN, GAP = 1, 2
 
+---Columns of one bare string: the path, which is the only part of a bar that is cut rather
+---than assembled. Anything already in segments is measured with `render.bar_width`, which
+---is the same count plus what a segment can hold that a string cannot say.
 ---@param text string
 ---@return integer
 local function cols(text)

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | --- | --- |
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
-| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them — and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, and a review with no files |
+| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them — how a winbar is assembled from typed segments, with no window, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, a name carrying a `%`, and a review with no files |
 | `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, each pane's winbar naming its own side of a rename, and the painted cell proving that bar mutes with its pane |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
@@ -477,8 +477,23 @@ so the out-of-core language path is still checked locally without ever failing C
   whose bar carries `○`, `▾`, `→` and `·` at once, and asserts the bar's display width is
   the pane's width exactly — with a second assertion that the bar really is longer in bytes
   than in columns, or the case is comparing two equal numbers and measuring nothing.
-  Replacing `view.lua`'s two `cols(...)` calls in `lay_out` with `#` must red it. Same trap
-  as "an ASCII fixture cannot fail the byte-splitting bug".
+  Replacing the `strdisplaywidth` in `render.bar_width` with `#` — the one ruler both bars
+  are padded and fitted by — must red it, and reds four cases across `render_spec` and
+  `since_batch_spec`. Same trap as "an ASCII fixture cannot fail the byte-splitting bug".
+- **A highlight marker is the same trap arriving from the other side.** `%#Group#` occupies
+  several characters in a bar and no columns at all on the screen, so a ruler that counts it
+  overshoots exactly as a byte count undershoots — and nothing on the bar carries a marker
+  yet, so no assertion made against what the bar *says* can notice. `render_spec`'s winbar
+  assembly block measures both spellings of one, the group a segment carries and a marker
+  written into chrome, and asserts they weigh nothing. Deleting the stripping in
+  `render.bar_width` reds one case; measuring the escaped literal instead of the drawn one
+  reds two.
+- **The kinds on the bar are the view's choice, and only one case pins it.** `render.bar`
+  escapes a literal and leaves chrome alone, which the pure cases prove — but *which* kind
+  each piece of a bar is asked for is decided in `view.lua`, and no fixture in the suite
+  holds a `%` in a path, a branch name or a scope label. `render_spec` reaches it through a
+  picker stub instead: a **target** called `ja%nus`, on a wide pane, whose `%` must come out
+  doubled. Marking the summary's segments as chrome reds that case and nothing else.
 - **The sticky header's teeth are in the case with no tree.** With the tree open, a winbar
   hung off the tree's own repaint follows the cursor perfectly, so every case but that one
   passes with the crossing latch put back inside `view_panel.sync_panel`. Returning early

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | --- | --- |
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
-| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them — how a winbar is assembled from typed segments, with no window, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, a name carrying a `%`, and a review with no files |
+| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, and the flag that removes them — how a winbar is assembled from typed segments, with no review, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, a name carrying a `%`, and a review with no files |
 | `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, each pane's winbar naming its own side of a rename, and the painted cell proving that bar mutes with its pane |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
@@ -488,6 +488,14 @@ so the out-of-core language path is still checked locally without ever failing C
   written into chrome, and asserts they weigh nothing. Deleting the stripping in
   `render.bar_width` reds one case; measuring the escaped literal instead of the drawn one
   reds two.
+- **A string case cannot tell markup from a plausible string.** Every case in that block was
+  written against the encoding the assembly emits, so a wrong one — `%{Group}` for
+  `%#Group#` — would have taken the expectations with it and left the block green. One case
+  hands the bar to `nvim_eval_statusline` instead and asks Neovim what it drew: the text
+  with the marker gone, the group named in a highlight run, and a width that has to equal
+  `render.bar_width`'s. Move the encoding and its expectation together and it is the only
+  case that reds. It is also the only one in the block that needs a window at all, and any
+  window will do — there is no review behind it.
 - **The kinds on the bar are the view's choice, and only one case pins it.** `render.bar`
   escapes a literal and leaves chrome alone, which the pure cases prove — but *which* kind
   each piece of a bar is asked for is decided in `view.lua`, and no fixture in the suite

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -608,6 +608,32 @@ describe("the sticky header on a pane that has to choose", function()
   end)
 end)
 
+-- The rule the assembly exists for, reached the way a reviewer reaches it. A **target**'s
+-- short name is a name the plugin did not choose, so the bar has to draw it rather than
+-- expand it -- and no fixture is needed to say so, because a picker stub can carry a `%`
+-- where a file name cannot without moving every count in the suite.
+--
+-- The cases above prove the escape; this one proves the view still asks for it. Marking the
+-- summary as text the plugin wrote is a one-word change that nothing else here would notice.
+describe("the sticky header naming something with a % in it", function()
+  local V = view.current()
+  config.get().pick_target = function(cb)
+    cb({ short = "ja%nus" })
+  end
+  -- Wide, so what is asserted is the escape and not what a narrow pane had room for.
+  vim.api.nvim_win_set_width(V.win, 100)
+  view.pick_target()
+
+  local function bar()
+    return vim.wo[V.win].winbar
+  end
+
+  it("doubles the % rather than letting it start a statusline item", function()
+    assert.is_truthy(bar():find("ja%%nus", 1, true), bar())
+    assert.is_nil(bar():find("ja%nus", 1, true), bar())
+  end)
+end)
+
 describe("the sticky header on a review with no files", function()
   local V = view.current()
   -- A revspec whose two ends are the same commit: a review that opened on a real scope and

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -339,6 +339,95 @@ describe("line keys", function()
   end)
 end)
 
+-- How a winbar is assembled: typed segments in, the one string a bar is set to out.
+--
+-- No window, no fixture and no repository, which is why the seam is here rather than in the
+-- view: the rule these cases hold is the one that protects a reviewer against the names
+-- their own repository chose, and it is cheap to keep true only if it can be asserted like
+-- this. The blocks below assert what the bar *says*; these assert what it is safe to put
+-- on it.
+describe("the winbar assembly", function()
+  it("doubles every % in a literal", function()
+    assert.same("src/%%f.lua", render.bar({ render.literal("src/%f.lua") }))
+  end)
+
+  it("draws what the plugin wrote as it stands", function()
+    assert.same(" · ", render.bar({ render.chrome(" · ") }))
+  end)
+
+  it("joins the segments in the order they arrive", function()
+    assert.same(
+      " ○ ▾ src/50%% done.lua · api",
+      render.bar({
+        render.chrome(" "),
+        render.literal("○ ▾ src/50% done.lua"),
+        render.chrome(" · "),
+        render.literal("api"),
+      })
+    )
+  end)
+
+  it("wraps a chrome segment that carries a highlight group", function()
+    assert.same("%#CodeReviewAdd#+12%*", render.bar({ render.chrome("+12", "CodeReviewAdd") }))
+  end)
+
+  -- The two kinds are the whole point: the same text is markup on one and a name on the
+  -- other, and nothing but the kind says which.
+  it("keeps a marker in chrome and doubles the same text in a literal", function()
+    assert.same("%#CodeReviewAdd#x", render.bar({ render.chrome("%#CodeReviewAdd#x") }))
+    assert.same("%%#CodeReviewAdd#x", render.bar({ render.literal("%#CodeReviewAdd#x") }))
+  end)
+
+  -- A caller cannot put a path on the bar by accident, because a segment that says nothing
+  -- about its kind is not a segment. The message is asserted, not merely the raise: every
+  -- one of these raises while the assembly does not exist at all, and a case satisfied by
+  -- that is measuring nothing.
+  ---@param fn fun()
+  local function refused(fn)
+    local ok, err = pcall(fn)
+    assert.is_false(ok)
+    assert.is_truthy(tostring(err):find("chrome", 1, true), tostring(err))
+  end
+
+  it("refuses a segment that does not say which kind it is", function()
+    refused(function()
+      render.bar({ { text = "src/%f.lua" } })
+    end)
+    refused(function()
+      render.bar({ "src/%f.lua" })
+    end)
+    refused(function()
+      render.bar_width({ { text = "src/%f.lua" } })
+    end)
+  end)
+
+  -- Columns and never bytes, for the reason the padding already records: a bar measured by
+  -- byte length drifts two columns for every glyph and does it on the first path with an
+  -- accent in it. The second assertion is the guard -- with an all-ASCII string the two
+  -- numbers agree and the case measures nothing.
+  it("measures a literal in columns rather than bytes", function()
+    local path = "○ ▾ src/café.lua"
+    assert.same(vim.fn.strdisplaywidth(path), render.bar_width({ render.literal(path) }))
+    assert.is_true(#path > vim.fn.strdisplaywidth(path), "nothing multibyte to measure")
+  end)
+
+  -- What is measured is what is drawn, not what is written: an escaped `%` is two
+  -- characters in the string and one column on the screen.
+  it("counts an escaped % as the one column it draws", function()
+    local segments = { render.literal("50% done") }
+    assert.same(8, render.bar_width(segments))
+    assert.same(9, #render.bar(segments))
+  end)
+
+  -- The mirror of the byte trap, and the one this seam introduces: a highlight marker is
+  -- characters in the string and no columns at all on the screen. Both spellings of one --
+  -- carried by the segment, and written into it -- have to measure the same.
+  it("gives a highlight marker no width at all", function()
+    assert.same(4, render.bar_width({ render.chrome("+12", "CodeReviewAdd"), render.chrome(" ") }))
+    assert.same(4, render.bar_width({ render.chrome("%#CodeReviewAdd#+12%*"), render.chrome(" ") }))
+  end)
+end)
+
 -- The sticky header: the file the cursor is in, named on the winbar so that reading past
 -- that file's own header row no longer costs a reviewer the file.
 --

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -426,6 +426,31 @@ describe("the winbar assembly", function()
     assert.same(4, render.bar_width({ render.chrome("+12", "CodeReviewAdd"), render.chrome(" ") }))
     assert.same(4, render.bar_width({ render.chrome("%#CodeReviewAdd#+12%*"), render.chrome(" ") }))
   end)
+
+  -- The claim no comparison of two strings can make: that what comes out is markup Neovim
+  -- reads rather than a plausible-looking string, and that the ruler above agrees with the
+  -- one Neovim draws by. Every case here would have been written against a wrong encoding
+  -- had one been chosen, and every one of them would have passed; this is the only one that
+  -- reds when the marker and its expectation move together. Asked of the statusline parser
+  -- a winbar goes through, so it needs no window of the review's own. `DiffAdd` because it
+  -- exists on a bare Neovim -- which group the bar asks for is not this slice's business,
+  -- and an undefined one comes back reported as no group at all.
+  it("emits markup Neovim reads, and measures what Neovim would draw", function()
+    local segments = {
+      render.chrome(" "),
+      render.chrome("+12", "DiffAdd"),
+      render.chrome(" "),
+      render.literal("src/50% done.lua"),
+    }
+    local drawn = vim.api.nvim_eval_statusline(render.bar(segments), { highlights = true })
+    assert.same(" +12 src/50% done.lua", drawn.str)
+    assert.same(render.bar_width(segments), drawn.width)
+    local groups = {}
+    for _, run in ipairs(drawn.highlights) do
+      groups[run.group] = true
+    end
+    assert.is_true(groups.DiffAdd or false, vim.inspect(drawn.highlights))
+  end)
 end)
 
 -- The sticky header: the file the cursor is in, named on the winbar so that reading past


### PR DESCRIPTION
Closes #127.

Prefactor. Both panes' bars come out byte-identical to the ones produced before this; nothing a reviewer sees changes.

## The seam

`render.bar(segments)` takes an ordered list of typed segments and returns the string a winbar is set to. A segment is **chrome** — text the plugin wrote, which may carry a highlight group — or a **literal** — a name the plugin did not choose, which is escaped. `render.bar_width(segments)` is the ruler both bars are padded and fitted by.

It sits beside `file_label`, in the pure module both bars already build on. That is the highest point the escaping rule can be held at, it adds no edge to the module stack, and it needs no review, no fixture and no repository to assert.

The view still owns *what* the bar says. What moved is *how* a bar becomes a string.

## What moved, and what did not

- The wholesale `%` escape becomes a per-literal one. Every name is still escaped; the only strings that are not are the ones the plugin wrote. A caller cannot pass a path unescaped by accident, because a segment has to say which kind it is — `render.bar` raises on one that does not.
- The commentary explaining why a repository's own file name can never be read as a statusline item moved with the rule, onto `render.literal`.
- `bar_width` measures what is **drawn**: an escaped `%` is two characters and one column, a `%#Group#` is several characters and none. The next slice inherits a ruler that knows this rather than discovering it.
- The fitting rule's four steps and their order are untouched. `summary_segments` is untouched, so #125 has no conflict with it.
- Nothing on the bar carries a highlight group yet, so it still draws in `WinBar`/`WinBarNC` and still mutes with its pane.

## Evidence

**Byte identity.** A harness dumps both panes' bars over one fixture in 93 states — every file in the unified layout, eleven pane widths through all four steps of the fitting rule, notes queued, a **target** whose short name carries a `%`, both panes at four terminal widths in the split layout, and a review with no files. Run before the change and after, the two dumps are identical (`md5 be42e647…` both times), including `ja%%nus` where the target's `%` is doubled.

**Red first.** All nine assembly cases were written before the function existed and observed red — eight on `attempt to call field 'literal'/'chrome'/'bar' (a nil value)`, and the refusal case on its message assertion, because a missing function raises too and a case satisfied by that measures nothing.

**Mutations, applied one at a time, whole tree clean between each:**

| Mutation | Reds |
| --- | --- |
| literals not escaped | 6 |
| chrome escaped as well | 4 |
| the kind left unchecked | 1 |
| `strdisplaywidth` → `#` in `bar_width` | 4, across `render_spec` and `since_batch_spec` |
| the ruler counts highlight markers | 1 |
| the ruler measures the escaped literal | 2 |
| a malformed marker | 2 |
| the summary marked as chrome | 1 |
| `%#Group#` → `%{Group}`, expectation moved with it | 1 — the case that asks Neovim |

The last one is why one case hands the bar to `nvim_eval_statusline` rather than comparing two strings: every string case would have been written against a wrong encoding and passed. It also pins `bar_width` against the width Neovim itself reports.

**Two cases beyond the pure block.** A **target** called `ja%nus`, through a picker stub, pins the view's choice of kinds — no fixture holds a `%`, and marking the summary as chrome otherwise reds nothing in the suite. The other asks Neovim what it drew, as above.

`make all` passes: 1,258 cases, exit 0.

## Prose

The design note claiming the bar carries no `%#Group#` and *cannot* was the wholesale escape's argument and is no longer true. It now records what is true — nothing on the bar carries one yet — and what the first segment that takes one will cost the muted set. The padding note gains the mirror of the trap it already held, as the PRD asks. `tests/README` had a mutation instruction naming two `cols(...)` calls that have moved.