### PR TITLE
feat(archive): keep the preamble a batch went under

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -182,7 +182,10 @@ what to ignore, how the pieces relate — and the payload renders it above the h
 it is read before the findings. Composed at **submit** time and never held in the **queue**,
 which keeps **entries** and nothing else. A **draft** of one is kept per repository, because
 a preamble is about a batch and not about a file. An **immediate send** carries none
-(ADR-0004), and a copied payload carries none either: only a **dispatch** carries one.
+(ADR-0004), and a copied payload carries none either: only a **dispatch** carries one — and
+a dispatch keeps it, in the **archive**, because it is part of what was sent. It belongs to
+the dispatch and not to either half of a batch the archive split, so both halves carry it,
+as both carry the same stamp and the same **target**.
 _Avoid_: prologue, cover note, header, message, prompt
 
 **`@ref`**:
@@ -210,7 +213,9 @@ _Avoid_: quick note, one-off, direct send
 
 **Archive**:
 The batches already dispatched from a repository, kept after the queue that held them was
-cleared. Only a **dispatch** writes it, so a payload copied to a register is not in it.
+cleared — the **entries** as they went and the **preamble** they went under. Only a
+**dispatch** writes it, so a payload copied to a register is not in it. Read-only, which is
+a claim about the record and not a feature left unwritten.
 _Avoid_: history, sent queue, outbox
 
 **Snapshot**:

--- a/README.md
+++ b/README.md
@@ -457,12 +457,18 @@ what `<C-s>` would have sent. `gy` copies no preamble either, because copying is
 submitting, and an annotation [sent on its own](#send-one-annotation-now) carries none: a
 batch of one has no batch to cover.
 
+A preamble that went is part of the record. It is kept with its batch and
+[read back with it](#read-the-last-batch-back-after-it-goes) — a float listing the findings
+and not the covering note would be describing a message nobody received. Shown there and
+never edited, for the reason that float refuses everything else.
+
 ### Read the last batch back after it goes
 
 A submit clears the queue, which is the moment "what did I actually ask for?" stops having
 an answer anywhere but the agent's transcript. `:CodeReviewLastBatch` gives it one: the
 annotations of the batch that went last, grouped by type exactly as the queue float and the
-payload group them, with the target it went to and when it went in the frame.
+payload group them, under the [preamble](#a-batch-can-carry-a-preamble) it went out under
+where there was one, with the target it went to and when it went in the frame.
 
 `gb` opens that same float from inside a review, in the diff and in the tree, so which
 window you are in never decides whether the key exists. The command needs no review open —
@@ -671,7 +677,9 @@ listing is still there.
 
 `gb`, or `:CodeReviewLastBatch` from anywhere, lists an annotation the same way — the
 reserved gutter, the bar in its type's colour, the code it inlined and its note — so the two
-read as one family. What is missing is every key that would change something.
+read as one family. A [preamble](#a-batch-can-carry-a-preamble) is drawn above them all, as
+prose rather than as an entry: no gutter and no bar, because it is about the batch and not
+about a place in the code. What is missing is every key that would change something.
 
 | Key | Action |
 | --- | --- |
@@ -867,7 +875,8 @@ making those annotations second-class.
 <summary>What a dispatched batch leaves behind</summary>
 
 A batch that is **dispatched** is kept rather than forgotten: the annotations as they went,
-where they went, when, and a **snapshot** of the working tree at that moment — a commit
+the **preamble** they went out under where there was one, where they went, when, and a
+**snapshot** of the working tree at that moment — a commit
 object minted with `git stash create`, which moves no ref, leaves the index alone and never
 touches your files. On a clean tree there is nothing to record that `HEAD` does not already
 say, and `HEAD` is what is stored.
@@ -880,7 +889,11 @@ agent received. An immediate send is a batch of one and is kept as one. The most
 
 `:CodeReviewLastBatch` reads the newest one back. A batch holding both kinds of annotation
 is written to both stores and rejoined by the moment it was dispatched, which is what stops
-a bare note being the one thing missing from what you read back.
+a bare note being the one thing missing from what you read back. Both halves carry the same
+preamble, for the reason they carry the same stamp and the same target: it belongs to the
+dispatch and not to either half of it. A record written before batches could carry one
+lacks the field and reads back with none, exactly as one written before the archive existed
+lacks the archive.
 
 </details>
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -55,8 +55,9 @@ files without one fall back to flat diff colours.
                                                        *:CodeReviewLastBatch*
 :CodeReviewLastBatch
         Read the last dispatched batch back: its annotations, grouped by type
-        exactly as the queue float and the payload group them, with the target
-        it went to and when it went in the frame. Needs no review view open --
+        exactly as the queue float and the payload group them, under the
+        |codereview-preamble| it went out under where there was one, with the
+        target it went to and when it went in the frame. Needs no review open --
         a batch is not a window. A bare note is listed like anything else,
         though it was kept in a different store. With nothing dispatched yet
         it says so rather than opening onto nothing. Also bound to `gb` in the
@@ -176,7 +177,9 @@ so the queue float's muscle memory gets a sentence rather than |E21| against a
 |nomodifiable| buffer. An annotation is drawn there exactly as the queue float
 draws one -- the reserved gutter, the bar in its type's colour, the code it
 inlined and its note -- so the two read as one family; what is missing is
-every key that would change something.
+every key that would change something. A |codereview-preamble| is drawn above
+them all, as prose rather than as an entry: no gutter and no bar, because it
+is about the batch and not about a place in the code.
 
 Annotation keys are prefixed with `a` rather than bound bare. Bare `b`, `f`,
 `n` and `s` would shadow back-word, find-char and next-search inside the
@@ -611,6 +614,15 @@ all: the payload is byte for byte what <C-s> would have sent. `gy` and
 |:CodeReviewCopy| carry none either, because copying is not submitting, and
 an |codereview-immediate-send| carries none: a batch of one has no batch to
 cover.
+
+A dispatched preamble is part of the record. It is kept with its batch and
+|:CodeReviewLastBatch| shows it, because a float that listed the findings and
+not the covering note would describe a message nobody received. It is shown
+and never edited, for the reason that surface refuses everything else: an
+archived record says something happened. A batch split across the two stores
+carries the same preamble in both halves -- a preamble belongs to the
+dispatch, exactly as the stamp and the target do, and not to either half of
+it. See |codereview-persistence-archive|.
 
 What you already reported                             *codereview-archived*
 
@@ -1097,7 +1109,8 @@ accepted cost of not making those annotations second-class.
 The archive                                 *codereview-persistence-archive*
 
 A batch that is dispatched is kept rather than forgotten. Each record holds
-the annotations as they went, where they went, when, and a snapshot: a commit
+the annotations as they went, the |codereview-preamble| they went out under
+where there was one, where they went, when, and a snapshot: a commit
 object recording the working tree at that moment, minted with `git stash
 create` -- which moves no ref, leaves the index alone and never touches the
 working tree, so nothing about a submit disturbs what you are reviewing. On a
@@ -1126,6 +1139,11 @@ write.
 of annotation is therefore two records, and they are rejoined by the moment
 they were dispatched -- both halves are stamped from one clock reading. That
 is what stops a bare note being the one thing missing from what you read back.
+Both halves carry the same preamble too, for the same reason they carry the
+same stamp and the same target: it belongs to the dispatch, not to either
+half. A record written before batches could carry one simply lacks the field
+and reads back with none, exactly as one written before the archive existed
+lacks the archive.
 
 ==============================================================================
 12. LUA API                                                 *codereview-api*

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -301,6 +301,22 @@ dispatches inside the same second read back as one batch. That is beyond any hum
 cadence and well within a loop's, which is why `archive_float_spec` clears both stores
 between blocks rather than trusting the clock.
 
+**A preamble belongs to the dispatch, so both halves of a split batch carry it.** It is not
+about the entries with a repository behind them, nor about the ones without — it is about
+the batch, exactly as the stamp and the target are, and those are already written to both.
+Storing it on one half alone reads as correct and fails in the direction that looks fine: a
+batch whose annotations all had files still shows its covering note, and the moment one is a
+**bare note** the rejoin has to decide which half to believe. Both carry it, and the rejoin
+takes either.
+
+**What is archived is what the payload rendered, through the payload's own rule.** An empty
+composer is a submit that sends no covering note, so the record must hold none — and a
+preamble is trimmed before it is rendered, so an untrimmed one in the archive would be a
+record that differs from the message by whitespace nobody can see. `payload.preamble` is
+that one rule, and it is exported for this second reader rather than copied: trimming in two
+places is how two things that agree today come to differ. A second trim inside `state` is
+the regression, and it is invisible until the day the two disagree.
+
 **The projection onto the diff is memoised on a write count, not rebuilt per repaint.** An
 archived entry is drawn from a table keyed by anchor, exactly as a queued one is — but the
 queue is in memory and an archive is a file, and a repaint runs on every resize, expansion,

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -14,7 +14,7 @@ change there is felt through.
 | Module | Owns | |
 | --- | --- | --- |
 | `annotate.lua` | The review path: cursor to entry, the deleted-line and hunk inlining rules, drop, grouping | stateful (queue, view) |
-| `archive.lua` | The archive read back: which batch went last, the read-only float listing it, and the projection of archived entries onto the diff's anchors | stateful (float) |
+| `archive.lua` | The archive read back: which batch went last, the read-only float listing it and the **preamble** it went under, and the projection of archived entries onto the diff's anchors | stateful (float) |
 | `capture.lua` | The capture path: the same entry from an ordinary buffer, no review view involved | stateful (queue, buffer) |
 | `composer.lua` | The shipped composer and its `@` reference picker — the default `compose` adapter, not a lesser one | stateful (float) |
 | `config.lua` | `setup()`, the defaults, and the injected adapters: `send`, `pick_target`, `pick_file`, `compose`, `open_diff` | stateful (options) |

--- a/lua/codereview/archive.lua
+++ b/lua/codereview/archive.lua
@@ -2,7 +2,8 @@
 ---
 ---What a reviewer asked for should be a fact the plugin holds, not something to scroll an
 ---agent's transcript for. This is where that fact is read: the **entries** of the newest
----archived **batch**, the **target** it went to, and when it went.
+---archived **batch**, the **preamble** it went out under, the **target** it went to, and
+---when it went.
 ---
 ---**Read-only, and that is a claim about the record rather than a feature left unwritten.**
 ---An archived entry says something happened. A surface that let you drop, edit or resubmit
@@ -66,7 +67,16 @@ function M.last(root)
     table.sort(entries, function(a, b)
       return (a.id or 0) < (b.id or 0)
     end)
-    return { at = owned.at, target = owned.target, snapshot = owned.snapshot, entries = entries }
+    return {
+      at = owned.at,
+      target = owned.target,
+      snapshot = owned.snapshot,
+      -- Either half would answer. A **preamble** is about the dispatch and not about either
+      -- half of it, so both were written the same one, exactly as both were stamped from one
+      -- `os.time()` and sent to one target.
+      preamble = owned.preamble,
+      entries = entries,
+    }
   end
 
   if not owned or (loose and loose.at > owned.at) then
@@ -177,7 +187,8 @@ end
 ---Its highlight columns are byte offsets, not display columns: the bar glyph is multibyte,
 ---and so is anything a host configures in its place.
 ---@param entries CRAnnotation[]
----@param opts { types: CRType[], bar: string, width: integer }
+---@param opts { types: CRType[], bar: string, width: integer, preamble?: string }
+---       `preamble` is the prose the batch went out under, absent where it went under none.
 ---@return { lines: string[], marks: table[] }
 local function build(entries, opts)
   local lines, marks = {}, {}
@@ -201,6 +212,22 @@ local function build(entries, opts)
     lines[#lines + 1] = text
     mark(#lines, bar_col, { end_col = bar_end, hl_group = group })
     return #lines
+  end
+
+  -- Above the batch, where the payload put it and where the agent read it first. Drawn as
+  -- prose and not as an entry: no gutter, no bar and no number, because the gutter and the
+  -- bar are what say *entry* on this surface and a preamble is about the batch instead.
+  --
+  -- Wrapped to the whole width, since nothing is indented in front of it, and wrapped here
+  -- rather than left to the window for the reason every other row is: the window does not
+  -- wrap, and a row folded back to column zero would land under no bar at all.
+  if opts.preamble then
+    for _, text in ipairs(render.wrap(opts.preamble, opts.width)) do
+      lines[#lines + 1] = text
+    end
+    -- The same blank row the payload writes between the preamble and the header, and the
+    -- only thing separating what covers the batch from the batch itself.
+    lines[#lines + 1] = ""
   end
 
   local index = 0
@@ -352,6 +379,10 @@ function M.open()
     -- a host has configured a glyph of its own.
     bar = cfg.icons.change_bar,
     width = vim.api.nvim_win_get_width(win),
+    -- Shown and never edited, which is the read-only claim covering the last thing this
+    -- surface draws exactly as it covers the first: an archived batch went out under this
+    -- prose, and nothing here can revise what an agent already received.
+    preamble = batch.preamble,
   })
 
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, painted.lines)

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -259,7 +259,16 @@ function M.deliver(items, to, opts)
   -- raise and the register the shipped default copies to leave the archive exactly where
   -- they leave the batch. Here rather than in the two callers because a batch and a batch
   -- of one go out through this function and must not diverge on the way (ADR-0004).
-  require("codereview.state").archive_batch(items, M.label_of(to), repo)
+  --
+  -- The preamble goes into the record through the renderer's own rule, not past it: what is
+  -- kept is what the agent was handed, so a batch that rendered no covering note is archived
+  -- with none. An **immediate send** and a copy reach neither branch with one.
+  require("codereview.state").archive_batch(
+    items,
+    M.label_of(to),
+    repo,
+    require("codereview.payload").preamble(opts.preamble)
+  )
   return true
 end
 

--- a/lua/codereview/payload.lua
+++ b/lua/codereview/payload.lua
@@ -127,6 +127,24 @@ local function describe(entry, base)
   return ("%s:%s%s"):format(where, range_text(entry), suffix), entry.lines
 end
 
+---The **preamble** as it is rendered, or nil when it renders nothing.
+---
+---Trimmed, so that the blank line under it is the one the renderer writes and not one the
+---reviewer happened to leave at the end of a composer. Nothing to say is nothing rendered:
+---an empty preamble leaves the message byte for byte what it was before preambles existed,
+---which is what makes the whole feature cost the fast path nothing.
+---
+---Here rather than inside `render` because there are two readers now. The **archive** keeps
+---what was *sent*, so the record and the message have to agree about whether a batch went
+---under a covering note at all, and about the text of it -- and trimming in two places is
+---exactly how two things that agree today come to differ.
+---@param preamble string|nil
+---@return string|nil
+function M.preamble(preamble)
+  local text = vim.trim(preamble or "")
+  return text ~= "" and text or nil
+end
+
 ---Render the whole queue as one message.
 ---@param items CRAnnotation[]
 ---@param base string Directory `@refs` should resolve against
@@ -143,13 +161,8 @@ function M.render(items, base, opts)
 
   -- Above the header rather than under it, because it is read first: the agent is told what
   -- the batch is about before it is told what is in it.
-  --
-  -- Trimmed, so that the blank line below it is the one this renderer writes and not one the
-  -- reviewer happened to leave at the end of a composer. Nothing to say is nothing rendered:
-  -- an empty preamble leaves the message byte for byte what it was before preambles existed,
-  -- which is what makes the whole feature cost the fast path nothing.
-  local preamble = vim.trim(opts.preamble or "")
-  if preamble ~= "" then
+  local preamble = M.preamble(opts.preamble)
+  if preamble then
     out[#out + 1] = preamble
     out[#out + 1] = ""
   end

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -31,6 +31,7 @@ local VERSION = 1
 ---@field at integer            When it went
 ---@field target string         Short name of where it went; "local" for the adapter's default
 ---@field snapshot string|nil   Commit object recording the working tree at that moment
+---@field preamble string|nil   The prose it went under, absent when it went under none
 ---@field entries CRAnnotation[]
 
 ---How many dispatched batches a store keeps, oldest dropped on write.
@@ -266,7 +267,12 @@ end
 ---       functions included, and one that will not JSON-encode would take the whole
 ---       document's write down with it.
 ---@param root string|nil nil outside a repository, where only the global store applies
-function M.archive_batch(items, target, root)
+---@param preamble string|nil The prose the batch went out under, as the payload rendered it
+---       -- nil where it rendered nothing, because the record is of what was sent. Written
+---       to both halves rather than to either: a preamble is about the **dispatch**, exactly
+---       as the stamp and the target are, and neither half is the thing it was written
+---       about.
+function M.archive_batch(items, target, root, preamble)
   local owned, loose = partition(items)
   -- One stamp for the batch, taken once: the two stores are recording the same dispatch.
   local at = os.time()
@@ -280,7 +286,7 @@ function M.archive_batch(items, target, root)
     -- No snapshot: these entries have no repository whose working tree could be recorded,
     -- and a snapshot of whichever checkout happened to be current would describe nothing
     -- they are about.
-    push(doc.archive, { at = at, target = target, entries = loose })
+    push(doc.archive, { at = at, target = target, preamble = preamble, entries = loose })
     write_global(doc)
   end
 
@@ -294,6 +300,7 @@ function M.archive_batch(items, target, root)
     -- Minted here rather than handed in. The snapshot is the working tree at the moment of
     -- dispatch, and it is only that if it is taken at that moment.
     snapshot = require("codereview.git").snapshot(root),
+    preamble = preamble,
     entries = owned,
   })
   M.save(root, data)

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,7 +29,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/archived_child.lua` | Spawned by `render_spec` to archive a batch and turn archived entries off — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
 | `codereview/capture_child.lua` | Spawned twice by `capture_spec` — deliberately not a spec. |
-| `codereview/archive_child.lua` | Spawned by `archive_spec` to dispatch a batch and exit — deliberately not a spec. |
+| `codereview/archive_child.lua` | Spawned by `archive_spec` to dispatch a batch under a **preamble** and exit — deliberately not a spec. |
 | `codereview/norepo_child.lua` | Spawned twice by `norepo_spec` (write, then read) — deliberately not a spec. |
 | `codereview/muted_child.lua` | Spawned eight times by `muted_spec`, one painted cell each — four on a token of a changed line for the muting, four on a token of a context line for the row a pane lights — deliberately not a spec. |
 | `codereview/faded_child.lua` | Spawned three times by `faded_spec`, one painted cell each — deliberately not a spec. |
@@ -52,8 +52,8 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit, and the **preamble**: above the header, the empty one that renders nothing, and the same arguments rendering the same message |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
-| `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
-| `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, the four things it refuses, and the key that opens it from the diff and from the tree while the command still opens it from anywhere |
+| `archive_spec` | A dispatched batch kept across a real restart: both stores, the **preamble** each half carries, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and the documents written before the archive and before preambles existed |
+| `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, the four things it refuses, the **preamble** it draws above the batch and will not let you edit, and the key that opens it from the diff and from the tree while the command still opens it from anywhere |
 | `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally and the two switches that take it away with the entries, the three things left unjudged, which of three candidate blobs it is judged against, and that the queue's own staleness rule is untouched by any of it |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
@@ -259,6 +259,27 @@ so the out-of-core language path is still checked locally without ever failing C
   that catches it is in `archive_float_spec`: two dispatches, a file edited between them so
   the two snapshots are genuinely different shas, and the batch the scope resolved against
   looked up *by its snapshot* rather than by taking the head a third time.
+- **A compose stub that answers one thing cannot tell a preamble from a note.** The same
+  adapter is asked for both, so a stub returning one string leaves "the preamble reached the
+  record" satisfied by an entry's note reaching it instead — and every assertion about where
+  it is drawn passes on a row holding the annotation. `archive_child.lua` and
+  `archive_float_spec` both branch on `ctx.preamble` and answer differently, which is the
+  only reason those cases measure the preamble at all. Same trap as "a filter test needs a
+  fixture only that filter can reject".
+- **A batch dispatched under a preamble restores focus on a later tick.** `<C-a>` is a
+  submit with a composer in front of it, and the submit schedules the focus restore every
+  composer path ends with. A spec that dispatches and then opens the last-batch float has
+  that restore land *after* the float is on screen — taking focus off it, so the keys the
+  next case feeds go to the window behind. `archive_float_spec`'s `dispatch_under` drains
+  with `vim.wait(50)` before returning, exactly as `focus_spec` drains between an annotation
+  and the submit that follows it.
+- **The archive lives in the same document as the queue, so "the file does not say it" is
+  not "the queue does not hold it".** `delivery_spec`'s claim that a preamble never joins
+  the queue was a search over the whole state file, which stopped being true the moment a
+  dispatch archived one into that same file — for a reason the case is not about. It now
+  decodes the document and searches the *entries*, queued and archived alike, which is the
+  claim: a preamble is not an entry. Asserting over `doc.queue` alone would be weaker still,
+  since a dispatched batch leaves it empty.
 - **A rejoin test needs the loose entry queued first.** Concatenating one store after the
   other happens to produce the right order whenever the repository entries were queued
   first, so a fixture in that order passes with the ordering deleted. `archive_float_spec`

--- a/tests/codereview/archive_child.lua
+++ b/tests/codereview/archive_child.lua
@@ -10,6 +10,10 @@
 -- exercised by the batch itself: one inside the repository, one about a file outside any
 -- checkout, one with no file at all.
 --
+-- Dispatched under a **preamble**, because a preamble belongs to the dispatch and not to
+-- either half of it: this is the batch that proves both halves come back carrying the same
+-- one, and that it comes back at all.
+--
 -- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
 -- archive_spec with XDG_STATE_HOME, FIXTURE and LOOSE_FILE in its environment, and it must
 -- NOT load tests/minimal_init.lua, which would mint a state directory of its own.
@@ -25,8 +29,11 @@ vim.cmd("cd " .. vim.fn.fnameescape(fixture))
 local codereview = require("codereview")
 codereview.setup({
   syntax = false,
-  compose = function(_, on_accept)
-    on_accept(nil, "dispatched by an earlier session")
+  -- Two answers from one adapter. A stub that said the same thing to a note and to a
+  -- preamble would leave "the preamble reached the record" satisfied by an entry's note
+  -- reaching it instead.
+  compose = function(ctx, on_accept)
+    on_accept(nil, ctx.preamble and "read the bare note last" or "dispatched by an earlier session")
   end,
   -- Answers inline, which is all this needs: nothing here is asserting the order a picker
   -- and a composer come in, only that the batch records where it went.
@@ -49,8 +56,12 @@ codereview.annotate("issue")
 
 -- Chosen before submitting, so the batch goes somewhere with a name rather than to the
 -- adapter's own default -- which is what makes "it records the target" an assertion.
-require("codereview.delivery").pick_target()
-codereview.submit()
+local delivery = require("codereview.delivery")
+delivery.pick_target()
+-- Through the submit that composes first, which is the only way a dispatch acquires a
+-- preamble at all. The composer above answers inline, so the batch has gone by the line
+-- below.
+delivery.submit_with_preamble()
 
 -- Printed so a failing archive_spec can show what the dispatching process believed it did.
 print("queued: " .. #queue.all() .. " left after submitting")

--- a/tests/codereview/archive_float_spec.lua
+++ b/tests/codereview/archive_float_spec.lua
@@ -23,11 +23,18 @@ local fixture = h.cd_fixture("mkfixture")
 ---the one condition that both empties the queue and records the batch.
 local sent = {}
 
+---What the composer answers with when it is asked for a **preamble** rather than for a note.
+---Set by whichever block is about to dispatch under one.
+---
+---Two answers from one adapter, because a stub that said the same thing to both would leave
+---"the float shows the preamble" satisfied by a row holding an entry's note.
+local preamble_text = ""
+
 local codereview = require("codereview")
 codereview.setup({
   syntax = false,
-  compose = function(_, on_accept)
-    on_accept(nil, "a note")
+  compose = function(ctx, on_accept)
+    on_accept(nil, ctx.preamble and preamble_text or "a note")
   end,
   pick_target = function(cb)
     cb({ short = "agent", cwd = fixture })
@@ -95,6 +102,20 @@ local function dispatch()
   restore()
 end
 
+---Dispatch whatever is queued under a **preamble**, which is the only way a batch acquires
+---one: it is composed at submit time and never sits in the queue.
+---@param text string What the composer answers with
+local function dispatch_under(text)
+  preamble_text = text
+  local _, restore = h.capture_notify()
+  delivery.submit_with_preamble()
+  restore()
+  -- Drained here rather than left to whatever pumps the loop next. The submit puts focus
+  -- back on a later tick, and a restore that landed after the float had opened would take
+  -- focus off it -- and the keys a block below feeds would go somewhere else entirely.
+  vim.wait(50)
+end
+
 ---@return integer win, integer buf
 local function open_float()
   codereview.last_batch()
@@ -115,6 +136,30 @@ end
 ---@return string
 local function note_row(text)
   return GUTTER .. BAR .. "   " .. text
+end
+
+---The row a line is drawn on, or nil when nothing in the float reads exactly that.
+---@param buf integer
+---@param want string
+---@return integer|nil
+local function row_of(buf, want)
+  for row, text in ipairs(lines(buf)) do
+    if text == want then
+      return row
+    end
+  end
+end
+
+---The row the batch itself starts on: the first group heading the listing writes.
+---@param buf integer
+---@return integer
+local function first_heading(buf)
+  for row, text in ipairs(lines(buf)) do
+    if text:find("^## ") then
+      return row
+    end
+  end
+  error("the float lists no group at all:\n" .. table.concat(lines(buf), "\n"))
 end
 
 ---Every extmark starting on a row, as { col, end_col, hl }.
@@ -394,6 +439,227 @@ describe("a batch holding a bare note as well as a file", function()
     assert.is_truthy(vim.tbl_contains(text, "## Untyped"), table.concat(text, "\n"))
     assert.same("CodeReviewBug", bar_group(buf, extent(buf, 1)))
     assert.same("CodeReviewNote", bar_group(buf, extent(buf, 3)))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+--- The preamble the batch went under --------------------------------------------
+
+-- A **preamble** is part of what was sent, so it is part of what is read back: a float that
+-- showed the findings and not the covering note would be describing a message nobody
+-- received. Drawn where the payload drew it -- above the batch, read before the findings --
+-- and drawn as prose, because it is not an **entry** and carries none of what lists one.
+describe("a batch dispatched under a preamble", function()
+  fresh()
+  queued({ note = "the batch that went" })
+  dispatch_under("read the deleted-line rule first")
+
+  local win, buf = open_float()
+  local text = lines(buf)
+  local row = row_of(buf, "read the deleted-line rule first")
+
+  it("kept it with the batch", function()
+    assert.same("read the deleted-line rule first", state.archive(root)[1].preamble)
+  end)
+
+  it("shows it", function()
+    assert.is_truthy(row, table.concat(text, "\n"))
+  end)
+
+  it("draws it above the batch, where the agent read it", function()
+    assert.is_true(assert(row) < first_heading(buf), table.concat(text, "\n"))
+  end)
+
+  -- The same blank row the payload writes between the two. Without it the covering note runs
+  -- straight into the first group heading, and what covers the batch reads as part of it.
+  it("separates it from the batch, as the payload separated it", function()
+    assert.same("", text[assert(row) + 1])
+    assert.same(row + 2, first_heading(buf))
+  end)
+
+  -- The gutter and the bar are what say "entry" on this surface. A preamble is about the
+  -- batch and not about a place in the code, and it is drawn as what it is.
+  it("draws it as prose rather than as an entry", function()
+    assert.is_nil(bar_group(buf, assert(row)), text[row])
+  end)
+
+  it("lists the batch's entries exactly as it lists any other batch's", function()
+    assert.is_truthy(vim.tbl_contains(text, note_row("the batch that went")), table.concat(text, "\n"))
+    assert.same("CodeReviewBug", bar_group(buf, extent(buf, 1)))
+  end)
+
+  it("counts the annotations, which the preamble is not one of", function()
+    assert.is_truthy(chrome(win, "title"):find("1 annotation ", 1, true), chrome(win, "title"))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+-- The read-only claim covers the preamble in full, for the reason it covers everything else
+-- here: an archived record says something happened, and a surface that let you revise it
+-- would be claiming the plugin can revise what an agent already received.
+describe("the preamble on a surface that refuses to edit", function()
+  fresh()
+  queued({ note = "already gone" })
+  dispatch_under("as it was dispatched")
+
+  local win, buf = open_float()
+  local row = assert(row_of(buf, "as it was dispatched"), table.concat(lines(buf), "\n"))
+  vim.api.nvim_win_set_cursor(win, { row, 0 })
+
+  it("holds a buffer nothing can be typed into", function()
+    assert.is_false(vim.bo[buf].modifiable)
+  end)
+
+  -- With the cursor on the preamble itself, which is where a reviewer who wants to change it
+  -- would put it. The notification is asserted as well as the record: `x` on a `nomodifiable`
+  -- buffer changes nothing either, and would leave this green while saying `E21`.
+  it("says why, rather than editing anything, on the key that drops from the queue float", function()
+    local msgs, restore = h.capture_notify()
+    h.feed("x")
+    restore()
+    assert.is_true(h.notified(msgs, "annotate again"), vim.inspect(msgs))
+    assert.same("as it was dispatched", lines(buf)[row])
+    assert.same("as it was dispatched", state.archive(root)[1].preamble)
+  end)
+
+  -- The whole of what this surface binds, asserted as a set rather than one key at a time:
+  -- a key added to rewrite a preamble is exactly what this case exists to red.
+  it("binds nothing that could rewrite it", function()
+    local expected = {}
+    for _, key in ipairs({ "x", "<C-s>", "q", "<Esc>" }) do
+      expected[vim.keycode(key)] = true
+    end
+    assert.same(expected, bound(buf))
+  end)
+
+  h.feed("q")
+end)
+
+-- A preamble belongs to the **dispatch** and not to either half of it, so both halves carry
+-- the same one -- exactly as they already carry the same stamp and the same **target**. Read
+-- back, the rejoined batch has one covering note and not two.
+describe("a preamble on a batch the two stores split", function()
+  fresh()
+  bare_note("a thought with no file behind it", "bug")
+  queued({ note = "and a file with one" })
+  dispatch_under("both halves are one batch")
+
+  local win, buf = open_float()
+  local text = lines(buf)
+
+  it("is a batch the two stores really did split", function()
+    assert.same(1, #state.archive(root)[1].entries)
+    assert.same(1, #state.global_archive()[1].entries)
+  end)
+
+  it("carries the same preamble in both halves", function()
+    assert.same("both halves are one batch", state.archive(root)[1].preamble)
+    assert.same("both halves are one batch", state.global_archive()[1].preamble)
+  end)
+
+  it("shows it once, over the batch the two were rejoined into", function()
+    local seen = 0
+    for _, line in ipairs(text) do
+      if line == "both halves are one batch" then
+        seen = seen + 1
+      end
+    end
+    assert.same(1, seen, table.concat(text, "\n"))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+-- The fast path costs this surface nothing either. A batch that went with no covering note
+-- has none to read back, and the float draws what it drew before a batch could carry one.
+describe("a batch dispatched with no preamble", function()
+  fresh()
+  queued({ note = "no covering note" })
+  dispatch()
+
+  local win, buf = open_float()
+
+  it("records none", function()
+    assert.is_nil(state.archive(root)[1].preamble)
+  end)
+
+  it("opens on the batch itself, with nothing above it", function()
+    assert.same(1, first_heading(buf))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+-- The submit key means submit, so an empty composer dispatches anyway -- and an empty
+-- preamble renders nothing into the payload. The record says the same thing: nothing was
+-- sent above the batch, so there is nothing above it to read back.
+describe("a batch dispatched under an empty preamble", function()
+  fresh()
+  queued({ note = "an empty composer" })
+  dispatch_under("  \n  ")
+
+  local win, buf = open_float()
+
+  it("was dispatched", function()
+    assert.same(0, queue.count())
+    assert.same(1, #state.archive(root))
+  end)
+
+  it("records none", function()
+    assert.is_nil(state.archive(root)[1].preamble)
+  end)
+
+  it("draws as a batch that was never offered one", function()
+    assert.same(1, first_heading(buf))
+  end)
+
+  vim.api.nvim_win_close(win, true)
+end)
+
+-- The window does not wrap -- a row folded back to column zero would leave the bar behind and
+-- an entry would appear to end -- so every row this float draws, it wraps itself. A preamble
+-- is prose a reviewer typed and is under no obligation to be narrow.
+describe("a preamble wider than the float", function()
+  fresh()
+  queued({ note = "a note" })
+  -- No spaces, so the wrap has nowhere to break but mid-word, and each of these occupies two
+  -- display columns -- which is where cutting by byte or by character count goes wrong.
+  local cjk = ("字"):rep(120)
+  dispatch_under(cjk)
+
+  local win, buf = open_float()
+  local width = vim.api.nvim_win_get_width(win)
+  local text = lines(buf)
+  local body = {}
+  for row = 1, first_heading(buf) - 1 do
+    if text[row] ~= "" then
+      body[#body + 1] = text[row]
+    end
+  end
+
+  it("wrapped it over several rows", function()
+    assert.is_true(#body > 1, table.concat(body, "\n"))
+  end)
+
+  it("keeps every row inside the float", function()
+    for row = 1, #text do
+      assert.is_true(
+        vim.fn.strdisplaywidth(text[row]) <= width,
+        ("row %d is %d columns wide in a %d-column float"):format(row, vim.fn.strdisplaywidth(text[row]), width)
+      )
+    end
+  end)
+
+  it("wrapped by display width rather than by character count", function()
+    for _, row in ipairs(body) do
+      assert.is_true(vim.fn.strdisplaywidth(row) > vim.fn.strchars(row), row)
+    end
+  end)
+
+  it("breaks between characters, not inside one", function()
+    assert.same(cjk, table.concat(body))
   end)
 
   vim.api.nvim_win_close(win, true)

--- a/tests/codereview/archive_spec.lua
+++ b/tests/codereview/archive_spec.lua
@@ -114,6 +114,12 @@ describe("what a restart finds", function()
     assert.same("agent", archive[1].target)
   end)
 
+  -- Part of what was sent, so part of what is kept. A record that held the findings and not
+  -- the covering note would describe a message nobody received.
+  it("keeps the preamble the batch went under", function()
+    assert.same("read the bare note last", archive[1].preamble)
+  end)
+
   it("records when it went", function()
     -- Loose, because the assertion is that a real time was stamped rather than that a
     -- clock reads a particular value.
@@ -141,6 +147,29 @@ describe("what a restart finds", function()
   -- whichever checkout happened to be current would describe nothing these are about.
   it("gives that batch no snapshot", function()
     assert.is_nil(loose[1].snapshot)
+  end)
+
+  -- A preamble is about the **dispatch** and not about either half of it, so it is written
+  -- to both -- exactly as the stamp and the target already are, and for the same reason:
+  -- neither half is the thing it was written about.
+  it("gives that batch the same preamble, since one dispatch went under one", function()
+    assert.same("read the bare note last", loose[1].preamble)
+    assert.same(archive[1].preamble, loose[1].preamble)
+  end)
+end)
+
+-- What a reviewer reads back is the batch, not either document that holds half of it. The
+-- rejoin builds a record of its own out of the two, so the preamble has to survive being
+-- rebuilt as well as being written.
+describe("the two halves read back as one dispatch", function()
+  local batch = assert(require("codereview.archive").last(root), "nothing was read back")
+
+  it("is the whole batch, both stores rejoined", function()
+    assert.same(3, #batch.entries, vim.inspect(batch.entries))
+  end)
+
+  it("carries the one preamble the dispatch went under", function()
+    assert.same("read the bare note last", batch.preamble)
   end)
 end)
 
@@ -319,6 +348,12 @@ describe("a batch dispatched from a clean working tree", function()
   it("falls back to HEAD, since there is nothing else to record", function()
     assert.same(h.git_lines(clean, { "rev-parse", "HEAD" })[1], state.archive(clean_root)[1].snapshot)
   end)
+
+  -- Submitted with `<C-s>`, which asks for nothing: there was no covering note to send, so
+  -- there is none to keep. The fast path costs the record exactly what it costs the payload.
+  it("records no preamble, because none was composed", function()
+    assert.is_nil(state.archive(clean_root)[1].preamble)
+  end)
 end)
 
 -- Nothing here ever reconciles a batch against a diff, so no later moment could decide one
@@ -382,5 +417,43 @@ describe("a document written before the archive existed", function()
 
   it("gains an empty archive rather than nothing at all", function()
     assert.same({}, loaded.archive)
+  end)
+end)
+
+-- The same shape one key further in. A batch dispatched before a batch could carry a
+-- **preamble** simply lacks the field, exactly as a document written before the archive
+-- existed lacks that one -- and nothing else about the record means anything different for
+-- want of it. Written by hand rather than dispatched, because this process cannot dispatch a
+-- batch the way a build without preambles did.
+describe("a batch archived before preambles existed", function()
+  vim.fn.writefile({
+    vim.json.encode({
+      version = 1,
+      scopes = {},
+      queue = {},
+      archive = {
+        {
+          -- Fixed rather than `os.time()`, so nothing here depends on which of the two
+          -- stores holds the newer record.
+          at = 1700000000,
+          target = "agent",
+          snapshot = "0123456789abcdef",
+          entries = {
+            { id = 9, type = "bug", kind = "file", path = "src/main.lua", key = "k", note = "sent long ago" },
+          },
+        },
+      },
+    }),
+  }, state.path(root))
+  local batch = assert(state.last_batch(root), "the batch written by hand was not read back")
+
+  it("reads back with everything it was written with", function()
+    assert.same("agent", batch.target)
+    assert.same(1, #batch.entries)
+    assert.same("sent long ago", batch.entries[1].note)
+  end)
+
+  it("reads back carrying no preamble, rather than not reading back", function()
+    assert.is_nil(batch.preamble)
   end)
 end)

--- a/tests/codereview/delivery_spec.lua
+++ b/tests/codereview/delivery_spec.lua
@@ -641,11 +641,19 @@ describe("a batch submitted with a preamble", function()
     assert.is_true(h.notified(msgs, "Submitted 1 annotation"), vim.inspect(msgs))
   end)
 
-  -- The queue keeps entries and nothing else. A preamble is composed at submit time, so
-  -- there is nothing about it for the queue's document to have written down.
-  it("writes no preamble into the persisted queue", function()
-    local doc = table.concat(vim.fn.readfile(state.path(root)), "\n")
-    assert.is_nil(doc:find("read the second one first", 1, true), doc)
+  -- The queue keeps **entries** and nothing else, and a preamble is not one: it is composed
+  -- at submit time and joins them nowhere. Read out of the decoded document rather than out
+  -- of the file's text, because the **archive** in that same file keeps the preamble on
+  -- purpose -- what must carry it nowhere is an entry, queued or archived alike.
+  it("writes the preamble into no entry, queued or archived", function()
+    local doc = vim.json.decode(table.concat(vim.fn.readfile(state.path(root)), "\n"))
+    local entries = vim.deepcopy(doc.queue or {})
+    for _, batch in ipairs(doc.archive or {}) do
+      vim.list_extend(entries, batch.entries or {})
+    end
+    -- Or the case is satisfied by a document with no entry in it to have been written into.
+    assert.is_true(#entries > 0, "nothing reached the document, so this measures nothing")
+    assert.is_nil(vim.json.encode(entries):find("read the second one first", 1, true), vim.inspect(entries))
   end)
 end)
 


### PR DESCRIPTION
A dispatched **preamble** was rendered into the payload and then forgotten, so the float
that answers *what did I already say* listed the findings and not the covering note —
describing a message nobody received.

The record now holds it, and the read-only float shows it above the batch, where the agent
read it. Read-only covers it in full for the reason it covers everything else there: an
archived record says something happened, and a surface that let you revise it would be
claiming the plugin can revise what an agent already received. It is drawn as prose and not
as an **entry** — no gutter, no bar — because the gutter and the bar are what say *entry* on
that surface, and a preamble is about the batch.

A preamble belongs to the **dispatch** and not to either half of a batch the two stores
split, so both halves carry it — exactly as both already carry the same stamp and the same
**target** — and the rejoin takes either. Storing it on one half alone fails in the
direction that looks fine: a batch whose annotations all had files still reads back with its
covering note, and only a **bare note** makes the gap visible.

What is archived is what was sent. `payload.preamble` is the one rule for what a preamble
renders as, exported for this second reader rather than copied, so an empty composer
archives nothing and the record cannot differ from the message by whitespace nobody can see.

A batch dispatched with no preamble reads back with none and the float draws exactly as it
did, and a record written before batches could carry one lacks the field and reads back with
none — the same shape as a document written before the archive existed.

One existing case changed with it. `delivery_spec`'s claim that a preamble never joins the
queue searched the whole state document, which stopped being true the moment a dispatch
archived one into that same file, for a reason the case is not about. It now decodes the
document and searches the *entries*, queued and archived alike, which is the claim a
preamble is not an entry — and it guards that there were entries to search.

Closes #128