### PR TITLE
feat(view): colour the sticky header and count in glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ One syntax-highlighted diff of everything a branch changed — unified or side b
 vim-native navigation, a file tree, reviewed-file collapsing, and a batch submit at the end.
 
 ```
-┌─ tree ──────────────┐┌─ Code review · branch vs origin/master · 2/7 · +9 -4 ─────┐
+┌─ tree ──────────────┐┌─ branch vs origin/master · ✓2/7 · +9 -4 ──────────────────┐
 │ ▾ apps          1/4 ││ ○ ▾ apps/api/src/main.ts                 +12 -3  [3 notes]│
 │   ▾ api/src     1/2 ││ @@ -19,6 +19,8 @@ function boot()                         │
 │     ▾ routes    0/1 ││  19 │  const app = express()                              │
@@ -95,7 +95,7 @@ opts = { layout = "split" }   -- "unified" (default) or "split"; validated at se
 ```
 
 ```
-┌─ tree ───────────┐┌─ Before · origin/master ────┐┌─ Code review · branch · 2/7 ─┐
+┌─ tree ───────────┐┌─ Before · origin/master ────┐┌─ branch · ✓2/7 ──────────────┐
 │ ▾ apps       1/4 ││     apps/api/src/main.ts    ││ ● ▾ apps/api/src/main.ts +12 │
 │   ▾ api/src  1/2 ││ @@ -19,6 @@                 ││ @@ +19,8 @@ function boot()  │
 │     ● main.ts  3 ││  19 │  const app = express()││  19 │  const app = express() │
@@ -267,7 +267,7 @@ A file's header row scrolls off the top as soon as you read past the first scree
 The **sticky header** keeps it:
 
 ```
- ○ ▾ src/routes.lua  +12 -3  [2 notes]        branch vs master · 2/7 reviewed · +40 -9
+ ○ ▾ src/routes.lua  +12 -3  [2 notes]        branch vs master · ✓2/7 · +40 -9 · ●2 · → janus
 ```
 
 The same icon, chevron, path, `+N -M` and note count the in-buffer header carries, with the
@@ -276,13 +276,29 @@ at the top of the window — so it is the file an annotation would attach to, wh
 you are reaching for when you annotate twenty lines into a hunk. It works with the tree
 dismissed, and with a review opened without one.
 
+The summary counts in glyphs rather than words — `✓2/7` reviewed, `●2` notes, `↺2` untouched
+— so that three numbers side by side cannot be read as one another. Every one comes from the
+`icons` table, so you can change any of them, and every one is plain Unicode: nothing here
+needs a Nerd Font. The bar does not name the review itself; a bar inside a review does not
+need to.
+
+It is coloured. Added counts green and removed counts red, the note count in the colour notes
+carry everywhere else, the delivery **target** accented, the separators quieter than the
+facts between them, and the path the brightest thing on the left — which is the thing you
+scrolled there to keep. The groups are the plugin's own (`CodeReviewBarIcon`,
+`CodeReviewBarSep`, `CodeReviewBarTarget`, `CodeReviewBarRev`, beside the stat and note-count
+groups the diff already uses), and every one is a default link into your colorscheme, so a
+theme you have never used supplies the colours and changing theme mid-review follows.
+
 In the split layout each pane names its own side, so a rename reads correctly on the side
 holding the old name; the unified layout spells it `old → new`, exactly as the file header
 does. On a pane too narrow for both halves the summary gives way first — starting with what
-the file beside it now says twice — and the path keeps its tail.
+the file beside it now says twice — and the path keeps its tail. The before pane's bar names
+the base revision, and never gives it up for the path: half a revision is worse than none of
+a path the other pane is naming anyway.
 
 The bar is chrome of the review window it sits on, so it mutes with that window: on the pane
-without focus the sticky header recedes with everything else in it.
+without focus the sticky header recedes with everything else in it, colours and all.
 
 ### Typed annotations
 
@@ -514,10 +530,10 @@ dispatched — `file changed` or `file unchanged` beside the note — and the wi
 ones that have not:
 
 ```
- Code review · branch vs master · 2/7 reviewed · +40 -12 · 1 note · 2 untouched · → janus
+ branch vs master · ✓2/7 · +40 -12 · ●1 · ↺2 · → janus
 ```
 
-`2 untouched` is the answer to *did it ignore something*, and it is exact on the case that
+`↺2` is the answer to *did it ignore something*, and it is exact on the case that
 matters: a file the agent never opened. The comparison is **per file**, against the snapshot
 the batch went out with — the same commit `since-batch` diffs against, so a file the tally
 calls touched is exactly a file that scope shows you.
@@ -703,7 +719,8 @@ opts = {
                   strength = 0.25 }, -- gentler than the muting, so the row stays findable
   panel = { enabled = true, width = 34, position = "left" },
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
-            collapsed = "▸", expanded = "▾", change_bar = "▌" },
+            collapsed = "▸", expanded = "▾", change_bar = "▌",
+            untouched = "↺" },     -- plain Unicode throughout: no Nerd Font anywhere
   types = nil,                     -- defaults to the five above; see Typed annotations
 }
 ```

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -314,7 +314,7 @@ The sticky header                                  *codereview-sticky-header*
 
 Each pane's winbar names the file the cursor is in, so reading past that
 file's own header row in the diff does not cost you the file: >
-    ○ ▾ src/routes.lua  +12 -3  [2 notes]    branch vs master · 2/7 reviewed
+    ○ ▾ src/routes.lua  +12 -3  [2 notes]    branch vs master · ✓2/7 · ●2
 <
 It carries what the in-buffer file header carries -- the icon, the chevron,
 the path, the `+N -M` and the note count -- with the review summary
@@ -329,12 +329,27 @@ scrolled off -- so it names the file an annotation would attach to, which is
 what matters when you annotate twenty lines into a hunk. It works with the
 file tree dismissed, and with a review that was opened without one.
 
+The summary counts in glyphs rather than words: `✓2/7` reviewed, `●2` notes,
+`↺2` untouched, one glyph each so that three numbers side by side are never
+ambiguous. All of them come from `icons` (|codereview-config|) and all of them
+are plain Unicode -- no Nerd Font is needed anywhere in this plugin. The bar
+does not name the review itself.
+
+It is coloured, in groups of the plugin's own that are default links into your
+colorscheme: added counts green and removed counts red, the note count in the
+colour notes carry on the diff, the target accented, the separators dimmed,
+and the path left in the bar's own group, which makes it the brightest thing
+on the left. See |codereview-highlights|. A pane without focus mutes its bar
+with everything else in it.
+
 On a pane too narrow to hold both halves, the summary gives way first -- and
-gives up what the file beside it now says twice (the plugin's own name, the
-review's line totals, the queue's note count) before anything only it can say.
-The path is then cut from its head, keeping its tail, because the file's own
-name is the part being kept. A review with no files at all shows the summary
-alone, with no empty file segment.
+gives up what the file beside it now says twice (the review's line totals, the
+queue's note count) before anything only it can say. The path is then cut from
+its head, keeping its tail, because the file's own name is the part being
+kept. The before pane's base revision is never cut for the path's sake: half a
+revision says less than none of a path the other pane is naming anyway. A
+review with no files at all shows the summary alone, with no empty file
+segment.
 
 What changed inside a line                                 *codereview-spans*
 
@@ -640,9 +655,9 @@ Touched and untouched                                  *codereview-touched*
 Each entry of the *last* batch says whether its file has changed since that
 batch was dispatched -- `file changed` or `file unchanged` beside the note --
 and the winbar tallies the ones that have not: >
-    Code review · branch vs master · 2/7 reviewed · +40 -12 · 2 untouched
+    branch vs master · ✓2/7 · +40 -12 · ↺2 · → janus
 <
-`2 untouched` answers "did it ignore something", and it is exact on the case
+`↺2` answers "did it ignore something", and it is exact on the case
 that matters: a file the agent never opened. The comparison is per file, made
 against the snapshot the batch went out with -- the same commit
 |codereview-since-batch| diffs against, so a file the tally calls touched is
@@ -664,7 +679,7 @@ when the batch went (a snapshot records none), and a bare note, which is about
 no file at all. Nothing judged means no segment on the winbar rather than a
 zero to misread.
 
-That the scope decides who is judged is why the tally reads `0 untouched`
+That the scope decides who is judged is why the tally reads `↺0`
 inside |codereview-since-batch|: that scope shows exactly the files that
 moved, so every entry it covers is touched by definition, and the ones you are
 looking for are the ones it is not showing. `branch` and `worktree` are where
@@ -935,6 +950,7 @@ Defaults: >
       icons = {
         reviewed = "✓", annotated = "●", unreviewed = "○",
         collapsed = "▸", expanded = "▾", change_bar = "▌",
+        untouched = "↺",
       },
       types = nil,
       send = nil, pick_target = nil, pick_file = nil,
@@ -1000,6 +1016,10 @@ defines, so overriding any of them works without the plugin fighting back: >
     CodeReviewUntouched    -> DiagnosticHint
     CodeReviewQueueIndex   -> LineNr
     CodeReviewQueueState   -> Comment
+    CodeReviewBarIcon      -> Comment
+    CodeReviewBarSep       -> NonText
+    CodeReviewBarTarget    -> Special
+    CodeReviewBarRev       -> Special
     CodeReviewPanelDir     -> Directory
     CodeReviewPanelSel     -> CursorLine
     CodeReviewBug          -> DiagnosticError

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -57,24 +57,38 @@ works too, and takes effect on the next redraw: measured in a prototype, not ass
 group the namespace does not define falls back to its global definition, so what is not in
 it stays bright.
 
-**The winbar draws in `WinBar`/`WinBarNC` and in nothing of the plugin's own.** No segment
-on it carries a `%#Group#` today, so the **sticky header** mutes with its window through
-those two built-in groups and needs nothing added to the muted set — which is also the whole
-of what keeps the two features from colliding, and is why `split_spec` asserts the painted
-cell of a muted pane's bar rather than trusting that the two happen to agree. This used to
-be a rule the escaping *enforced*, and it is now only a fact about what the bar is built
-from: chrome may carry a group (see below), so the first segment that takes one leaves this
-paragraph out of date and the muted set with something to say about the winbar.
+**The winbar draws in `WinBar`/`WinBarNC` and in the plugin's own groups on top of them.**
+A segment carrying a `%#Group#` takes that group's foreground and leaves the bar's own
+background showing through, and both halves of that resolve through the window's highlight
+namespace — measured, not assumed: in a **muted** pane the same cell comes back as the
+group's *twin* over the muted `WinBarNC`'s background. So the sticky header mutes with its
+window on two mechanisms at once, and each needs the other to be right. The built-in pair is
+in `EDITOR_GROUPS`; every group the bar asks for is in `LINKS`, which is what `hl.groups()`
+derives the muted set from, so a bar group added anywhere else is one a muted pane leaves
+bright. `split_spec` reads two cells of one bar for exactly this reason: one inside the path,
+which carries no group of the plugin's own and is where the muting is proven, and one on the
+file's added count, which carries one and is where the colour is.
+
+**The path is the one thing on the bar left in the bar's own group**, and that is what makes
+it the brightest thing on the left rather than any group being brighter: the icon and the
+chevron in front of it are quiet, the separators quieter still, and everything else carries
+the group the surface saying the same thing on the diff carries — the stat, the note count
+and the untouched tally are the diff's own groups, not a second set for the bar. One colour,
+one meaning, wherever a reviewer meets it.
 
 **Every name on the winbar is escaped, per segment, and the bar is padded by hand in display
-columns.** A bar is built from typed segments — chrome, which the plugin wrote and may carry
-a highlight group, or a literal, which is a name the plugin did not choose — and
-`render.bar` doubles every `%` in a literal. The rule is the same one the wholesale escape
-held: the bar carries a path a reviewer's repository chose, and a `%f` in one would be read
-as a statusline item and expanded into something else. What moved is where it is applied, so
-that a caller cannot pass a path unescaped by accident: a segment has to say which kind it
-is, and the kind that takes a name is the kind that escapes it. The statusline's `%=` would
-now be possible, and would still buy nothing — see below.
+columns.** A bar is built from typed segments — chrome, which the plugin wrote, or a literal,
+which is a name the plugin did not choose — and `render.bar` doubles every `%` in a literal.
+The rule is the same one the wholesale escape held: the bar carries a path a reviewer's
+repository chose, and a `%f` in one would be read as a statusline item and expanded into
+something else. What moved is where it is applied, so that a caller cannot pass a path
+unescaped by accident: a segment has to say which kind it is, and the kind that takes a name
+is the kind that escapes it. **Escaping is by kind and colouring is not** — either kind may
+carry a highlight group, because most of what is worth colouring on this bar is a name: the
+**target**, the base revision, a count carrying a glyph a host configured. The alternative is
+a caller writing the markers around a name by hand, which is markup arriving from outside the
+one seam that decides what markup is. The statusline's `%=` would now be possible, and would
+still buy nothing — see below.
 
 **The ruler for that bar is `render.bar_width`, and it measures what is drawn.** Two things
 separate a bar's string from its columns, and they pull opposite ways. Almost everything on
@@ -83,18 +97,26 @@ a bar padded by `#` lands a dozen columns short of the pane while every ASCII as
 the suite still passes; the renamed file is what catches it. The mirror of that is a
 highlight marker: `%#Group#` is characters in the string and no columns at all on the
 screen, so a bar measured with its markers in drifts the other way, by the width of every
-one of them. Both are why the padding is arithmetic rather than `%=` — the fitting rule has
-to know how many columns the path may keep, which is the same measurement either way, and a
-bar that padded itself would take its own width out of reach of every assertion that reads
-it.
+one of them. That half stopped being hypothetical the moment the bar was coloured: a
+hundred-column bar is now some two hundred and fifty characters, so a ruler counting the
+string overshoots by more than the pane is wide. Both are why the padding is arithmetic
+rather than `%=` — the fitting rule has to know how many columns the path may keep, which is
+the same measurement either way, and a bar that padded itself would take its own width out of
+reach of every assertion that reads it. The same trap reaches the *tests*: a needle spanning
+two segments is not in the option's string at all, so `h.winbar` reads the bar as Neovim
+draws it and every assertion about what a bar says goes through it.
 
 **What the sticky header sheds on a narrow pane is decided by what it now says twice.** The
-summary drops the plugin's own name, the review's line totals and the queue's note count
-first — the file segment beside them carries a chevron, that file's own `+N -M` and that
-file's own note count — and only then does the path give up its head, down to the file's own
-name. Below that the summary keeps shedding, from its head, so the target it ends on is the
-last thing to go. Shedding the summary's *tail* was the first attempt and is wrong: the
-tail is where everything nothing else on screen says has accumulated.
+summary drops the review's line totals and the queue's note count first — the file segment
+beside them carries that file's own `+N -M` and that file's own note count — and only then
+does the path give up its head, down to the file's own name. Below that the summary keeps
+shedding, from its head, so the target it ends on is the last thing to go. Shedding the
+summary's *tail* was the first attempt and is wrong: the tail is where everything nothing
+else on screen says has accumulated. The review's own name used to head that list, and it is
+gone from the bar entirely: it was the first thing dropped on a narrow pane, and a bar inside
+a review does not need to say it is one. That, with the words the glyphs replaced, is about
+thirty columns handed to the path — enough that a 45-column pane keeps the directory above
+the file as well as the file.
 
 **Collapsing is done at render time, not with folds.** A collapsed file's body is never
 emitted, so the buffer and the anchor map stay small on a large review, and there is one

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -104,6 +104,13 @@ M.defaults = {
     width = 34,
     position = "left", ---@type "left"|"right"
   },
+  ---Every glyph the plugin draws, in one place. All plain Unicode: nothing here needs a
+  ---Nerd Font, and nothing added here may.
+  ---
+  ---The **sticky header** spends three of them on the three counts it carries -- reviewed,
+  ---notes and untouched -- so that three numbers side by side cannot be read as one another.
+  ---The first two are the icons a file already carries, because the same glyph says the same
+  ---thing in both places.
   icons = {
     reviewed = "✓",
     annotated = "●",
@@ -111,6 +118,7 @@ M.defaults = {
     collapsed = "▸",
     expanded = "▾",
     change_bar = "▌",
+    untouched = "↺",
   },
 
   --- Annotations ---

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -64,6 +64,23 @@ local LINKS = {
   CodeReviewPanelSel = "CursorLine",
   CodeReviewPanelDir = "Directory",
 
+  -- The **sticky header**'s own chrome. Everything else on that bar draws in a group it
+  -- shares with the surface saying the same thing on the diff -- the stat in
+  -- `CodeReviewStatAdd` and `CodeReviewStatDel`, the note count in `CodeReviewNoteCount`,
+  -- the untouched tally in `CodeReviewUntouched` -- because one colour has to mean one
+  -- thing wherever a reviewer meets it.
+  --
+  -- The path is deliberately not here. It draws in the bar's own group, which is the
+  -- brightest thing a winbar has, and the two groups below are what leave it that: the
+  -- separators are quieter than the facts between them, and the icon and the chevron are
+  -- chrome in front of the one fact the reviewer scrolled there to keep.
+  CodeReviewBarIcon = "Comment",
+  CodeReviewBarSep = "NonText",
+  CodeReviewBarTarget = "Special",
+  -- The base revision the before **pane** names. Its own group rather than the target's:
+  -- the two are accented alike today, and they answer entirely different questions.
+  CodeReviewBarRev = "Special",
+
   -- The chrome of the floats that list entries as rows -- the queue float, and the archive
   -- float that reads the last dispatched batch back. Named for the queue because that is
   -- where they started, and shared rather than duplicated because the two surfaces list the

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -324,7 +324,7 @@ end
 ---@class CRBarSegment
 ---@field kind "chrome"|"literal"
 ---@field text string
----@field hl string|nil          Highlight group; chrome only, and nil draws in the bar's own
+---@field hl string|nil          Highlight group, or nil to draw in the bar's own
 
 ---Chrome: a piece of the bar the plugin itself wrote.
 ---
@@ -346,15 +346,23 @@ end
 ---statusline item and expanded into something else -- the window's own file name, in that
 ---case, which is not even the file the bar is naming. The same holds for every other name
 ---the plugin did not choose: a **scope**'s label, a **target**'s short name, a base
----revision.
+---revision, and a glyph a host put in the icon table.
 ---
 ---A segment has to say which kind it is precisely so this cannot be forgotten. There is no
 ---way onto the bar that does not go through one of these two functions, and the one that
 ---takes a name is the one that escapes it.
+---
+---A literal takes a highlight group as chrome does, and for the reason the escape exists:
+---most of what is worth colouring on this bar is a name -- the **target**, the base
+---revision, a count carrying a configured glyph -- and the alternative is a caller writing
+---the markers around one by hand, which is markup arriving from outside the one seam that
+---decides what markup is. The escape is unchanged by it: the name is doubled, and the
+---markers go outside what was doubled.
 ---@param text string
+---@param hl string|nil
 ---@return CRBarSegment
-function M.literal(text)
-  return { kind = "literal", text = text }
+function M.literal(text, hl)
+  return { kind = "literal", text = text, hl = hl }
 end
 
 ---@param seg CRBarSegment
@@ -371,13 +379,16 @@ end
 function M.bar(segments)
   local out = {}
   for i, seg in ipairs(segments) do
+    local text = seg.text
+    -- Escape by kind, colour whatever asked for it: the two are separate questions, and a
+    -- name that is coloured is still a name.
     if kind_of(seg) == "literal" then
-      out[i] = (seg.text:gsub("%%", "%%%%"))
-    elseif seg.hl then
-      out[i] = ("%%#%s#%s%%*"):format(seg.hl, seg.text)
-    else
-      out[i] = seg.text
+      text = (text:gsub("%%", "%%%%"))
     end
+    if seg.hl then
+      text = ("%%#%s#%s%%*"):format(seg.hl, text)
+    end
+    out[i] = text
   end
   return table.concat(out)
 end

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -126,9 +126,16 @@ end
 -- What a bar is *made of* is `render.lua`'s: an ordered list of segments, each saying
 -- whether the plugin wrote it or whether it is a name the plugin did not choose, and
 -- `render.bar` is what turns that list into the string a winbar is set to. Everything here
--- decides *which* segments there are. `render.bar_width` is the ruler for all of it, and the
--- only one: it measures what a bar draws, which is neither its byte length nor its
--- character count.
+-- decides *which* segments there are, what each one says and which group it carries.
+-- `render.bar_width` is the ruler for all of it, and the only one: it measures what a bar
+-- draws, which is neither its byte length nor its character count -- and a highlight marker
+-- is several characters of it and no columns at all.
+--
+-- The groups are `hl.lua`'s, linked by default into whatever colorscheme is active, so a
+-- theme change is the theme's problem and a **muted** pane's bar recedes with the pane
+-- through the twins that set already has. The path carries none of them: the bar's own group
+-- is the brightest thing on a winbar, and leaving the path in it is what makes it the
+-- brightest thing on the left.
 
 local SEP = " · "
 -- One blank column at each edge, and at least two between the halves, so the two never
@@ -177,16 +184,44 @@ local function set_winbar(win, segments)
   vim.wo[win].winbar = render.bar(segments)
 end
 
----What the review summary says, one segment per `·`.
+---The `+N -M` a stat is, with its two halves coloured apart.
+---
+---Taken as the string the stat already is rather than as two numbers, so that the file's own
+---counts and the review's totals are spelled by one format and coloured by one rule. A
+---`binary` file has no counts in it and takes no colour.
+---@param stat string
+---@return CRBarSegment[]
+local function stat_segments(stat)
+  local plus, minus = stat:match("^(%+%d+) (%-%d+)$")
+  if not plus then
+    return { render.chrome(stat) }
+  end
+  return {
+    render.chrome(plus, "CodeReviewStatAdd"),
+    render.chrome(" "),
+    render.chrome(minus, "CodeReviewStatDel"),
+  }
+end
+
+---What the review summary says, one entry per `·`.
 ---
 ---A list rather than a string because a pane too narrow for both halves is one the summary
----gives way on, and which segment goes is the only thing here that is not a format.
----`spare` marks the ones the sticky header beside them now says twice: the plugin's own
----name, against a bar that names a file with a review chevron on it; the review's line
----totals, against the file's own `+N -M` two columns to the left; the queue's note count,
----against the file's own. What is not spare is what nothing else on screen says.
----@return { text: string, spare: boolean|nil }[]
+---gives way on, and which entry goes is the only thing here that is not a format. `spare`
+---marks the ones the sticky header beside them says twice: the review's line totals, against
+---the file's own `+N -M` two columns to the left; the queue's note count, against the file's
+---own. What is not spare is what nothing else on screen says.
+---
+---The review's own name is not here at all. It was the first thing a narrow pane dropped,
+---and a bar inside a review does not need to say it is one -- which is about thirty columns
+---handed back to the path.
+---
+---Each entry is already segments, because a count is coloured and the `·` beside it is not,
+---and because the counts carry glyphs a host chose: those are literals for the reason the
+---file's icon is one. Three counts, three glyphs, so that three numbers side by side cannot
+---be read as one another.
+---@return { parts: CRBarSegment[], spare: boolean|nil }[]
 local function summary_segments()
+  local icons = config.get().icons
   local reviewed = 0
   for _ in pairs(V.reviewed) do
     reviewed = reviewed + 1
@@ -197,35 +232,42 @@ local function summary_segments()
     notes = notes + #items
   end
   local out = {
-    { text = "Code review", spare = true },
-    { text = V.scope.label },
-    { text = ("%d/%d reviewed"):format(reviewed, #V.files) },
-    { text = ("+%d -%d"):format(added, removed), spare = true },
+    { parts = { render.literal(V.scope.label) } },
+    { parts = { render.literal(("%s%d/%d"):format(icons.reviewed, reviewed, #V.files)) } },
+    { parts = stat_segments(("+%d -%d"):format(added, removed)), spare = true },
   }
   if notes > 0 then
-    out[#out + 1] = { text = ("%d note%s"):format(notes, notes == 1 and "" or "s"), spare = true }
+    out[#out + 1] = {
+      parts = { render.literal(("%s%d"):format(icons.annotated, notes), "CodeReviewNoteCount") },
+      spare = true,
+    }
   end
   -- Read rather than computed: this runs on every paint, and a paint runs on every resize.
   -- The git behind the number is paid where the archive is judged, which is where the diff
   -- is read -- see `judge_archive`.
   if V.untouched then
-    out[#out + 1] = { text = ("%d untouched"):format(V.untouched) }
+    out[#out + 1] = {
+      parts = { render.literal(("%s%d"):format(icons.untouched, V.untouched), "CodeReviewUntouched") },
+    }
   end
   local to = delivery.target()
   if to and to.short then
-    out[#out + 1] = { text = ("→ %s"):format(to.short) }
+    -- One literal, arrow and all: the arrow is the plugin's and costs nothing by being
+    -- escaped, and a marker pair around each half would say the same thing twice.
+    out[#out + 1] = { parts = { render.literal(("→ %s"):format(to.short), "CodeReviewBarTarget") } }
   end
   return out
 end
 
 ---The summary as segments, minus whatever a narrow pane has made it drop.
 ---
----Literals, every one of them. Two carry names the plugin did not choose -- the **scope**'s
----label and the **target**'s short name -- and the rest cost nothing by being escaped, since
----a format the plugin wrote holds no `%` left by the time it has been formatted. Escaping
----one segment too many draws exactly what was asked for; escaping one too few is how a
----branch called `100%-done` stops being a branch name. The separators are the plugin's own.
----@param segments { text: string, spare: boolean|nil }[]
+---Names are literals, and that is where the escaping lives: the **scope**'s label, the
+---**target**'s short name and every configured glyph are things the plugin did not choose.
+---What the plugin formatted itself holds no `%` left by the time it has been formatted, so
+---escaping one segment too many draws exactly what was asked for; escaping one too few is
+---how a branch called `100%-done` stops being a branch name. The separators are the plugin's
+---own, and quieter than the facts they separate.
+---@param segments { parts: CRBarSegment[], spare: boolean|nil }[]
 ---@param dropped table<integer, boolean>|nil
 ---@return CRBarSegment[]
 local function join(segments, dropped)
@@ -233,9 +275,9 @@ local function join(segments, dropped)
   for i, seg in ipairs(segments) do
     if not (dropped and dropped[i]) then
       if #out > 0 then
-        out[#out + 1] = render.chrome(SEP)
+        out[#out + 1] = render.chrome(SEP, "CodeReviewBarSep")
       end
-      out[#out + 1] = render.literal(seg.text)
+      vim.list_extend(out, seg.parts)
     end
   end
   return out
@@ -272,13 +314,29 @@ end
 ---Literals, the icons included: a host chooses those, so they are not text the plugin wrote.
 ---The path stays a bare string rather than a segment because it is the one part the fitting
 ---rule cuts, and `render.keep_tail` takes text.
+---
+---Coloured as the in-buffer file header colours the same facts, and for the same reason one
+---function names the file for both: the counts apart, the note count in the group the notes
+---themselves carry, the icon and the chevron quiet. The path takes no group at all, which
+---leaves it drawing in the bar's own -- the brightest thing on the left, and the thing the
+---reviewer scrolled there to keep.
 ---@param label CRFileLabel
 ---@return { head: CRBarSegment[], path: string, tail: CRBarSegment[] }
 local function file_segment(label)
+  local tail = { render.chrome("  ") }
+  vim.list_extend(tail, stat_segments(label.stat))
+  -- Whatever the label puts after the stat, which is the note count when there is one. Taken
+  -- off the label rather than spelled again here: how a file's right-hand side reads is
+  -- `render.file_label`'s answer, and a second spelling of it would drift from the in-buffer
+  -- header the first time either moved.
+  local rest = label.right:sub(#label.stat + 1)
+  if rest ~= "" then
+    tail[#tail + 1] = render.chrome(rest, "CodeReviewNoteCount")
+  end
   return {
-    head = { render.literal(("%s %s "):format(label.icon, label.chevron)) },
+    head = { render.literal(("%s %s "):format(label.icon, label.chevron), "CodeReviewBarIcon") },
     path = label.name,
-    tail = { render.literal("  " .. label.right) },
+    tail = tail,
   }
 end
 
@@ -298,7 +356,7 @@ end
 ---kept the least of what it was holding.
 ---@param room integer Columns, margins already taken off
 ---@param file { head: CRBarSegment[], path: string, tail: CRBarSegment[] }
----@param segments { text: string, spare: boolean|nil }[]
+---@param segments { parts: CRBarSegment[], spare: boolean|nil }[]
 ---@return CRBarSegment[] left, CRBarSegment[] right
 local function fit(room, file, segments)
   -- The order they go in: the spares, then the rest from the head.
@@ -382,8 +440,14 @@ local function update_before_winbar()
   end
   local rev = V.scope.before
   -- `:0` is git's name for the index, and a name nobody reads as one. The revision itself is
-  -- a name the repository chose, so it is a literal beside chrome rather than one string.
-  local left = { render.chrome("Before · "), render.literal(rev == ":0" and "index" or rev) }
+  -- a name the repository chose, so it is a literal beside chrome rather than one string --
+  -- and it is accented, because it is what this pane exists to name. The same separator, and
+  -- the same quiet group on it, as the summary on the other pane.
+  local left = {
+    render.chrome("Before"),
+    render.chrome(SEP, "CodeReviewBarSep"),
+    render.literal(rev == ":0" and "index" or rev, "CodeReviewBarRev"),
+  }
   local width = vim.api.nvim_win_get_width(V.before_win)
   -- A file that exists only on the after side has no pre-image path to name, exactly as its
   -- header row on this pane has none: the revision keeps the bar to itself and says so by

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,15 +36,15 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/quiet_child.lua` | Spawned eight times by `quiet_spec`, one painted cell each, where two quiet states meet — deliberately not a spec. |
 | `codereview/drafts_child.lua` | Spawned by `drafts_spec` to abandon a half-written note and exit — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
-| `codereview/winbar_child.lua` | Spawned three times by `split_spec` to read one cell of a pane's winbar — deliberately not a spec. |
+| `codereview/winbar_child.lua` | Spawned four times by `split_spec` to read one cell of a pane's winbar — three inside the path for the muting, one on the file's added count for the colour — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
 
 | Spec | Covers |
 | --- | --- |
 | `types_spec` | Configuring annotation types: defaulting, validation, grouping, a custom type end to end |
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
-| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, the flag that removes them and the key that overrides that flag in both directions, for a session — how a winbar is assembled from typed segments, with no review, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, what a narrow pane sheds, the tree dismissed, a name carrying a `%`, and a review with no files |
-| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, each pane's winbar naming its own side of a rename, and the painted cell proving that bar mutes with its pane |
+| `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, the flag that removes them and the key that overrides that flag in both directions, for a session — how a winbar is assembled from typed segments, with no review, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, which group every piece of the bar draws in, what a narrow pane sheds and what the glyphs bought the path, the tree dismissed, a name carrying a `%`, and a review with no files |
+| `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, each pane's winbar naming its own side of a rename, and the painted cells proving that bar mutes with its pane and draws its counts in a group of the plugin's own |
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
@@ -54,7 +54,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
 | `archive_spec` | A dispatched batch kept across a real restart: both stores, the snapshot and what minting it must not disturb, the bound, the id a new annotation takes, what dropping does on the anchor that holds both, and a document written before the archive existed |
 | `archive_float_spec` | The surface over that record: which batch it decides went last, the two stores rejoined into one listing, how it draws an entry, the four things it refuses, and the key that opens it from the diff and from the tree while the command still opens it from anywhere |
-| `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally and the two switches that take it away with the entries, the three things left unjudged, which of three candidate blobs it is judged against, and that the queue's own staleness rule is untouched by any of it |
+| `touched_spec` | Whether an archived entry's file has moved since its batch went: the reconciliation, the marker on the diff, the winbar tally, how a narrow pane fits a summary that tally is in, and the two switches that take it away with the entries, the three things left unjudged, which of three candidate blobs it is judged against, and that the queue's own staleness rule is untouched by any of it |
 | `since_batch_spec` | The scope that diffs against the newest snapshot, inside a view: what it leaves out, syntax, navigation, collapse, reviewed marks, both layouts, the entry annotating in it produces, and where `gs` reaches it |
 | `viewless_spec` | The queue with no review view open: persist, restore, submit, immediate send |
 | `open_diff_spec` | The `open_diff` adapter: what it is handed across a scope whose post-image is a ref and one whose post-image is the working tree, from both panes and from the tree, and the key that exists only while it is wired |
@@ -134,17 +134,19 @@ so the out-of-core language path is still checked locally without ever failing C
 - **The `gA` cases have to sit at the end of `render_spec`, and what they are keeping clear
   of is a winbar.** Opening a review is what runs `judge_archive`, and this file archives a
   batch part-way down — so the first case that opens a review of its own is also the first to
-  put an `N untouched` segment on the **sticky header**, and every case below it then reads a
-  bar one segment longer than the one it was written against. The case that notices is `the
+  put an untouched tally on the **sticky header**, and every case below it then reads a bar
+  one segment longer than the one it was written against. The case that notices is `the
   sticky header on a pane that has to choose`: at 45 columns the summary sheds its spares
-  first and then from its head, so one more segment pushes the shedding one step further and
-  the `0/N reviewed` tally that case asserts *survives* is exactly what goes. Measured rather
-  than predicted — a bare `view.reconcile()` above that block reds it, and nothing else in the
-  suite, on a bar reading `○ ▾ … → src/newname.lua  +1 -1  2 untouched` with the reviewed
-  tally gone. Nothing in that failure mentions archived entries or the key, which is what
-  makes it expensive: a case about `gA` breaks a case about narrow panes, and the two have
-  nothing to say to each other. Moving the block up the file brings it back, and so does
-  giving any earlier block a review of its own.
+  first and then from its head, and one more segment on it is columns the path does not get.
+  What reds is `spends the columns the shorter summary freed on the path` — the path keeps
+  five columns fewer, which is the head of the pre-image name in a rename. Measured rather
+  than predicted — a bare `view.reconcile()` above that block reds that one case, and nothing
+  else in the suite, on a bar reading `○ ▾ …ua → src/newname.lua  +1 -1  ✓0/8 · ↺2`. Nothing
+  in that failure mentions archived entries or the key, which is what makes it expensive: a
+  case about `gA` breaks a case about narrow panes, and the two have nothing to say to each
+  other. Moving the block up the file brings it back, and so does giving any earlier block a
+  review of its own. The glyphs bought that bar about thirty columns, so what used to go at
+  45 was the whole `0/N reviewed` tally; the trap is the same one, one notch further down.
 - **A session-lived override can only be caught falling back to configuration once.** `gA`
   overrides `archived` for the whole process, so "unset means the configured value" is
   observable only while this process has not yet pressed the key. `render_spec`'s cases for
@@ -333,14 +335,29 @@ so the out-of-core language path is still checked locally without ever failing C
 - **A muted winbar cannot be told from a bright one by its text**, and a non-current window
   draws its winbar in `WinBarNC` whether or not anything is muted — so "the unfocused pane's
   bar is not `WinBar`" holds with the muted namespace never reaching the winbar at all. The
-  sticky header carries no group of the plugin's own, so that namespace covering `WinBar`
+  path on that bar carries no group of the plugin's own, so that namespace covering `WinBar`
   and `WinBarNC` is the only thing making it recede with its pane, and the only assertion
   that can see it is the painted cell. `split_spec` spawns `winbar_child.lua` three times
   over one cell inside the path the bar names — focused, muted, and **muted off** — and it
   is the third that gives the second its teeth: without it the muted reading is only known
-  to differ from `WinBar`, not to be a blend of anything. Its window position is taken from
-  `nvim_win_get_position`, which is the winbar's own row, and the offset into the bar is a
-  display width, since the icon and the chevron in front of the path are both multibyte.
+  to differ from `WinBar`, not to be a blend of anything. A fourth run reads a different
+  cell of the same bar — the file's added count, which is where a group of the plugin's own
+  is — because no reading of the path can say that group reached the screen, and no reading
+  of the count can say the bar mutes: it is taken on the pane with focus, at the group's own
+  brightness. Its window position is taken from `nvim_win_get_position`, which is the
+  winbar's own row, and the offset into the bar is a display width **of what the bar draws**,
+  from `nvim_eval_statusline`: the icon and the chevron in front of the path are multibyte,
+  so a byte offset lands early, and a highlight marker is characters with no columns at all,
+  so an offset measured off the option lands late.
+- **An assertion about what the winbar says has to read what it draws.** The option holds
+  markup: the file's `+N -M` is two segments with a marker between them, so
+  `winbar:find("+1 -1")` is nil however the bar reads — and an `is_nil` written that way
+  passes whatever the bar says, which is a case gone quiet rather than a case passing.
+  `h.winbar` puts the option through Neovim's own statusline parser and hands back the text
+  and the width a reviewer sees, and every assertion about what a bar says goes through it.
+  The one that must not is `render_spec`'s escape case: `ja%%nus` in the markup is `ja%nus`
+  on the screen, and there the markup *is* the claim. The case beside it reads the drawn bar,
+  which is where "the name was drawn rather than expanded" can be seen at all.
 - **`WinResized` is no use to a test.** It is fired from the main loop, so it lands after
   whatever changed the width has returned — and in a headless spec, which never pumps the
   loop, it does not land at all. Anything that changes a window's width has to repaint for

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -378,6 +378,14 @@ describe("the winbar assembly", function()
     assert.same("%%#CodeReviewAdd#x", render.bar({ render.literal("%#CodeReviewAdd#x") }))
   end)
 
+  -- A name can be coloured too, and the escape is unchanged by it: the bar's coloured
+  -- pieces are largely names -- a **target**'s short name, a base revision, a count carrying
+  -- a glyph a host configured -- and the alternative is a caller writing the markers around
+  -- one by hand, which is exactly what having a kind per segment refuses.
+  it("wraps a literal that carries a highlight group, and doubles its % as well", function()
+    assert.same("%#CodeReviewNoteCount#50%% done%*", render.bar({ render.literal("50% done", "CodeReviewNoteCount") }))
+  end)
+
   -- A caller cannot put a path on the bar by accident, because a segment that says nothing
   -- about its kind is not a segment. The message is asserted, not merely the raise: every
   -- one of these raises while the assembly does not exist at all, and a case satisfied by
@@ -451,16 +459,34 @@ describe("the winbar assembly", function()
     end
     assert.is_true(groups.DiffAdd or false, vim.inspect(drawn.highlights))
   end)
+
+  -- The same claim for a coloured *name*, which is the case the bar actually needs: the
+  -- escape and the marker have to compose, so that what Neovim draws is the name as it
+  -- stands, in the group asked for, and no wider than the ruler said.
+  it("colours a name without letting the escape reach the screen", function()
+    local segments = { render.literal("src/50% done.lua", "DiffAdd") }
+    local drawn = vim.api.nvim_eval_statusline(render.bar(segments), { highlights = true })
+    assert.same("src/50% done.lua", drawn.str)
+    assert.same(render.bar_width(segments), drawn.width)
+    local groups = {}
+    for _, run in ipairs(drawn.highlights) do
+      groups[run.group] = true
+    end
+    assert.is_true(groups.DiffAdd or false, vim.inspect(drawn.highlights))
+  end)
 end)
 
 -- The sticky header: the file the cursor is in, named on the winbar so that reading past
 -- that file's own header row no longer costs a reviewer the file.
 --
 -- Asserted through the window option, as the scope above already is -- what a reviewer's
--- editor holds after a real cursor movement, never the function that put it there. This is
--- the *unified* layout's bar, including the rename spelled `old → new`; the per-pane rules
--- are `split_spec`'s. Every case reads a file from well below its header row, because the
--- header is exactly what has gone by the time this matters.
+-- editor holds after a real cursor movement, never the function that put it there. Through
+-- `h.winbar`, which is that option as Neovim *draws* it: the bar carries highlight markers
+-- now, and a needle spanning two of its segments is not in the raw string at all, so an
+-- assertion that something is absent would pass whatever the bar says. This is the *unified*
+-- layout's bar, including the rename spelled `old → new`; the per-pane rules are
+-- `split_spec`'s. Every case reads a file from well below its header row, because the header
+-- is exactly what has gone by the time this matters.
 --
 -- These blocks run last in this file and move the pane's width and the scope about, which
 -- nothing below them would survive.
@@ -468,7 +494,7 @@ describe("the sticky header", function()
   local V = view.current()
 
   local function bar()
-    return vim.wo[V.win].winbar
+    return h.winbar(V.win)
   end
 
   ---Read a file the way a reviewer does -- autocmd and all, which is the only thing that
@@ -528,9 +554,127 @@ describe("the sticky header", function()
   -- existed is still on it, moved to the right rather than dropped.
   it("keeps the review summary beside the file", function()
     local added, removed = require("codereview.diff").totals(V.files)
+    local icons = config.get().icons
     assert.is_truthy(bar():find(V.scope.label, 1, true), bar())
-    assert.is_truthy(bar():find(("0/%d reviewed"):format(#V.files), 1, true), bar())
+    assert.is_truthy(bar():find(("%s0/%d"):format(icons.reviewed, #V.files), 1, true), bar())
     assert.is_truthy(bar():find(("+%d -%d"):format(added, removed), 1, true), bar())
+  end)
+end)
+
+-- What the bar says with room for all of it, and which group each piece of it draws in.
+--
+-- Wide on purpose: at the width this file's tree leaves, the summary is already shedding, so
+-- "the review's own name is gone" would hold here with nothing having dropped it. A hundred
+-- columns is room for the whole summary beside a short path, which is where its absence
+-- means something.
+--
+-- The groups are read through `nvim_eval_statusline`, which is the parser a winbar goes
+-- through: it reports what each byte of the *drawn* bar is covered by, so a marker that
+-- landed one segment out is visible here. What no markup can say -- that the cell really
+-- draws in that group -- is `split_spec`'s painted cell.
+describe("the sticky header with room for the whole summary", function()
+  local V = view.current()
+  local icons = config.get().icons
+
+  ---@param path string
+  local function read_into(path)
+    local index = assert(h.file_index(V, path))
+    vim.api.nvim_set_current_win(V.win)
+    vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index] + 1, 0 })
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+  end
+
+  vim.api.nvim_win_set_width(V.win, 100)
+  view.paint()
+  read_into("src/nonl.md")
+
+  local function bar()
+    return h.winbar(V.win)
+  end
+
+  ---What the bar draws, and the group covering each byte of it. The raw option, because the
+  ---groups are what is being read and `h.winbar` has already thrown them away.
+  ---@return { str: string, highlights: table[] }
+  local function drawn()
+    local markup = vim.wo[V.win].winbar
+    return vim.api.nvim_eval_statusline(markup, { winid = V.win, use_winbar = true, highlights = true })
+  end
+
+  ---The highlight group the first byte of `needle` is drawn in.
+  ---
+  ---`WinBar` is what comes back for anything carrying no group of the plugin's own, which is
+  ---the winbar's own foreground and the brightest thing on it.
+  ---@param needle string
+  ---@return string
+  local function group_of(needle)
+    local d = drawn()
+    local at = assert(d.str:find(needle, 1, true), ("%q is not on the bar: %s"):format(needle, d.str)) - 1
+    local group = "WinBar"
+    for _, run in ipairs(d.highlights) do
+      if run.start <= at then
+        group = run.group
+      end
+    end
+    return group
+  end
+
+  -- Guards the block: at a width the summary is already shedding at, half the cases below
+  -- would be asserting that a narrow pane dropped something.
+  it("really has room for the whole summary", function()
+    assert.same(100, vim.api.nvim_win_get_width(V.win))
+    assert.is_truthy(bar():find(V.scope.label, 1, true), bar())
+    local added, removed = require("codereview.diff").totals(V.files)
+    assert.is_truthy(bar():find(("+%d -%d"):format(added, removed), 1, true), bar())
+  end)
+
+  -- A bar inside a review does not need to say it is one, and the columns it cost are the
+  -- ones the path fights hardest for.
+  it("no longer names the review itself", function()
+    assert.is_nil(bar():find("Code review", 1, true), bar())
+  end)
+
+  -- Three numbers side by side, each with a glyph of its own so none of them can be read as
+  -- another. Every glyph comes from the configured icon table and none of them needs a Nerd
+  -- Font.
+  it("says the reviewed tally in a glyph rather than in a word", function()
+    assert.is_truthy(bar():find(("%s0/%d"):format(icons.reviewed, #V.files), 1, true), bar())
+    assert.is_nil(bar():find("reviewed", 1, true), bar())
+  end)
+
+  it("draws the path in the bar's own group, the brightest thing on it", function()
+    assert.same("WinBar", group_of("src/nonl.md"))
+  end)
+
+  it("colours the file's own added and removed counts apart", function()
+    local file = V.files[assert(h.file_index(V, "src/nonl.md"))]
+    assert.same("CodeReviewStatAdd", group_of(("+%d"):format(file.added)))
+    assert.same("CodeReviewStatDel", group_of(("-%d"):format(file.removed)))
+  end)
+
+  it("dims the separators and the icons in front of the path", function()
+    assert.same("CodeReviewBarSep", group_of("·"))
+    assert.same("CodeReviewBarIcon", group_of(icons.unreviewed))
+  end)
+
+  -- Every group here is a `default = true` link into whatever colorscheme is active, which
+  -- is what makes a theme change the theme's problem -- and what gives the bar **muted**
+  -- twins for free, since `hl.groups()` derives the muted set from the same table. Asserted
+  -- as a link to a defined group, never as a resolved colour.
+  it("links the bar's own groups into the colorscheme rather than defining colours", function()
+    for _, group in ipairs({ "CodeReviewBarIcon", "CodeReviewBarSep", "CodeReviewBarTarget", "CodeReviewBarRev" }) do
+      local def = vim.api.nvim_get_hl(0, { name = group })
+      assert.is_truthy(def.link, ("%s is not a link: %s"):format(group, vim.inspect(def)))
+      assert.is_truthy(vim.api.nvim_get_hl(0, { name = def.link }), ("%s links nowhere"):format(group))
+    end
+  end)
+
+  -- The theme's problem, proven rather than asserted of the links: a colorscheme clears every
+  -- global definition, and the bar has to come back linked into the new one.
+  it("comes back in the new theme's colours when the colorscheme changes", function()
+    vim.cmd("colorscheme blue")
+    local def = vim.api.nvim_get_hl(0, { name = "CodeReviewBarSep" })
+    assert.is_truthy(def.link, vim.inspect(def))
+    vim.cmd("colorscheme default")
   end)
 end)
 
@@ -543,7 +687,7 @@ describe("the sticky header with the tree dismissed", function()
   view.toggle_panel()
 
   local function bar()
-    return vim.wo[V.win].winbar
+    return h.winbar(V.win)
   end
 
   ---@param path string
@@ -575,7 +719,7 @@ describe("the sticky header on a pane that has to choose", function()
   view.toggle_panel() -- back, so the after pane has a neighbour to give columns to
 
   local function bar()
-    return vim.wo[V.win].winbar
+    return h.winbar(V.win)
   end
 
   ---Resize the pane and repaint. `WinResized` is fired from the main loop and never lands
@@ -625,11 +769,20 @@ describe("the sticky header on a pane that has to choose", function()
   end)
 
   -- The summary gives way, and gives up what the file beside it now says twice before what
-  -- only it can say: the plugin's own name and the review's line totals go, the reviewed
-  -- tally is still there.
+  -- only it can say: the review's line totals go, the reviewed tally is still there.
   it("sheds the summary rather than the file", function()
-    assert.is_nil(bar():find("Code review", 1, true), bar())
-    assert.is_truthy(bar():find(("0/%d reviewed"):format(#V.files), 1, true), bar())
+    local added, removed = require("codereview.diff").totals(V.files)
+    assert.is_nil(bar():find(("+%d -%d"):format(added, removed), 1, true), bar())
+    assert.is_truthy(bar():find(("%s0/%d"):format(config.get().icons.reviewed, #V.files), 1, true), bar())
+  end)
+
+  -- What the glyphs were spent on. The summary is about thirty columns shorter than the
+  -- words were, and on this pane every one of them goes to the path: the words left room for
+  -- `…→ src/newname.lua` and no more, so any of the *old* name arriving is columns that did
+  -- not exist before. The path still gives up its head, which is the rule -- it is keeping
+  -- more of it.
+  it("spends the columns the shorter summary freed on the path", function()
+    assert.is_truthy(bar():find("e.lua → src/newname.lua", 1, true), bar())
   end)
 end)
 
@@ -649,6 +802,9 @@ describe("the sticky header naming something with a % in it", function()
   vim.api.nvim_win_set_width(V.win, 100)
   view.pick_target()
 
+  -- The raw option, and the one block in this file that must read it: the claim is about the
+  -- markup a winbar is set to. Drawn, the doubled `%` is one `%` again, which is the right
+  -- answer and not the one being asserted here.
   local function bar()
     return vim.wo[V.win].winbar
   end
@@ -656,6 +812,13 @@ describe("the sticky header naming something with a % in it", function()
   it("doubles the % rather than letting it start a statusline item", function()
     assert.is_truthy(bar():find("ja%%nus", 1, true), bar())
     assert.is_nil(bar():find("ja%nus", 1, true), bar())
+  end)
+
+  -- And what the doubling is *for*, which the markup alone does not say: what reaches the
+  -- screen is the target's own name, not the window's file name that `%f` would have put
+  -- there. Neovim's own parser answers it.
+  it("draws the name the picker chose rather than expanding it", function()
+    assert.is_truthy(h.winbar(V.win):find("→ ja%nus", 1, true), h.winbar(V.win))
   end)
 end)
 
@@ -666,18 +829,20 @@ describe("the sticky header on a review with no files", function()
   view.set_scope("HEAD..HEAD")
 
   local function bar()
-    return vim.wo[V.win].winbar
+    return h.winbar(V.win)
   end
 
   it("really has no files", function()
     assert.same(0, #V.files)
   end)
 
-  -- Left-aligned and starting with the summary's first word: no file segment, and no empty
-  -- one either. A bar that drew the icons with nothing after them would fail here.
+  -- Left-aligned and starting with the summary's first segment, which is the scope now that
+  -- the review's own name has gone: no file segment, and no empty one either. A bar that drew
+  -- the icons with nothing after them would fail here.
   it("gives the summary the winbar to itself", function()
-    assert.same(" Code review", bar():sub(1, #" Code review"), bar())
-    assert.is_truthy(bar():find("0/0 reviewed", 1, true), bar())
+    local head = " " .. V.scope.label
+    assert.same(head, bar():sub(1, #head), bar())
+    assert.is_truthy(bar():find(("%s0/0"):format(config.get().icons.reviewed), 1, true), bar())
   end)
 
   it("draws no chevron for a file that is not there", function()

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -592,30 +592,10 @@ describe("the sticky header with room for the whole summary", function()
     return h.winbar(V.win)
   end
 
-  ---What the bar draws, and the group covering each byte of it. The raw option, because the
-  ---groups are what is being read and `h.winbar` has already thrown them away.
-  ---@return { str: string, highlights: table[] }
-  local function drawn()
-    local markup = vim.wo[V.win].winbar
-    return vim.api.nvim_eval_statusline(markup, { winid = V.win, use_winbar = true, highlights = true })
-  end
-
-  ---The highlight group the first byte of `needle` is drawn in.
-  ---
-  ---`WinBar` is what comes back for anything carrying no group of the plugin's own, which is
-  ---the winbar's own foreground and the brightest thing on it.
   ---@param needle string
-  ---@return string
+  ---@return string|nil
   local function group_of(needle)
-    local d = drawn()
-    local at = assert(d.str:find(needle, 1, true), ("%q is not on the bar: %s"):format(needle, d.str)) - 1
-    local group = "WinBar"
-    for _, run in ipairs(d.highlights) do
-      if run.start <= at then
-        group = run.group
-      end
-    end
-    return group
+    return h.winbar_group(V.win, needle)
   end
 
   -- Guards the block: at a width the summary is already shedding at, half the cases below
@@ -642,7 +622,7 @@ describe("the sticky header with room for the whole summary", function()
   end)
 
   it("draws the path in the bar's own group, the brightest thing on it", function()
-    assert.same("WinBar", group_of("src/nonl.md"))
+    assert.is_nil(group_of("src/nonl.md"))
   end)
 
   it("colours the file's own added and removed counts apart", function()
@@ -812,6 +792,12 @@ describe("the sticky header naming something with a % in it", function()
   it("doubles the % rather than letting it start a statusline item", function()
     assert.is_truthy(bar():find("ja%%nus", 1, true), bar())
     assert.is_nil(bar():find("ja%nus", 1, true), bar())
+  end)
+
+  -- Where a **target** is named the bar is accented, arrow and name alike: it is where a
+  -- batch is going, and a reviewer looks for it while reading code.
+  it("accents the target it is naming", function()
+    assert.same("CodeReviewBarTarget", h.winbar_group(V.win, "→ ja%nus"))
   end)
 
   -- And what the doubling is *for*, which the markup alone does not say: what reaches the

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -1267,6 +1267,22 @@ describe("the sticky header in the split layout", function()
     assert.is_truthy(after:find(reviewed, 1, true), after)
   end)
 
+  -- The before pane's bar gets the same treatment as the after pane's, and this is the only
+  -- place either can be said of *it*: the revision it exists to name is accented, the
+  -- separator in front of that is as quiet as the summary's, and the pre-image path is left
+  -- in the bar's own group -- the brightest thing on this bar, exactly as on the other one.
+  it("colours the before pane's bar as it colours the after pane's", function()
+    assert.same("CodeReviewBarRev", h.winbar_group(V.before_win, V.scope.before))
+    assert.same("CodeReviewBarSep", h.winbar_group(V.before_win, "·"))
+    assert.is_nil(h.winbar_group(V.before_win, "src/oldname.lua"))
+  end)
+
+  -- The note count carries the colour notes carry everywhere else, which is the one thing on
+  -- this bar `render_spec` cannot reach: nothing is queued while its own summary is measured.
+  it("draws the queue's note count in the group the notes themselves carry", function()
+    assert.same("CodeReviewNoteCount", h.winbar_group(V.win, ("%s1"):format(config.get().icons.annotated)))
+  end)
+
   -- A file added on the branch exists on one side only, and the before pane's header row for
   -- it is filler. Its winbar says the same thing by naming nothing.
   it("names no pre-image for a file that has none", function()

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -682,7 +682,8 @@ describe("opening in the split layout", function()
   end)
 
   it("carries the review status on the after pane's winbar", function()
-    assert.is_truthy(vim.wo[V.win].winbar:find("reviewed", 1, true))
+    local reviewed = ("%s0/%d"):format(require("codereview.config").get().icons.reviewed, #V.files)
+    assert.is_truthy(h.winbar(V.win):find(reviewed, 1, true), h.winbar(V.win))
   end)
 
   it("names the revision the before pane is showing", function()
@@ -1238,7 +1239,9 @@ describe("the sticky header in the split layout", function()
   end
 
   read_into("src/newname.lua")
-  local after, before = vim.wo[V.win].winbar, vim.wo[V.before_win].winbar
+  -- What the two bars draw, not the markup they are set to: a needle that crossed one of the
+  -- highlight markers on them would never be found in the option itself.
+  local after, before = h.winbar(V.win), h.winbar(V.before_win)
 
   -- Guards the block: on a pane with no room for both, the before pane's path is dropped
   -- rather than drawn over its revision, and every case here would be reading that instead.
@@ -1259,8 +1262,9 @@ describe("the sticky header in the split layout", function()
   end)
 
   it("keeps the review summary on the after pane where it has always been", function()
+    local reviewed = ("%s0/%d"):format(require("codereview.config").get().icons.reviewed, #V.files)
     assert.is_truthy(after:find(V.scope.label, 1, true), after)
-    assert.is_truthy(after:find("reviewed", 1, true), after)
+    assert.is_truthy(after:find(reviewed, 1, true), after)
   end)
 
   -- A file added on the branch exists on one side only, and the before pane's header row for
@@ -1318,6 +1322,9 @@ describe("the sticky header on a muted pane", function()
   local muted = child({ FOCUS = "before", MUTED = "1" })
   local bright = child({ FOCUS = "after", MUTED = "1" })
   local unmuted_nc = child({ FOCUS = "before", MUTED = "0" })
+  -- The fourth reading is a different cell of the same bar: the file's added count, which is
+  -- the one segment on the left carrying a group of the plugin's own.
+  local stat = child({ FOCUS = "after", MUTED = "1", CELL = "stat" })
 
   -- Every reading is of a cell inside the path, so a bar that had stopped naming the file
   -- would fail here before any colour was compared.
@@ -1344,5 +1351,16 @@ describe("the sticky header on a muted pane", function()
   -- darker *than*.
   it("comes back at that group's own brightness with muting off", function()
     assert.same("cell s fg=ee0000 bg=004400", unmuted_nc)
+  end)
+
+  -- The claim no reading of the path can make, and no comparison of two strings can make
+  -- either: a group of the plugin's own reaches the screen. The cell is the `+` of the file's
+  -- own added count, on the pane with focus, and the reading has to be the group the stat
+  -- links into rather than the bar's own foreground -- which is what the bright reading above
+  -- is, taken from the same bar three cells to the left. The background is the bar's, because
+  -- a `%#Group#` naming a foreground leaves it showing through.
+  it("draws the added count in the plugin's own group rather than the bar's foreground", function()
+    assert.same("cell + fg=00cc66 bg=006600", stat)
+    assert.are_not.same(bright:sub(#"cell + " + 1), stat:sub(#"cell + " + 1), "the same colour as the path")
   end)
 end)

--- a/tests/codereview/touched_spec.lua
+++ b/tests/codereview/touched_spec.lua
@@ -37,6 +37,20 @@ codereview.setup({
   send = function() end,
 })
 
+local icons = require("codereview.config").get().icons
+
+---The tally as the **sticky header** spells it: the configured glyph, and the number on it.
+---
+---A glyph rather than the word, because three counts sit side by side on that bar and each
+---needs one of its own. Every assertion about it reads `h.winbar`, which is the bar as
+---Neovim draws it: the option holds highlight markers, and a tally that had gone missing
+---from behind one would be found all the same.
+---@param n integer
+---@return string
+local function tally(n)
+  return ("%s%d"):format(icons.untouched, n)
+end
+
 ---Queue one whole-file annotation, as the review path would have left it.
 ---@param path string
 ---@param note string
@@ -247,7 +261,7 @@ describe("an archived entry on the diff", function()
   end)
 
   it("tallies the untouched ones on the winbar", function()
-    assert.is_truthy(vim.wo[V.win].winbar:find("1 untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_truthy(h.winbar(V.win):find(tally(1), 1, true), h.winbar(V.win))
   end)
 end)
 
@@ -275,7 +289,7 @@ describe("a stale queued entry beside them", function()
   end)
 
   it("leaves the tally where it was", function()
-    assert.is_truthy(vim.wo[V.win].winbar:find("1 untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_truthy(h.winbar(V.win):find(tally(1), 1, true), h.winbar(V.win))
   end)
 
   queue.clear()
@@ -296,7 +310,7 @@ describe("a scope that covers neither file", function()
   end)
 
   it("tallies nothing rather than nothing-untouched", function()
-    assert.is_nil(vim.wo[V.win].winbar:find("untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_nil(h.winbar(V.win):find(icons.untouched, 1, true), h.winbar(V.win))
   end)
 
   it("judges nothing", function()
@@ -327,7 +341,7 @@ describe("a file deleted since the dispatch", function()
   end)
 
   it("leaves nothing untouched, and says so rather than going quiet", function()
-    assert.is_truthy(vim.wo[V.win].winbar:find("0 untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_truthy(h.winbar(V.win):find(tally(0), 1, true), h.winbar(V.win))
   end)
 end)
 
@@ -339,7 +353,7 @@ describe("the configuration flag", function()
   view.refresh()
 
   it("takes the tally with the entries", function()
-    assert.is_nil(vim.wo[V.win].winbar:find("untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_nil(h.winbar(V.win):find(icons.untouched, 1, true), h.winbar(V.win))
   end)
 
   it("judges nothing, so nothing is spent deciding", function()
@@ -351,7 +365,7 @@ describe("the configuration flag", function()
   view.refresh()
 
   it("brings both back together", function()
-    assert.is_truthy(vim.wo[V.win].winbar:find("0 untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_truthy(h.winbar(V.win):find(tally(0), 1, true), h.winbar(V.win))
   end)
 end)
 
@@ -367,7 +381,7 @@ describe("the key beside it", function()
   h.feed("gA")
 
   it("takes the tally with the entries", function()
-    assert.is_nil(vim.wo[V.win].winbar:find("untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_nil(h.winbar(V.win):find(icons.untouched, 1, true), h.winbar(V.win))
   end)
 
   it("judges nothing, so nothing is spent deciding", function()
@@ -382,7 +396,7 @@ describe("the key beside it", function()
   h.feed("gA")
 
   it("brings both back together, without re-reading the diff", function()
-    assert.is_truthy(vim.wo[V.win].winbar:find("0 untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_truthy(h.winbar(V.win):find(tally(0), 1, true), h.winbar(V.win))
   end)
 end)
 
@@ -446,7 +460,7 @@ describe("a file the reviewer edited between annotating and submitting", functio
   end)
 
   it("counts as untouched on the winbar", function()
-    assert.is_truthy(vim.wo[V.win].winbar:find("1 untouched", 1, true), vim.wo[V.win].winbar)
+    assert.is_truthy(h.winbar(V.win):find(tally(1), 1, true), h.winbar(V.win))
   end)
 
   -- The reviewer's own edits are not the agent's work, and the entry carries the blob that
@@ -462,5 +476,49 @@ describe("a file the reviewer edited between annotating and submitting", functio
     local touched = state.reconcile_archive(root, V.files)
     assert.is_nil(touched[dispatched_ids["the agent will edit this file"]])
     assert.same({ [entry.id] = false }, touched)
+  end)
+end)
+
+-- The **sticky header** with one more segment on it than a review usually has, on a pane
+-- that cannot hold them all. `render_spec` owns the fitting rule; what only this file can
+-- reach is the rule fitting a summary the tally is *in*, because this segment is the one
+-- that comes and goes.
+--
+-- Last in this file: it narrows the pane, which nothing below it would survive.
+describe("the tally on a pane that has to choose", function()
+  local V = assert(view.current())
+
+  vim.api.nvim_win_set_width(V.win, 45)
+  view.paint()
+  local index = assert(h.file_index(V, "src/newname.lua"))
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index] + 1, 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+
+  local function bar()
+    return h.winbar(V.win)
+  end
+
+  -- Guards the block: with no tally on the bar this is `render_spec`'s narrow-pane case
+  -- again, and every case below would pass without the segment it is about being there.
+  it("really is fitting a bar the tally is on", function()
+    assert.same(1, V.untouched)
+    assert.same(45, vim.api.nvim_win_get_width(V.win))
+    assert.is_truthy(bar():find(tally(1), 1, true), bar())
+  end)
+
+  -- The order is unchanged by the extra segment: the review's line totals are what the file
+  -- beside them says twice, so they go first and the counts that only the summary can give
+  -- stay. In words this bar had room for one of them; in glyphs it has room for both.
+  it("sheds what the file says twice and keeps both counts", function()
+    local added, removed = require("codereview.diff").totals(V.files)
+    assert.is_nil(bar():find(("+%d -%d"):format(added, removed), 1, true), bar())
+    assert.is_truthy(bar():find(("%s0/%d"):format(icons.reviewed, #V.files), 1, true), bar())
+  end)
+
+  -- The path still gives up its head rather than its tail, tally or no tally.
+  it("keeps the file's own name at the end of the path", function()
+    assert.is_truthy(bar():find("src/newname.lua", 1, true), bar())
+    assert.is_truthy(bar():find("…", 1, true), bar())
   end)
 end)

--- a/tests/codereview/touched_spec.lua
+++ b/tests/codereview/touched_spec.lua
@@ -263,6 +263,12 @@ describe("an archived entry on the diff", function()
   it("tallies the untouched ones on the winbar", function()
     assert.is_truthy(h.winbar(V.win):find(tally(1), 1, true), h.winbar(V.win))
   end)
+
+  -- The same group the entries themselves are drawn in, two rows below. One colour, one
+  -- meaning: the tally is the count of what is drawn in that colour on the diff.
+  it("draws the tally in the group those entries carry on the diff", function()
+    assert.same("CodeReviewUntouched", h.winbar_group(V.win, tally(1)))
+  end)
 end)
 
 -- A queued entry's staleness and an archived entry's touchedness are drawn from the same

--- a/tests/codereview/winbar_child.lua
+++ b/tests/codereview/winbar_child.lua
@@ -19,8 +19,14 @@
 -- channels are all even, so a half-strength blend toward a black background has no rounding
 -- in it.
 --
+-- `CELL` chooses which cell that is: the path, which carries no group of the plugin's own
+-- and is the reading the muting is proven with, or the file's added count, which carries
+-- one and is the reading the *colour* is proven with. Neither can stand in for the other:
+-- the path says the bar recedes with its pane, and the count says a group of the plugin's
+-- reaches the screen at all.
+--
 -- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. Spawned by
--- `split_spec` with FIXTURE, FOCUS and MUTED in its environment, and it must NOT load
+-- `split_spec` with FIXTURE, FOCUS, MUTED and CELL in its environment, and it must NOT load
 -- tests/minimal_init.lua, which would mint a state directory of its own.
 vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
 vim.o.termguicolors = true
@@ -35,6 +41,11 @@ vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
 -- it came from as well as how bright it was.
 vim.api.nvim_set_hl(0, "WinBar", { fg = 0xeeee00, bg = 0x006600 })
 vim.api.nvim_set_hl(0, "WinBarNC", { fg = 0xee0000, bg = 0x004400 })
+-- What `CodeReviewStatAdd` links into, given a colour of its own that is neither of the
+-- two above -- so a cell drawn in it cannot be confused with a cell that took the bar's own
+-- foreground. A `%#Group#` sets the foreground and leaves the bar's background showing
+-- through, which is why only the foreground here differs from `WinBar`'s.
+vim.api.nvim_set_hl(0, "Added", { fg = 0x00cc66 })
 
 require("codereview").setup({
   layout = "split",
@@ -67,11 +78,19 @@ vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
 -- FOCUS=before is the muted reading and FOCUS=after the bright one.
 vim.api.nvim_set_current_win(vim.env.FOCUS == "before" and V.before_win or V.win)
 
--- Where the path starts on that bar, in display columns rather than bytes: the icon and the
--- chevron in front of it are both multibyte, so a byte offset lands two cells early.
-local bar = vim.wo[V.win].winbar
-local at = assert(bar:find(PATH, 1, true), "the winbar does not name " .. PATH .. ": " .. bar)
-local offset = vim.fn.strdisplaywidth(bar:sub(1, at - 1))
+-- Where that segment starts on the bar, in display columns of what the bar *draws*.
+--
+-- Taken from `nvim_eval_statusline` rather than from the option's own string, and both
+-- halves of that matter. Columns rather than bytes, because the icon and the chevron in
+-- front of the path are multibyte and a byte offset lands two cells early. Drawn rather than
+-- written, because the bar carries highlight markers -- characters in the string and no
+-- columns at all on the screen -- so a reading measured off the option drifts right by the
+-- width of every marker in front of it. Same trap, arriving from the two opposite sides.
+local file = V.files[index]
+local needle = vim.env.CELL == "stat" and ("+%d -%d"):format(file.added, file.removed) or PATH
+local drawn = vim.api.nvim_eval_statusline(vim.wo[V.win].winbar, { winid = V.win, use_winbar = true })
+local at = assert(drawn.str:find(needle, 1, true), ("the winbar does not carry %q: %s"):format(needle, drawn.str))
+local offset = vim.fn.strdisplaywidth(drawn.str:sub(1, at - 1))
 
 -- A window's own position is its winbar's row, its text beginning one row below.
 local top, left = unpack(vim.api.nvim_win_get_position(V.win))

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -146,6 +146,22 @@ function M.line_row(view, path)
   end)
 end
 
+---What a window's **sticky header** draws, and how many columns of it.
+---
+---Read through Neovim's own statusline parser rather than off the window option, and every
+---assertion about what a bar *says* has to come through here. The option holds markup: a
+---needle spanning two segments is not in that string at all, so an `is_nil` for one passes
+---whatever the bar says, and a width taken from it counts the highlight markers -- several
+---characters each and no columns at all on the screen. Both are the same trap the bar's own
+---padding walked into from the other side. What must still read the raw option is the one
+---assertion about the *escape*, which is a claim about the markup itself.
+---@param win integer
+---@return string text, integer width
+function M.winbar(win)
+  local drawn = vim.api.nvim_eval_statusline(vim.wo[win].winbar, { winid = win, use_winbar = true })
+  return drawn.str, drawn.width
+end
+
 M.NS = vim.api.nvim_create_namespace("codereview")
 
 ---@param view CRView

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -162,6 +162,34 @@ function M.winbar(win)
   return drawn.str, drawn.width
 end
 
+---The group of the plugin's own that the first byte of `needle` is drawn in, or nil.
+---
+---**nil means the bar's own group**, which is the brightest thing a winbar has -- and it is
+---reported as an absence rather than by name because that name is `WinBar` in the pane with
+---focus and `WinBarNC` in the other one. A case naming it answers differently depending on
+---where the cursor was, which is a case that reds for a reason that has nothing to do with
+---colour. What is read is the group stacked *on top of* the bar's own, which is exactly the
+---question every caller is asking.
+---
+---Read through the same parser `M.winbar` uses, so a marker that landed one segment out is
+---visible here. What this cannot say is that the cell on the screen took that group's
+---colour. Only a painted cell can, and `split_spec` reads two.
+---@param win integer
+---@param needle string
+---@return string|nil
+function M.winbar_group(win, needle)
+  local opts = { winid = win, use_winbar = true, highlights = true }
+  local drawn = vim.api.nvim_eval_statusline(vim.wo[win].winbar, opts)
+  local at = assert(drawn.str:find(needle, 1, true), ("%q is not on the bar: %s"):format(needle, drawn.str)) - 1
+  local stack = {}
+  for _, run in ipairs(drawn.highlights) do
+    if run.start <= at then
+      stack = run.groups
+    end
+  end
+  return #stack > 1 and stack[#stack] or nil
+end
+
 M.NS = vim.api.nvim_create_namespace("codereview")
 
 ---@param view CRView


### PR DESCRIPTION
Closes #129. Parent PRD: #121.

The **sticky header** was monochrome and verbose: one group across its whole width, and
words where a glyph says the same thing in a third of the columns.

```
before
 ○ ▾ src/oldname.lua → src/newname.lua  +1 -1    Code review · branch vs master · 0/8 reviewed · +8 -4
after
 ○ ▾ src/oldname.lua → src/newname.lua  +1 -1    branch vs master · ✓0/8 · +8 -4 · ●5 · ↺2 · → claude
```

## What changed

**Colour.** Added counts green and removed counts red, the note count in the group notes
carry on the diff, the untouched tally in the group those entries carry, the **target**
accented, the separators dimmed, the icon and chevron quiet. Four groups are new
(`CodeReviewBarIcon`, `CodeReviewBarSep`, `CodeReviewBarTarget`, `CodeReviewBarRev`) and the
rest are the diff's own, so one colour means one thing wherever a reviewer meets it. Every
one is a `default = true` link, so an unfamiliar colorscheme supplies the colours and a
theme change follows — and because they sit in `LINKS`, the **muted** set `hl.groups()`
derives already covers them, which is what keeps the bar receding with its pane now that it
carries groups at all.

The path deliberately carries no group: the bar's own is the brightest thing a winbar has,
and leaving the path in it is what makes it the brightest thing on the left.

**Glyphs.** The three counts take one each from the configured icon table — `✓3/17`, `●5`,
`↺2` — so three numbers side by side cannot be read as one another. `icons.untouched` is the
one new key; the other two are the icons a file already carries. All plain Unicode: no Nerd
Font anywhere.

**The review's own name leaves the bar.** It was already the first thing dropped on a narrow
pane, and a bar inside a review does not need to say it is one.

**Fitting.** Re-tuned, not redesigned: the four steps keep their order and the path's tail
stays what they protect hardest. What moved is the arithmetic, and about thirty columns went
to the path — a 45-column pane keeps `…ame.lua → src/newname.lua` where it used to keep
`…→ src/newname.lua`, and the reviewed tally now survives beside an `untouched` segment
where it used to be shed. The before pane gets the same treatment, and its base revision is
still never cut for the path's sake.

## The one seam that moved

A literal may now carry a highlight group, as chrome already could. Most of what is worth
colouring on this bar is a *name* — the target, the base revision, a count carrying a glyph
a host configured — and the alternative was a caller writing `%#Group#` around a name by
hand, which is markup arriving from outside the seam that exists to decide what markup is.
The escape rule is untouched: escaping is by kind, colouring is not.

## Notes

- `render.bar_width` already measured what is drawn, and it had to: a hundred-column bar is
  now about two hundred and fifty characters. The same trap reached the *tests* — a needle
  spanning two segments is not in the option's string at all, so an `is_nil` written that
  way passes whatever the bar says. `h.winbar` puts the bar through Neovim's own statusline
  parser, and every assertion about what a bar says goes through it. The escape case still
  reads the raw option, because there the markup is the claim.
- `winbar_child.lua` gains a fourth reading, on the file's added count, and takes its offset
  from what the bar draws rather than from the option. Its three constraints are unchanged:
  one `nvim__inspect_cell` per process, an 80x24 grid, colours whose channels are all even.
- No fixture changes.
- `make all`: 1406 passing, 0 failed, exit 0.