### PR TITLE
feat(delivery): let a batch carry a preamble

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -160,6 +160,16 @@ The queue as a single unit of delivery — what one submission sends.
 The rendered text of a batch: the message the receiving agent actually reads.
 _Avoid_: output, body, prompt
 
+**Preamble**:
+The prose a reviewer writes above a **batch**, addressed to the receiving agent, that is not
+an **annotation**. It says what the batch is about as a whole — which part matters most,
+what to ignore, how the pieces relate — and the payload renders it above the header, where
+it is read before the findings. Composed at **submit** time and never held in the **queue**,
+which keeps **entries** and nothing else. A **draft** of one is kept per repository, because
+a preamble is about a batch and not about a file. An **immediate send** carries none
+(ADR-0004), and a copied payload carries none either: only a **dispatch** carries one.
+_Avoid_: prologue, cover note, header, message, prompt
+
 **`@ref`**:
 A file or line reference inside a payload, written relative to the **target**'s working
 directory so the agent can resolve it.

--- a/README.md
+++ b/README.md
@@ -428,6 +428,29 @@ in the `+` register without submitting it. It is the same text `send` would have
 handed, target and all, and it costs the batch nothing: the queue is untouched, so reading
 what an agent will be told is not a decision to send it.
 
+### A batch can carry a preamble
+
+`<C-s>` submits with no questions asked. `<C-a>` — in the diff and in the queue float —
+opens the composer first, and submits when you submit the composer. What you write is the
+**preamble**: the prose above the batch, addressed to the agent, that is not an annotation.
+It is where what the batch is about as a whole goes — which part matters most, what to
+ignore, how the pieces relate — instead of an untyped annotation in the middle of the
+findings.
+
+It is rendered above the header, so it is read before them, and it is never queued. A
+preamble is written at the moment the batch goes and forgotten afterwards: the queue holds
+annotations and nothing else.
+
+Abandon the composer and nothing is sent. The queue is whole, nothing is archived, and what
+you wrote is kept as a draft, so the next `<C-a>` offers it back rather than making you
+write it twice. That draft is kept per repository rather than per file, because a preamble
+is about a batch and not about a line of code.
+
+An empty composer still submits and renders nothing at all, leaving the payload exactly
+what `<C-s>` would have sent. `gy` copies no preamble either, because copying is not
+submitting, and an annotation [sent on its own](#send-one-annotation-now) carries none: a
+batch of one has no batch to cover.
+
 ### Read the last batch back after it goes
 
 A submit clears the queue, which is the moment "what did I actually ask for?" stops having
@@ -501,9 +524,13 @@ the tally off along with everything else.
 ### The payload
 
 Grouped by type, in the configured order, most actionable first, with anything untyped
-last. A diff is inlined where an `@ref` cannot carry the change.
+last. A diff is inlined where an `@ref` cannot carry the change. A preamble, where one was
+written, sits above the header with a blank line under it; with none the payload starts at
+the header.
 
 ````markdown
+the auth rewrite is the part to read — the route moves are mechanical
+
 Code review — 4 annotations on branch vs origin/master (8 files, 6 reviewed)
 
 ## Bugs (2) — diagnose and fix these
@@ -550,6 +577,7 @@ worth a look before we ship this
 | `gy` | Copy the batch to the `+` register, without submitting it |
 | `<C-t>` | Choose the delivery target |
 | `<C-s>` | Submit the batch |
+| `<C-a>` | Submit the batch under a [preamble](#a-batch-can-carry-a-preamble) |
 | `q` | Close |
 
 Annotation keys are prefixed with `a` rather than bound bare, because bare `b`, `f`, `n`
@@ -608,6 +636,7 @@ under the cursor and not what a heading further up happened to say.
 | `gy` | Copy the batch to the `+` register, without submitting it |
 | `<C-t>` | Choose the delivery target |
 | `<C-s>` | Submit the batch |
+| `<C-a>` | Submit the batch under a [preamble](#a-batch-can-carry-a-preamble) |
 | `q` / `<Esc>` | Close, keeping the queue |
 
 `gy` leaves the float open, because it takes nothing out of the queue — everything it is

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -102,6 +102,7 @@ Buffer-local, inside the review view:
     gy               Copy the batch to the `+` register, without submitting
     <C-t>            Choose the delivery target
     <C-s>            Submit the batch
+    <C-a>            Submit the batch under a |codereview-preamble|
     q                Close the review
 
 Navigation:                                          *codereview-navigation*
@@ -149,9 +150,10 @@ hands focus back to the diff. Collapsed directories belong to the review, not
 to the tree, so they are exactly as you left them when it comes back.
 
 In the queue float: <CR> jumps to the annotation under the cursor, x drops an
-entry, gy copies the batch, <C-t> routes, <C-s> submits, q closes and keeps
-the queue. `gy` leaves the float open -- it takes nothing out of the queue, so
-every row it is listing is still true.
+entry, gy copies the batch, <C-t> routes, <C-s> submits, <C-a> submits under a
+|codereview-preamble|, q closes and keeps the queue. `gy` leaves the float
+open -- it takes nothing out of the queue, so every row it is listing is
+still true.
 
 A jump closes the float and centres the line the annotation is about,
 expanding the file first if it was collapsed. The queue is shared with the
@@ -529,6 +531,12 @@ started in: annotating a file in the review and capturing it from an ordinary
 buffer are the same thought about the same code, and meet the same draft. A
 draft for one file never surfaces while you annotate another.
 
+A |codereview-preamble| has no file, so it is keyed by the repository the
+batch would go out of, and by one key for everything outside a checkout --
+the same split the queue's two stores make. That leaves one preamble draft
+per repository, which is what coming back to a batch you were writing for
+expects. It never meets a note's draft, whichever file that note is about.
+
 They live in `stdpath("state")/codereview/drafts.json`, separate from review
 progress because a draft is not review progress -- that document is rewritten
 whenever the queue changes, and a draft has nothing to do with the queue.
@@ -538,6 +546,40 @@ you the note you were about to write in order to report one you had already
 abandoned.
 
 Wire |codereview-opt-compose| to replace this composer with your own.
+
+Covering a batch                                      *codereview-preamble*
+
+<C-s> submits with no questions asked. <C-a> -- in the diff and in the queue
+float -- opens the composer first and submits when the composer is submitted.
+What you write there is the *preamble*: the prose above the batch, addressed
+to the receiving agent, that is not an annotation.
+
+It carries what the batch is about as a whole -- which part matters most,
+what to ignore, how the pieces relate. The payload writes it above the
+header, with a blank line under it, so it is read before the findings: >
+    the auth rewrite is the part to read -- the route moves are mechanical
+
+    Code review — 4 annotations on branch vs master (8 files, 6 reviewed)
+<
+A preamble is never queued. It is written at the moment the batch goes and
+forgotten afterwards: the queue holds annotations and nothing else, so
+nothing about the queue or its persistence changes for it.
+
+An abandoned composer is not a submit. Nothing reaches |codereview-opt-send|,
+nothing is archived, and the queue is exactly as it was -- and what you wrote
+is kept as a draft, so the next <C-a> offers it back. That draft is keyed by
+the repository rather than by a file, because a preamble is about a batch;
+outside a checkout there is one key for all of them, which is the split the
+queue's own two stores make. See |codereview-drafts|.
+
+A batch that did not go keeps its preamble the same way. Its annotations wait
+in the queue to be retried, and the preamble has no queue to wait in.
+
+An empty composer still submits, and an empty preamble renders nothing at
+all: the payload is byte for byte what <C-s> would have sent. `gy` and
+|:CodeReviewCopy| carry none either, because copying is not submitting, and
+an |codereview-immediate-send| carries none: a batch of one has no batch to
+cover.
 
 What you already reported                             *codereview-archived*
 
@@ -765,8 +807,18 @@ compose({ctx}, {on_accept}, {label})                  *codereview-opt-compose*
             rel_path    repository-relative path; nil outside a checkout
             file_path   absolute path; nil for a note with no file
             origin_win  window the annotation was started from
-            routing     immediate sends only -- see below
+            routing     immediate sends and preambles -- see below
+            preamble    true when the text is a |codereview-preamble| for
+                        the batch rather than a note about code
+            root        repository the batch is going out of; nil outside a
+                        checkout. Preambles only
 <
+        A preamble is about a batch, so it names no file at all: both
+        paths above are nil and `root` is what a draft of it is keyed by. A
+        composer that keeps drafts should key them through
+        `require("codereview.drafts").key(ctx)`, which answers for every
+        shape at once.
+
         `routing` is `{ label(), pick(on_done) }` for the target *this note*
         will reach: `label()` is what to name in the chrome, `pick()` changes
         it and calls {on_done} once the picker has answered. It is absent for a

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -18,9 +18,9 @@ change there is felt through.
 | `capture.lua` | The capture path: the same entry from an ordinary buffer, no review view involved | stateful (queue, buffer) |
 | `composer.lua` | The shipped composer and its `@` reference picker — the default `compose` adapter, not a lesser one | stateful (float) |
 | `config.lua` | `setup()`, the defaults, and the injected adapters: `send`, `pick_target`, `pick_file`, `compose`, `open_diff` | stateful (options) |
-| `delivery.lua` | Where a batch is going, how that is chosen, and the submit that empties the queue only on dispatch | stateful (target, queue) |
+| `delivery.lua` | Where a batch is going, how that is chosen, the **preamble** composed at submit time, and the submit that empties the queue only on dispatch | stateful (target, queue) |
 | `diff.lua` | Unified-diff parsing, and the intra-line spans within a paired line | pure |
-| `drafts.lua` | Note text abandoned in a composer, keyed by absolute path, in a store of its own | stateful (disk) |
+| `drafts.lua` | Note text abandoned in a composer, keyed by absolute path — or by repository, for a **preamble** — in a store of its own | stateful (disk) |
 | `fade.lua` | The **faded** file rule: which rows one file's fade covers, and which group a faded row carries in place of its own | stateful (editor) |
 | `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes | stateful (git) |
 | `hl.lua` | The highlight groups: `default = true` links into whatever colorscheme is active, and the blended twin of each group a **muted** window draws | stateful (editor) |
@@ -48,7 +48,7 @@ change there is felt through.
   is not local to a leaf almost certainly reaches one of them.
 - **On top**: `capture`, then `init`.
 
-## The two cycles
+## The three cycles
 
 `view` and `annotate` require each other. This is known and accepted — not a defect to fix
 in passing. `annotate` needs the focused pane, the current view, the repaint and the anchor
@@ -62,7 +62,15 @@ the `since-batch` scope. Function-local on both sides, as above. The alternative
 the snapshot in from outside, which would put the one scope that needs it into every caller
 of `resolve_scope` — and scope resolution is exactly what must stay one function.
 
-`keymaps`, `queue_float`, `view_layout` and `view_panel` would each be a third. All four run
+`delivery` and `composer` are the third, and the smallest. A **preamble** is composed at
+submit time, so the submit has to reach whichever composer is wired — and the plugin's own
+is the *default implementation* of that adapter rather than a fallback beside it (ADR-0003),
+so "whichever is wired" always includes it. The composer points back for one field: the
+footer it draws names the batch's target, and routing is delivery's. Function-local on both
+sides, as above. The alternative was handing the composer in from every caller, which buys
+nothing and spreads the one rule ADR-0003 exists to keep in one place.
+
+`keymaps`, `queue_float`, `view_layout` and `view_panel` would each be a fourth. All four run
 the view's exported actions, and all four take them as an argument — `view` hands itself in —
 rather than requiring `view` for them. That is deliberate, and it is what leaves `keymaps` a
 function of its arguments and the configured annotation types. `queue_float` reads no view

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -13,10 +13,15 @@
 ---And the submit, which is what holds the rule the other two serve: restore the queue,
 ---deliver it, and empty it only if the send reports it went (ADR-0005).
 ---
----Windows are deliberately not its business. It calls the picker adapter and keeps what
----comes back; putting focus back where the question was asked is the one concession, and
----only because the picker answers on a later tick, by which time no caller is still on the
----stack to do it. What a surface then has to repaint is the surface's own affair.
+---The **preamble** is composed here for the same reason the handoff is. It is written at
+---the moment the batch goes, it is rendered with the batch, and it is not an **entry** --
+---so no queue holds it and no surface is where it belongs either.
+---
+---Windows are deliberately not its business. It calls the picker and the composer adapters
+---and keeps what comes back; putting the editor back where the question was asked is the
+---one concession, and only because both answer on a later tick, by which time no caller is
+---still on the stack to do it. What a surface then has to repaint is the surface's own
+---affair.
 local config = require("codereview.config")
 local git = require("codereview.git")
 
@@ -173,11 +178,16 @@ end
 ---misrepresents the send it stands in for.
 ---@param items CRAnnotation[]
 ---@param base string
----@param opts { scope_label?: string, files?: integer, reviewed?: integer }
+---@param opts { preamble?: string, scope_label?: string, files?: integer, reviewed?: integer }
 ---@return string
 local function render_at(items, base, opts)
   return require("codereview.payload").render(items, base, {
     types = config.get().types,
+    -- Absent on every path but a submit that composed one. A copy performs no submit, so it
+    -- composes nothing and carries nothing, and an **immediate send** is a batch of one with
+    -- no batch to cover (ADR-0004) -- both reach this with no preamble in their opts rather
+    -- than with a rule of their own saying so.
+    preamble = opts.preamble,
     scope_label = opts.scope_label,
     files = opts.files,
     reviewed = opts.reviewed,
@@ -192,7 +202,7 @@ end
 ---an agent would have been given.
 ---@param items CRAnnotation[]
 ---@param to table|nil Where it would be going, or nil for the adapter's default
----@param opts { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---@param opts { root?: string, preamble?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
 ---@return string
 function M.render(items, to, opts)
   opts = opts or {}
@@ -209,7 +219,7 @@ end
 ---knowing about views ended up depending on one being open.
 ---@param items CRAnnotation[]
 ---@param to table|nil Where it is going, or nil for whatever the adapter defaults to
----@param opts { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---@param opts { root?: string, preamble?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
 ---       `root` is the review's, when there is one. Without it the working directory's
 ---       repository stands in, which is the only answer available to a caller -- buffer
 ---       capture sending a single note -- that never had a review behind it.
@@ -275,8 +285,11 @@ end
 ---Here rather than on the review view because a batch is not a window. It can be
 ---submitted with nothing open, and what remains the view's share of this is closing the
 ---float that was listing the batch and repainting the diff behind it.
----@param ctx { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
----       What the review the batch came from can say about itself, when there was one.
+---@param ctx { root?: string, preamble?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---       What the review the batch came from can say about itself, when there was one, plus
+---       the **preamble** when one was composed for this batch. The preamble arrives here
+---       rather than out of the queue because it is not an **entry**: it is written about
+---       the batch, at the moment the batch goes.
 ---@return boolean dispatched
 function M.submit(ctx)
   local queue = require("codereview.queue")
@@ -313,6 +326,111 @@ function M.submit(ctx)
     )
   )
   return true
+end
+
+---Put the editor back once a composer has handed control over.
+---
+---Two concessions of the same kind the picker already makes: windows are not this module's
+---business, but a composer answers on a later tick and no caller is still on the stack by
+---then. Closing a window does not end insert mode, so a composer submitted from its
+---insert-mode mapping leaves focus in the review buffer still inserting -- and that buffer
+---is `nomodifiable`, where every navigation key lands as a failed edit instead of a motion.
+---A composer the plugin did not ship is under no obligation to put focus back either.
+---
+---Scheduled rather than immediate: returning from an insert-mode mapping puts Vim straight
+---back into insert, and a composer is free to call back before closing its own window.
+---@param win integer The window the submit was asked for from
+local function restore_editing(win)
+  vim.schedule(function()
+    if vim.fn.mode():sub(1, 1) == "i" then
+      vim.cmd("stopinsert")
+    end
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_set_current_win(win)
+    end
+  end)
+end
+
+---Compose a **preamble**, then submit the batch under it.
+---
+---The fast path costs nothing: this is the ordinary submit with a composer in front of it,
+---and the rule behind it is the same one -- a dispatch is what empties the queue, and
+---nothing else does (ADR-0005). The flow is here for the reason the submit is: none of it
+---is about a window, and both work with nothing open.
+---
+---An abandoned composer is not a submit. A composer that is dismissed never calls back, so
+---nothing is rendered, nothing is handed to the adapter, nothing is archived and the queue
+---is exactly where it was -- and what was typed is kept as a **draft** by whichever composer
+---collected it, under the key that composer read on the way in.
+---
+---The preamble never joins the queue. It is composed here, at the moment the batch goes,
+---handed to the renderer as one more thing the payload is rendered with, and forgotten. The
+---queue keeps **entries** and nothing else, so nothing about its shape or its persistence
+---changes.
+---@param ctx { root?: string, scope_label?: string, files?: integer, reviewed?: integer }|nil
+---       What the review the batch came from can say about itself, exactly as `submit`
+---       takes it. The preamble is added to it here.
+---@param after fun(dispatched: boolean)|nil Runs once a submit has been made, which an
+---       abandoned composer never is. What a surface repaints afterwards is its own affair,
+---       and it can no longer do it when this returns: the composer answers on a later tick.
+function M.submit_with_preamble(ctx, after)
+  local queue = require("codereview.queue")
+  ctx = ctx or {}
+
+  -- Asked before the composer opens rather than after it closes, exactly as an immediate
+  -- send asks for its target first: there is no covering note worth writing for a batch that
+  -- does not exist, and discovering that afterwards would cost what was written.
+  ensure_queue()
+  local count = queue.count()
+  if count == 0 then
+    info("Queue is empty — annotate something first")
+    return
+  end
+
+  -- The repository the batch is going out of, resolved exactly as the batch's own
+  -- destination resolves it, so the preamble's draft is filed against the same repository
+  -- the archive is keyed on.
+  local _, repo = destination(target, ctx)
+  local compose_ctx = {
+    -- The adapter contract's own field, answered honestly: a preamble carries no separate
+    -- context either, and there is no file for `rel_path` or `file_path` to name.
+    scope = "none",
+    label = ("Preamble · %d annotation%s"):format(count, count == 1 and "" or "s"),
+    preamble = true,
+    root = repo,
+    -- The batch's routing, because a preamble goes exactly where the batch goes. It is the
+    -- same footer and the same key an annotation joining the queue gets.
+    routing = M.routing(),
+    -- Read before anything opens, and handed on: a composer the reviewer dismisses never
+    -- calls back, so on that path nothing but the composer can put focus back.
+    origin_win = vim.api.nvim_get_current_win(),
+  }
+
+  local compose = config.get().compose or require("codereview.composer").open
+  -- "submit" is the verb the composer names its submit key with. What that key does here is
+  -- exactly what `<C-s>` on the diff does, which is why it is not called anything else.
+  compose(compose_ctx, function(_, text)
+    restore_editing(compose_ctx.origin_win)
+
+    -- Whatever the composer collected, including nothing at all: the submit key means
+    -- submit, and an empty preamble renders nothing, leaving the payload what it was.
+    ctx.preamble = text or ""
+    local dispatched = M.submit(ctx)
+
+    -- Where a batch that did not go keeps its entries in the queue to be retried, a preamble
+    -- has no queue to wait in -- and by now the composer has closed its window, wiped its
+    -- buffer and cleared its draft, because a submitted note is not an abandoned one. Same
+    -- shape as an undispatched immediate send, and the same reason (ADR-0005): the reviewer
+    -- typed it once. The next `<C-a>` reads it back from the key it was written under.
+    if not dispatched then
+      local drafts = require("codereview.drafts")
+      drafts.set(drafts.key(compose_ctx), ctx.preamble)
+    end
+
+    if after then
+      after(dispatched)
+    end
+  end, "submit")
 end
 
 ---Put the payload in the `+` register, deliberately, without submitting the batch.

--- a/lua/codereview/drafts.lua
+++ b/lua/codereview/drafts.lua
@@ -66,9 +66,22 @@ end
 ---draft -- they are the same thought about the same code, and both paths already carry a
 ---canonical absolute path. A bare note has no file at all, and every bare note shares the
 ---one slot there is.
+---
+---A **preamble** has no file either, and keying it by one would file prose about a batch
+---under whichever file the reviewer happened to be looking at. It is keyed by the repository
+---the batch is going out of, and by one fixed key outside a checkout -- the same split the
+---**queue**'s two stores already make, and the same reason: what has no repository behind it
+---has to share one slot. That leaves one preamble draft per repository, which is what a
+---reviewer coming back to a batch they were writing for expects.
+---
+---Prefixed, so neither preamble key can collide with an absolute path or with the bare
+---note's slot. Nothing else in this store carries a prefix, because nothing else needs one.
 ---@param ctx table
 ---@return string
 function M.key(ctx)
+  if ctx.preamble then
+    return ("preamble:%s"):format(ctx.root or "(no repository)")
+  end
   return ctx.file_path or "(no file)"
 end
 

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -122,6 +122,9 @@ function M.diff(buf, view)
     ["gy"] = { view.copy, "Copy the batch to the clipboard" },
     ["<C-t>"] = { view.pick_target, "Choose the delivery target" },
     ["<C-s>"] = { view.submit, "Submit the batch" },
+    -- `<C-a>` for the reason `a` became the annotation prefix: increment is dead in a
+    -- nomodifiable buffer, so it costs a keystroke and no motion.
+    ["<C-a>"] = { view.submit_with_preamble, "Submit the batch under a preamble" },
     ["q"] = { view.close, "Close the review" },
   })
 

--- a/lua/codereview/payload.lua
+++ b/lua/codereview/payload.lua
@@ -130,7 +130,9 @@ end
 ---Render the whole queue as one message.
 ---@param items CRAnnotation[]
 ---@param base string Directory `@refs` should resolve against
----@param opts { types: CRType[], scope_label?: string, files?: integer, reviewed?: integer }
+---@param opts { types: CRType[], preamble?: string, scope_label?: string, files?: integer, reviewed?: integer }
+---       `preamble` is the prose the batch is covered by, composed at submit time. It is
+---       not an entry and never comes out of the queue.
 ---@return string
 function M.render(items, base, opts)
   local out = {}
@@ -138,6 +140,19 @@ function M.render(items, base, opts)
   -- Once, before the entries: the comparison below is against paths that are already
   -- canonical, and `base` is the only side that never went through git or a realpath.
   base = M.resolve_base(base)
+
+  -- Above the header rather than under it, because it is read first: the agent is told what
+  -- the batch is about before it is told what is in it.
+  --
+  -- Trimmed, so that the blank line below it is the one this renderer writes and not one the
+  -- reviewer happened to leave at the end of a composer. Nothing to say is nothing rendered:
+  -- an empty preamble leaves the message byte for byte what it was before preambles existed,
+  -- which is what makes the whole feature cost the fast path nothing.
+  local preamble = vim.trim(opts.preamble or "")
+  if preamble ~= "" then
+    out[#out + 1] = preamble
+    out[#out + 1] = ""
+  end
 
   -- Grouped from the arguments rather than through queue.lua, so this stays a pure
   -- function of them: the same list always renders the same message, which is what makes

--- a/lua/codereview/queue_float.lua
+++ b/lua/codereview/queue_float.lua
@@ -291,7 +291,7 @@ function M.open(view)
       n == 1 and "" or "s",
       stale > 0 and (" · %d stale"):format(stale) or ""
     )
-    cfg_win.footer = (" ^T %s · ⏎ jump · x drop · gy copy · ^S submit · q close "):format(
+    cfg_win.footer = (" ^T %s · ⏎ jump · x drop · gy copy · ^S submit · ^A preamble · q close "):format(
       #name > 24 and (name:sub(1, 23) .. "…") or name
     )
     if vim.api.nvim_win_is_valid(win) then
@@ -376,6 +376,13 @@ function M.open(view)
     close()
     view.submit()
   end, { buffer = buf, desc = "Submit the batch" })
+
+  -- Closed first, exactly as `<C-s>` closes it: the composer opens over this list, and a
+  -- batch that is about to go must not be left listed behind it.
+  vim.keymap.set("n", "<C-a>", function()
+    close()
+    view.submit_with_preamble()
+  end, { buffer = buf, desc = "Submit the batch under a preamble" })
 
   vim.keymap.set("n", "q", close, { buffer = buf, desc = "Close (keeps the queue)" })
   vim.keymap.set("n", "<Esc>", close, { buffer = buf, desc = "Close (keeps the queue)" })

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1301,6 +1301,17 @@ local function review_ctx()
   return { root = V_.root, scope_label = V_.scope.label, files = #V_.files, reviewed = reviewed }
 end
 
+---Close a float that is listing the batch about to be handed over.
+---
+---Shared by both submit keys: a submitted batch must never leave a dialog listing it on
+---screen, and a composer opening over that dialog is no better.
+local function close_queue_float()
+  if V and V.queue_win and vim.api.nvim_win_is_valid(V.queue_win) then
+    vim.api.nvim_win_close(V.queue_win, true)
+    V.queue_win = nil
+  end
+end
+
 ---Submit the batch, and put the windows back the way a sent batch leaves them.
 ---
 ---The rule -- restore, deliver, empty only on a dispatch -- is delivery's, because none of
@@ -1309,10 +1320,7 @@ end
 ---review can say about itself.
 function M.submit()
   -- Submitting empties the queue, so any open queue float is now describing nothing.
-  if V and V.queue_win and vim.api.nvim_win_is_valid(V.queue_win) then
-    vim.api.nvim_win_close(V.queue_win, true)
-    V.queue_win = nil
-  end
+  close_queue_float()
 
   local dispatched = delivery.submit(review_ctx())
   -- A batch that did not go is still queued and still drawn on the diff, so there is
@@ -1325,6 +1333,32 @@ function M.submit()
     judge_archive()
     M.paint()
   end
+end
+
+---Submit the batch under a **preamble**, written in the composer first.
+---
+---`<C-s>` with a composer in front of it and the same submit behind it, so the fast path
+---costs nothing: `<C-s>` still asks no questions. The flow itself is delivery's, for the
+---reason the plain submit's is -- none of it is about a window, and it works with nothing
+---open.
+---
+---What is left here is what submitting already left here, a composer later: the float that
+---was listing the batch, and the diff behind it once something has actually gone. Handed
+---over rather than run in order, because a composer answers on a later tick and an abandoned
+---one never answers at all -- and an abandoned composer is not a submit, so there is nothing
+---to repaint.
+function M.submit_with_preamble()
+  close_queue_float()
+
+  delivery.submit_with_preamble(review_ctx(), function(dispatched)
+    if dispatched then
+      -- Exactly what the plain submit does with a dispatch, and for the same reasons: the
+      -- batch that just went was snapshotted a moment ago, so every entry in it is
+      -- untouched and the winbar should say so now rather than at the next reconcile.
+      judge_archive()
+      M.paint()
+    end
+  end)
 end
 
 ---Copy the batch to the clipboard, exactly as submitting would have rendered it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,6 +33,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/muted_child.lua` | Spawned four times by `muted_spec`, one painted cell each — deliberately not a spec. |
 | `codereview/faded_child.lua` | Spawned three times by `faded_spec`, one painted cell each — deliberately not a spec. |
 | `codereview/quiet_child.lua` | Spawned eight times by `quiet_spec`, one painted cell each, where two quiet states meet — deliberately not a spec. |
+| `codereview/drafts_child.lua` | Spawned by `drafts_spec` to abandon a half-written note and exit — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `codereview/winbar_child.lua` | Spawned three times by `split_spec` to read one cell of a pane's winbar — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
@@ -48,7 +49,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
 | `bounded_spec` | Emission bounded by the viewport: what a paint writes and what it leaves out, the bound it shares with the harvest, what a scroll adds and what scrolling back does not, both panes at once — on a diff taller than the window, guarded |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
-| `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit |
+| `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit, and the **preamble**: above the header, the empty one that renders nothing, and the same arguments rendering the same message |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
 | `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, and the four things it refuses |
@@ -56,7 +57,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
-| `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, the draft an undispatched immediate send leaves behind, and the deliberate copy that is not a dispatch |
+| `delivery_spec` | What a send adapter may report — nothing, true, false, a raise — the clipboard default, the one condition that empties the queue, the draft an undispatched immediate send leaves behind, and the deliberate copy that is not a dispatch; then the **preamble**: `<C-a>` from the diff and from the float with and without a review, the empty one that submits anyway, the abandoned composer that submits nothing, and what a copy and a batch of one carry instead (nothing) |
 | `capture_spec` | Annotating from an ordinary buffer: scope, types, declining one, blob, composer, diagnostics, restart, one queue, the immediate send |
 | `staleness_spec` | Buffer annotations going stale: judged against disk at any scope, on restore, and in view |
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
@@ -65,7 +66,8 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colours one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
-| `focus_spec` | Queue-float focus across the async picker, submit closing the float |
+| `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
+| `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
 | `queue_jump_panel_spec` | That jump with the tree dismissed, summoned, and never there — the one surface neither slice could test alone |
 | `interactive_spec` | The insert-mode leak, and where a completed or cancelled `@` leaves you, in a real pty-backed Neovim |
@@ -391,6 +393,14 @@ so the out-of-core language path is still checked locally without ever failing C
   answers a tick later, which is the shape a real picker has and the only one that
   reproduces the defect. `composer_spec`'s file picker still answers inline on purpose: it
   is asserting text and cursor, not mode.
+- **A focus assertion made on the tick an annotation restored focus is measuring that
+  restore.** `annotate`'s `collect` schedules a focus restore of its own, and the `vim.wait`
+  a later assertion spends waiting for focus to settle is what pumps it. So a block that
+  queues an annotation and then submits on the same tick passes with the *submit's* restore
+  deleted — measured twice while `focus_spec`'s preamble cases were being written, each cut
+  applied on its own. Draining the loop between the two is what gives the second one teeth,
+  and the case that needs it is the one where the batch was refused: a dispatch repaints,
+  and the repaint puts focus back whether or not anything else does.
 - **`scrollbind` and `cursorbind` follow motions, not the API.** They *do* work in a
   headless Neovim, which was measured rather than assumed: a `normal!` motion, a `<C-e>`
   and fed keys all propagate to the bound window, and `nvim_win_set_cursor` does not.

--- a/tests/codereview/delivery_spec.lua
+++ b/tests/codereview/delivery_spec.lua
@@ -587,3 +587,296 @@ describe("a copy taken with a review view open", function()
     assert.same(sent[#sent].text, copied)
   end)
 end)
+
+--- The preamble, which is composed and never queued ----------------------------
+
+-- `<C-a>` is `<C-s>` with a composer in front of it. What the composer collects is rendered
+-- above the batch's header; the submit that follows is the same submit, under the same one
+-- rule about what empties the queue (ADR-0005).
+--
+-- The compose adapter is the seam here, exactly as `send` is below it: the composer the
+-- plugin ships is the default implementation of that contract and not a lesser path beside
+-- it (ADR-0003), so a stub that answers is the honest way to drive the flow.
+describe("a batch submitted with a preamble", function()
+  codereview.open("branch")
+  local composed = {}
+  cfg.compose = function(ctx, on_accept, label)
+    composed[#composed + 1] = { ctx = ctx, label = label }
+    on_accept(nil, "read the second one first")
+  end
+  queue_one("submitted under a preamble")
+  local before, before_archive = #sent, #archived()
+  local msgs, restore = h.capture_notify()
+  h.feed("<C-a>")
+  restore()
+
+  it("opens a composer", function()
+    assert.same(1, #composed)
+  end)
+
+  -- A preamble is about the batch, so the composer is told nothing about a file: there is
+  -- none, and a path there would key its draft to code the preamble is not about.
+  it("tells the composer it is writing a preamble, not annotating a file", function()
+    assert.is_nil(composed[1].ctx.file_path)
+    assert.is_nil(composed[1].ctx.rel_path)
+    assert.is_true(composed[1].ctx.preamble)
+    assert.same(root, composed[1].ctx.root)
+  end)
+
+  it("hands the adapter the preamble above the batch's header", function()
+    assert.same(before + 1, #sent)
+    assert.same("read the second one first", vim.split(sent[#sent].text, "\n")[1])
+    assert.is_truthy(sent[#sent].text:find("\n\nCode review — 1 annotation", 1, true), sent[#sent].text)
+  end)
+
+  it("empties the queue, because a dispatch is a dispatch", function()
+    assert.same(0, queue.count())
+  end)
+
+  it("records the batch in the archive", function()
+    assert.same(before_archive + 1, #archived())
+  end)
+
+  it("confirms it in the words `<C-s>` confirms a submit in", function()
+    assert.is_true(h.notified(msgs, "Submitted 1 annotation"), vim.inspect(msgs))
+  end)
+
+  -- The queue keeps entries and nothing else. A preamble is composed at submit time, so
+  -- there is nothing about it for the queue's document to have written down.
+  it("writes no preamble into the persisted queue", function()
+    local doc = table.concat(vim.fn.readfile(state.path(root)), "\n")
+    assert.is_nil(doc:find("read the second one first", 1, true), doc)
+  end)
+end)
+
+-- The other surface a batch is submitted from. The float lists the batch, so a submit
+-- through it closes it exactly as `<C-s>` does: what has gone must not be left on screen.
+describe("a batch submitted with a preamble from the queue float", function()
+  queue_one("submitted from the list")
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "written over the queue")
+  end
+  codereview.queue()
+  local float = vim.api.nvim_get_current_win()
+  local before = #sent
+  h.feed("<C-a>")
+
+  it("opened a float to submit from", function()
+    assert.is_truthy(float)
+  end)
+
+  it("closes the float", function()
+    assert.is_false(vim.api.nvim_win_is_valid(float))
+  end)
+
+  it("dispatches with the preamble above the header", function()
+    assert.same(before + 1, #sent)
+    assert.same("written over the queue", vim.split(sent[#sent].text, "\n")[1])
+  end)
+
+  it("empties the queue", function()
+    assert.same(0, queue.count())
+  end)
+end)
+
+-- The float opens with no review view, as a batch is submitted with none. The view is what
+-- closes a float over a batch that has gone, and with nothing open there is no view to do
+-- it -- so the float closing is the float's own business on this path and nobody else's.
+describe("a preamble submitted from the queue float with no review open", function()
+  codereview.close()
+  queue_one("submitted from a float with nothing behind it")
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "written with no review open")
+  end
+  codereview.queue()
+  local float = vim.api.nvim_get_current_win()
+  local before = #sent
+  h.feed("<C-a>")
+
+  it("had no review view to lean on", function()
+    assert.is_nil(require("codereview.view").current())
+  end)
+
+  it("closes the float", function()
+    assert.is_false(vim.api.nvim_win_is_valid(float))
+  end)
+
+  it("dispatches with the preamble above the header", function()
+    assert.same(before + 1, #sent)
+    assert.same("written with no review open", vim.split(sent[#sent].text, "\n")[1])
+    assert.same(0, queue.count())
+  end)
+end)
+
+-- The submit key means submit. A reviewer who opens the composer and decides they have
+-- nothing to write still asked for a batch to go, and an empty preamble renders nothing --
+-- so what goes is exactly what `<C-s>` would have sent.
+describe("a preamble left empty", function()
+  -- Back on the diff, where both keys are bound: the block above submitted with the review
+  -- closed, and the pair below is a claim about what the two keys produce from one surface.
+  codereview.open("branch")
+  cfg.compose = nil
+  queue_one("byte for byte")
+  h.feed("<C-s>")
+  local plain = sent[#sent].text
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "")
+  end
+  queue_one("byte for byte")
+  local before = #sent
+  h.feed("<C-a>")
+
+  it("submits anyway", function()
+    assert.same(before + 1, #sent)
+    assert.same(0, queue.count())
+  end)
+
+  it("hands over the payload `<C-s>` produces, byte for byte", function()
+    assert.same(plain, sent[#sent].text)
+  end)
+end)
+
+-- Backing out of the note backs out of the send. A composer that never calls back is what
+-- abandoning one looks like from here: nothing was collected, so nothing was submitted.
+describe("a preamble composer that was abandoned", function()
+  queue_one("still here, because nothing was submitted")
+  cfg.compose = function() end
+  local before, before_archive = #sent, #archived()
+  local msgs, restore = h.capture_notify()
+  h.feed("<C-a>")
+  restore()
+
+  it("hands the send adapter nothing", function()
+    assert.same(before, #sent)
+  end)
+
+  it("leaves the queue whole", function()
+    assert.same(1, queue.count())
+    assert.same("still here, because nothing was submitted", queue.all()[1].note)
+  end)
+
+  it("archives nothing, because nothing was dispatched", function()
+    assert.same(before_archive, #archived())
+  end)
+
+  it("claims nothing was submitted", function()
+    assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
+  end)
+
+  -- The batch is exactly where it was, so the fast path still takes it.
+  it("leaves the batch submittable", function()
+    h.feed("<C-s>")
+    assert.same(before + 1, #sent)
+    assert.same(0, queue.count())
+  end)
+end)
+
+-- An empty queue is an empty queue whichever key was pressed, and there is no covering note
+-- worth writing for a batch that does not exist.
+describe("a preamble asked for with nothing queued", function()
+  queue.clear()
+  local composed = 0
+  cfg.compose = function(_, on_accept)
+    composed = composed + 1
+    on_accept(nil, "nothing to cover")
+  end
+  local before = #sent
+  local msgs, restore = h.capture_notify()
+  h.feed("<C-a>")
+  restore()
+
+  it("opens no composer", function()
+    assert.same(0, composed)
+  end)
+
+  it("takes the guard `<C-s>` takes, worded the same", function()
+    assert.is_true(h.notified(msgs, "Queue is empty — annotate something first"), vim.inspect(msgs))
+    assert.same(before, #sent)
+  end)
+end)
+
+-- A batch that did not go is still queued and can be retried. The preamble has no queue to
+-- wait in, so it goes where an undispatched errand's note goes (ADR-0005): the draft store,
+-- under the key the composer wrote it from.
+describe("a preamble whose batch was not dispatched", function()
+  drafts.clear()
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "kept, because nothing took the batch")
+  end
+  cfg.send = function(text, target)
+    records(text, target)
+    return false, "the agent pane is gone"
+  end
+  queue_one("queued still")
+  local msgs, restore = h.capture_notify()
+  h.feed("<C-a>")
+  restore()
+  cfg.send = records
+
+  it("keeps the queue", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("says why it did not go", function()
+    assert.is_true(h.notified(msgs, "the agent pane is gone"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "Submitted"), vim.inspect(msgs))
+  end)
+
+  -- Written once. The shipped composer is what reads a draft back, so the proof that
+  -- "kept" means what it says is the next `<C-a>` holding it.
+  it("offers the preamble back the next time one is asked for", function()
+    cfg.compose = nil
+    h.feed("<C-a>")
+    local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    h.feed("q")
+    assert.same({ "kept, because nothing took the batch" }, reopened)
+  end)
+end)
+
+-- Copy is deliberately not a dispatch, and a preamble belongs to a send: `gy` performs no
+-- submit, so it composes nothing and carries nothing.
+describe("copying a batch with a compose adapter wired", function()
+  drafts.clear()
+  queue_one("copied without a preamble")
+  local composed = 0
+  cfg.compose = function(_, on_accept)
+    composed = composed + 1
+    on_accept(nil, "never in a copy")
+  end
+  vim.fn.setreg("+", "")
+  h.feed("gy")
+  local copied = vim.fn.getreg("+")
+
+  it("opens no composer", function()
+    assert.same(0, composed)
+  end)
+
+  it("heads the register with the batch's own header", function()
+    assert.is_truthy(vim.split(copied, "\n")[1]:find("Code review — 1 annotation", 1, true), copied)
+  end)
+
+  it("carries no preamble at all", function()
+    assert.is_nil(copied:find("never in a copy", 1, true), copied)
+  end)
+end)
+
+-- An immediate send is a batch of one (ADR-0004) and the smallest act there is: it bypasses
+-- the queue, so there is no batch for a preamble to cover.
+describe("an immediate send", function()
+  queue.clear()
+  codereview.close()
+  vim.cmd("edit " .. vim.fn.fnameescape(main))
+  cfg.compose = function(_, on_accept)
+    on_accept(nil, "an errand under no preamble")
+  end
+  codereview.annotate("bug", nil, { immediate = true })
+  cfg.compose = nil
+
+  it("heads its payload with the batch header, with nothing above it", function()
+    assert.is_truthy(vim.split(sent[#sent].text, "\n")[1]:find("Code review — 1 annotation", 1, true))
+  end)
+
+  it("carries the note it collected as an annotation, not as a preamble", function()
+    assert.is_truthy(sent[#sent].text:find("### 1. ", 1, true), sent[#sent].text)
+  end)
+end)

--- a/tests/codereview/drafts_spec.lua
+++ b/tests/codereview/drafts_spec.lua
@@ -68,3 +68,137 @@ describe("the writing session", function()
     end)
   end)
 end)
+
+--- The preamble's draft, which is keyed by a repository rather than by a file ---------
+
+-- Abandon a **preamble** and the text is kept exactly as a note's is. What differs is the
+-- key: a preamble is written about a **batch** and not about a file, so it is filed against
+-- the repository the batch would go out of, and one written outside a checkout shares the
+-- single slot there is -- the same split the **queue**'s two stores already make.
+--
+-- Driven through the view's action rather than `<C-a>` itself, as the cases above are driven
+-- through `annotate`: which key reaches it is `delivery_spec`'s claim, and a draft is not
+-- about a keystroke.
+local codereview = require("codereview")
+local view = require("codereview.view")
+local queue = require("codereview.queue")
+local git = require("codereview.git")
+
+describe("a preamble abandoned in the composer", function()
+  -- The composer the block above left open. Abandoned rather than left floating over
+  -- everything below it, and the store wiped afterwards so nothing here is restored by
+  -- accident.
+  h.feed("q")
+  view.close()
+  drafts.clear()
+
+  -- Something to cover. A preamble is only ever asked for when there is a batch to write it
+  -- above, and the guard that says so runs before any composer opens.
+  queue.clear()
+  queue.add({ type = "bug", kind = "note", note = "something worth covering" })
+
+  view.submit_with_preamble()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "read the third one first" })
+  h.feed("q")
+
+  it("leaves the queue whole, because abandoning is not submitting", function()
+    assert.same(1, queue.count())
+  end)
+
+  view.submit_with_preamble()
+  local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  h.feed("q")
+
+  it("offers it back to the next preamble asked for in that repository", function()
+    assert.same({ "read the third one first" }, reopened)
+  end)
+end)
+
+describe("a preamble asked for in another repository", function()
+  -- A second checkout, built rather than borrowed: "keyed by the repository" is a claim
+  -- about two of them, and one repository cannot make it.
+  local other = h.fixture("mktree")
+  vim.cmd("cd " .. vim.fn.fnameescape(other))
+
+  it("is a different repository from the first", function()
+    assert.are_not.same(vim.uv.fs_realpath(fixture), vim.uv.fs_realpath(other))
+    assert.is_truthy(git.root(other))
+  end)
+
+  view.submit_with_preamble()
+  local opened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "written in the other checkout" })
+  h.feed("q")
+
+  it("opens on an empty composer", function()
+    assert.same({ "" }, opened)
+  end)
+
+  vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+  view.submit_with_preamble()
+  local first = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  h.feed("q")
+
+  it("leaves the first repository's preamble where it was", function()
+    assert.same({ "read the third one first" }, first)
+  end)
+end)
+
+-- The other half of the split: what has no repository behind it has to share one slot,
+-- because there is nothing to key it by. Two directories outside a checkout are the same
+-- reviewer with the same batch in front of them.
+describe("a preamble with no repository behind it", function()
+  local outside = vim.fn.tempname() .. "-outside"
+  local elsewhere = vim.fn.tempname() .. "-elsewhere"
+  vim.fn.mkdir(outside, "p")
+  vim.fn.mkdir(elsewhere, "p")
+
+  -- Asserted rather than assumed: if the temp directory ever sits inside a repository, both
+  -- cases below silently become a test of the ordinary in-repository path.
+  it("has two directories genuinely outside any checkout", function()
+    assert.is_nil(git.root(outside), outside .. " is inside a checkout")
+    assert.is_nil(git.root(elsewhere), elsewhere .. " is inside a checkout")
+  end)
+
+  vim.cmd("cd " .. vim.fn.fnameescape(outside))
+  view.submit_with_preamble()
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "loose prose about a loose batch" })
+  h.feed("q")
+
+  vim.cmd("cd " .. vim.fn.fnameescape(elsewhere))
+  view.submit_with_preamble()
+  local reopened = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  h.feed("q")
+
+  it("meets the same draft from any directory outside one", function()
+    assert.same({ "loose prose about a loose batch" }, reopened)
+  end)
+end)
+
+-- A **bare note** has no file either, and every bare note shares the one slot there is. A
+-- preamble is not a bare note: filing one where the other lives would hand a reviewer their
+-- covering prose when they annotate a thought, and their thought when they cover a batch.
+describe("a preamble beside a bare note's draft", function()
+  vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+  vim.cmd("enew")
+  codereview.annotate("issue")
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, { "a thought with no file behind it" })
+  h.feed("q")
+
+  view.submit_with_preamble()
+  local preamble = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  h.feed("q")
+
+  it("opens holding the repository's preamble, not the bare note", function()
+    assert.same({ "read the third one first" }, preamble)
+  end)
+
+  vim.cmd("enew")
+  codereview.annotate("issue")
+  local note = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  h.feed("q")
+
+  it("leaves the bare note's draft where it was", function()
+    assert.same({ "a thought with no file behind it" }, note)
+  end)
+end)

--- a/tests/codereview/focus_spec.lua
+++ b/tests/codereview/focus_spec.lua
@@ -232,6 +232,92 @@ local function settled(win)
   return vim.api.nvim_get_current_win()
 end
 
+--- Submitting under a preamble ---------------------------------------------------
+
+-- `<C-a>` is a submit too, so the two window rules a submit carries are its rules as well,
+-- one composer later. The float here has already lost focus, which is the state the view's
+-- own rule exists for: the failure `<C-s>` had was a batch sent with a dialog left on
+-- screen listing it.
+--
+-- The composer for the submit itself hands back from the tree, rather than through the
+-- host-shaped stand-in above. Measured, not assumed: closing that stand-in's windows leaves
+-- focus on the diff here anyway, so an assertion made against it would pass with nothing
+-- restoring anything -- the same trap the stand-in was written for on the annotation path.
+-- A host composer is a window of its own and is entitled to hand back from wherever it
+-- likes; the plugin is what puts focus back (see `codereview-opt-compose`).
+---@param text string
+---@return fun(ctx: table, on_accept: fun(target: table|nil, text: string))
+local function composer_handing_back_from_the_tree(text)
+  return function(_, on_accept)
+    local tree = assert(V.panel_win, "no file tree to hand back from")
+    vim.api.nvim_set_current_win(tree)
+    on_accept(nil, text)
+  end
+end
+
+describe("submitting under a preamble from the diff while a float is open", function()
+  sent = {}
+  composer = host_composer("something worth covering")
+  annotate_something("fix")
+  composer = composer_handing_back_from_the_tree("read the whole thing first")
+  view.review_queue()
+  local qwin = vim.api.nvim_get_current_win()
+
+  it("opened a float", function()
+    assert.is_true(vim.api.nvim_win_is_valid(qwin))
+  end)
+
+  vim.api.nvim_set_current_win(V.win)
+  view.submit_with_preamble()
+
+  it("submits the batch under what the composer collected", function()
+    assert.same(1, #sent)
+    assert.same("read the whole thing first", vim.split(sent[1].text, "\n")[1])
+    assert.same(0, queue.count())
+  end)
+
+  it("leaves no stale float behind", function()
+    assert.is_false(vim.api.nvim_win_is_valid(qwin))
+    assert.is_nil(V.queue_win)
+  end)
+end)
+
+-- Where the reviewer is left afterwards. A batch that did not go repaints nothing --
+-- there is nothing new to draw and the entries are all still queued -- so nothing behind
+-- the composer moves the cursor back, and a reviewer who asked from the diff would be left
+-- in the tree with a batch to retry.
+describe("a preamble whose batch the adapter refused", function()
+  local cfg = require("codereview.config").get()
+  local sending = cfg.send
+  composer = host_composer("something worth covering")
+  annotate_something("fix")
+  -- Drained before the submit starts. The annotation above restores focus on the *next*
+  -- tick, so a submit begun on this one would be measured against that restore rather than
+  -- against anything this block does -- and the case would pass with nothing here restoring
+  -- anything. Measured: without this the assertion below survives the restore being cut.
+  vim.wait(50)
+  cfg.send = function()
+    return false, "the agent pane is gone"
+  end
+  composer = composer_handing_back_from_the_tree("kept for the retry")
+
+  vim.api.nvim_set_current_win(V.win)
+  local msgs, restore = h.capture_notify()
+  view.submit_with_preamble()
+  restore()
+  local focused = settled(V.win)
+  cfg.send = sending
+
+  it("keeps the batch to be retried", function()
+    assert.same(1, queue.count())
+    assert.is_true(h.notified(msgs, "the agent pane is gone"), vim.inspect(msgs))
+  end)
+
+  it("still puts focus back in the window the submit was asked from", function()
+    assert.same(V.win, focused)
+  end)
+end)
+
 describe("annotating from the diff", function()
   composer = host_composer("a note")
 

--- a/tests/codereview/payload_spec.lua
+++ b/tests/codereview/payload_spec.lua
@@ -155,6 +155,56 @@ describe("rendering a mixed queue in-tree", function()
   end)
 end)
 
+-- The prose above the batch, addressed to the agent rather than to a line of code.
+--
+-- Rendered from the same queue the block above rendered, so "an empty preamble leaves the
+-- payload exactly as it is today" is asserted against the message this suite already pins
+-- down, byte for byte -- not against a message shaped for the case.
+describe("rendering a batch with a preamble", function()
+  local opts = { types = config.get().types, scope_label = V.scope.label, files = #V.files, reviewed = 0 }
+  ---@param preamble string|nil
+  local function rendered(preamble)
+    return payload.render(queue.all(), V.root, vim.tbl_extend("force", opts, { preamble = preamble }))
+  end
+  local today = rendered(nil)
+
+  it("renders the same message twice from the same arguments", function()
+    assert.same(today, rendered(nil))
+  end)
+
+  it("writes the preamble above the header, with a blank line between them", function()
+    assert.same("read the second one first\n\n" .. today, rendered("read the second one first"))
+  end)
+
+  -- The whole message, not only its first lines: a preamble is written above the batch and
+  -- changes nothing inside it.
+  it("leaves the header, the groups and the entries untouched", function()
+    local text = rendered("read the second one first")
+    assert.same(vim.split(today, "\n"), vim.list_slice(vim.split(text, "\n"), 3))
+    assert.is_truthy(text:find("\n\nCode review — 4 annotations on branch", 1, true), text)
+  end)
+
+  -- The empty case is the one a reviewer reaches by pressing the submit key on a composer
+  -- they decided they had nothing to write in.
+  it("renders nothing at all for an empty preamble", function()
+    assert.same(today, rendered(""))
+  end)
+
+  it("renders nothing for a preamble of whitespace either", function()
+    assert.same(today, rendered("  \n\n  "))
+  end)
+
+  -- A preamble arrives with the reviewer's own spacing around it, which is theirs to write
+  -- and not theirs to have counted: the blank line below it is the payload's.
+  it("keeps one blank line however the reviewer spaced it", function()
+    assert.same(rendered("mind the gap"), rendered("\n mind the gap \n\n"))
+  end)
+
+  it("keeps a preamble written over several lines as it was written", function()
+    assert.same("first line\n\nsecond line\n\n" .. today, rendered("first line\n\nsecond line"))
+  end)
+end)
+
 -- A remark worth reading with no instruction attached. It used to be dropped here: the
 -- renderer collected the entries matching each configured type, so one matching none never
 -- reached the agent at all.


### PR DESCRIPTION
## What

A **batch** can now carry a **preamble**: the prose a reviewer writes above a batch, addressed to the receiving agent, that is not an annotation.

`<C-s>` submits exactly as it did. `<C-a>` opens the shipped **composer** and submits when the composer is submitted — bound on the diff and in the queue float, the two places a batch is submitted from. `<C-a>` is free in both for the reason `a` became the annotation prefix: increment is dead in a `nomodifiable` buffer.

The payload renders the preamble above the header, then a blank line, then the header it writes today. An empty preamble renders nothing at all, so the message is byte for byte what it was.

## How it holds together

- **The preamble never enters the queue.** It is composed at submit time, handed to the renderer as one more argument and forgotten. The **queue** keeps **entries** and nothing else, so neither its shape nor its persistence moved — asserted by reading the persisted document back and finding no preamble in it.
- **`delivery` owns the flow**, because none of it is about a window and all of it works with nothing open: compose, submit, archive. `view` keeps the two things it already kept — the float that was listing the batch, and the repaint behind it.
- **An abandoned composer is not a submit** (ADR-0005). Nothing is handed to the adapter, nothing is archived, the queue is whole — and what was typed is kept as a **draft**, so the next `<C-a>` offers it back.
- **That draft is keyed by repository**, and by one fixed key outside a checkout: the same split the queue's two stores make. A preamble has no file, and filing one under a file would hand a reviewer their covering prose when they annotate a thought.
- **`gy` and an immediate send carry none**, by the rule rather than by a rule of their own: a copy performs no submit, and a batch of one has no batch to cover (ADR-0004).
- **`payload` stays pure.** Same arguments in, same message out, asserted as such.

## Two things worth a second opinion

**A batch that was refused keeps its preamble too.** No acceptance criterion asked for this. Its entries wait in the queue to be retried, the preamble has no queue to wait in, and by then the composer has cleared its draft — so without it the reviewer retypes prose they wrote a second ago. It is the same shape ADR-0005 already settled for an undispatched **immediate send**, reached through the same store. Say the word and it comes out.

**`delivery` now reaches for the shipped composer, which is a third module cycle.** `composer` already required `delivery` for the target its footer names. Composing at submit time means the submit has to reach whichever composer is wired, and the plugin's own is the default implementation of that adapter rather than a fallback beside it (ADR-0003) — so "whichever is wired" always includes it. Function-local on both sides, and written down in `lua/codereview/CLAUDE.md` beside the other two. The alternative, handing the composer in from every caller, spreads the one rule ADR-0003 exists to keep in one place.

## Vocabulary

**Preamble** is defined in `CONTEXT.md` with what it avoids (prologue, cover note, header, message, prompt), and used in the code, the comments, the tests, the README and the help file.

## Evidence

Red before green for every new claim, and each mutation applied on its own:

| Cut | Reds |
| --- | --- |
| the whole feature absent | 14 in `delivery_spec`, 3 in `payload_spec` |
| an empty preamble emits its blank line anyway | 4, one of them an existing payload case |
| `drafts.key` without its preamble branch | 3 — both cross-repository cases and the bare-note collision |
| that key falling back to the working directory | 1 — the one fixed key outside a checkout |
| no draft written back when the adapter refuses | 1 |
| no empty-queue guard before the composer opens | 1 |
| the float's `<C-a>` not closing the float | 1 — the case with no review open, which is the only one where the view cannot do it |
| the view not closing the float | 1 |
| no focus restored after the composer | 1 |

The last one has a trap of its own, now in `tests/README.md`: `annotate` schedules a focus restore, and a submit begun on the same tick is measured against *that*. Draining the loop between the two is what gave the case teeth, and it only bites where the batch was refused — a dispatch repaints, and the repaint puts focus back whether or not anything else does.

`make all` passes: 33 spec files, 0 failures, exit 0.

Closes #126