### PR TITLE
fix(view): repaint on a resize only when a review window moved

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -467,6 +467,41 @@ case the header exists for.
 **`nvim_win_call` propagates only the first return value.** Returning `line("w0"), line("w$")`
 from it silently loses the end of the range.
 
+**One terminal resize fires `VimResized` *and* `WinResized`, so a callback on both runs
+twice.** Measured by driving a real Neovim over a pty and resizing the pty three times:
+
+```
+3 real terminal resizes -> WinResized=3 VimResized=3
+```
+
+The view's resize autocommand listens to both, so every terminal resize used to cost two
+complete repaints: both panes re-rendered, both buffers rewritten, the whole file tree
+rebuilt, twice. Confirmed in ordinary use as well — 6 and 6, against 14 full paints, which
+is the 12 those callbacks caused plus the 2 from opening the review.
+
+The two arrive in a fixed order and agree about what they see, which is what makes one
+comparison enough. `VimResized` is first, and the windows already report their new
+dimensions when it lands, so `WinResized` reads exactly the same numbers a moment later:
+
+```
+resize to 100x36   VimResized  after 22x33  before 42x33  tree 34x33
+                   WinResized  after 22x33  before 42x33  tree 34x33
+```
+
+That order was the trap worth measuring rather than assuming. Had `VimResized` arrived
+before the windows moved, a record written at the first callback would have been stale, the
+second would have seen a change, and the review would have repainted twice anyway — with a
+guard that reads as correct and halves nothing. It does not, so the record is written by the
+**paint**, which is also what keeps every other repainting path in step: the layout toggle
+and the file tree's arrival both change a pane's width and repaint for themselves, and the
+event the main loop lands afterwards then finds nothing to do.
+
+**That autocommand has no pattern and no buffer, so a window resized anywhere runs it.**
+Including in another tab page, where the review is not even on screen. Measured over the
+same pty: `:tabnew` followed by `:split` fired `WinResized` twice with every review window
+the size it already was — two full repaints of a review nobody was looking at. The same
+comparison answers it, because none of the review's windows moved.
+
 **`winhighlight` with `NormalNC` cannot mute a pane.** It is the obvious way to make an
 unfocused window recede and it is the wrong one here: it changes only a window's *default*
 foreground and background, and in the panes almost nothing uses those. A changed row carries

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -65,6 +65,7 @@ local NS = vim.api.nvim_create_namespace("codereview")
 ---@field syntax_cache table<string, CRCapture[]|false>  `path|side` -> captures; false to skip it
 ---@field syntax_painted table<string, boolean>|nil      Path -> already replayed onto this render
 ---@field syntax_rows table<integer, CRFileRows>|nil     File index -> where its lines are drawn
+---@field dims string|nil                 The size of every review window the last paint was made at
 
 ---@type CRView|nil
 local V = nil
@@ -652,6 +653,29 @@ local function refade(entered)
   end
 end
 
+---The size of every review window, as one value two moments can be compared by.
+---
+---The two **panes** and the **file tree**, each as its width and its height, which is
+---exactly what a paint is a function of: header padding and the winbar are cut to a pane's
+---width, and how far past the window marks are emitted comes from its height. A window that
+---is not there contributes a placeholder rather than nothing, so a layout toggle and a tree
+---that arrives or leaves are changes like any other.
+---
+---A string rather than a table, because the only question ever asked of it is whether it is
+---the one recorded before.
+---@return string
+local function dimensions()
+  local out = {}
+  for _, win in ipairs({ V.win, V.before_win or -1, V.panel_win or -1 }) do
+    if vim.api.nvim_win_is_valid(win) then
+      out[#out + 1] = ("%dx%d"):format(vim.api.nvim_win_get_width(win), vim.api.nvim_win_get_height(win))
+    else
+      out[#out + 1] = "-"
+    end
+  end
+  return table.concat(out, " ")
+end
+
 ---Redraw from the files already in memory. Cheap; no git.
 ---@param keep_file integer|nil File index to park the cursor on afterwards
 function M.paint(keep_file)
@@ -659,6 +683,12 @@ function M.paint(keep_file)
     return
   end
   local cfg = config.get()
+  -- What this paint is drawn for, recorded by the paint itself rather than by the resize
+  -- callback that is the one thing reading it. Every path that changes a review window
+  -- repaints for itself -- the layout toggle, the tree arriving or leaving, a pane rebuilt --
+  -- so recording it here is what leaves the resize event those paths' main loop lands
+  -- afterwards with nothing to do.
+  V.dims = dimensions()
   -- The queue is the source of truth for annotations; the view only ever displays a
   -- projection of it, so there is no second copy to keep in sync.
   V.notes = require("codereview.queue").by_key()
@@ -1741,11 +1771,19 @@ function M.open(spec)
   -- also what gives it back to a pane the layout toggle rebuilt.
   view_layout.attach_pane(V, M, V.buf)
 
-  -- Header padding is width-dependent, so a resize needs a full repaint.
+  -- Header padding is width-dependent, so a resize needs a full repaint -- but only a resize
+  -- that moved a review window.
+  --
+  -- One terminal resize fires `VimResized` *and* `WinResized`, so this callback runs twice
+  -- for one resize, and each run repainted both panes and rebuilt the whole file tree. It
+  -- carries no pattern and no buffer either, so a window resized in another tab page ran it
+  -- as well. Both are answered by the same comparison: the paint records the dimensions it
+  -- drew at, and a callback that finds them unchanged returns. `docs/design-notes.md` holds
+  -- the measurements, and `repaint_spec` owns the rule.
   vim.api.nvim_create_autocmd({ "VimResized", "WinResized" }, {
     group = V.augroup,
     callback = function()
-      if M.current() then
+      if M.current() and dimensions() ~= V.dims then
         M.paint()
       end
     end,

--- a/tests/README.md
+++ b/tests/README.md
@@ -393,6 +393,16 @@ so the out-of-core language path is still checked locally without ever failing C
   of its terminal-resize case changed `columns` in the `describe` body and then counted the
   paints of two events that had nothing left to do, which reported *zero* repaints and read
   as the guard working perfectly.
+- **The file tree cannot change size on its own, so its place in the resize record has no
+  spec.** The record the guard compares holds all three review windows, because
+  `paint_panel` builds the tree from its own window's width — but the tree can never be the
+  only one that moved. Narrowing it hands the columns to a **pane** (measured: the tree at 34
+  → 20 put the before pane at 37 → 51), and its height is the panes' height, since the three
+  share a row. So the record differs on a pane whether or not the tree is in it, and taking
+  the tree out of `dimensions()` reds nothing in the suite. That is a fact about where the
+  windows are and not a case waiting to be written; the same shape as "no fixture is both
+  tall and multilingual" above. Anyone who gives the tree a window arrangement of its own
+  should take this bullet out and assert it.
 - **A repaint test needs a seam a counter cannot fake, and change ticks are it.**
   `repaint_spec` reads `nvim_buf_get_changedtick` on the two panes and the file tree, because
   a paint rewrites each of those buffers exactly once. A counter on the view would measure the
@@ -401,6 +411,13 @@ so the out-of-core language path is still checked locally without ever failing C
   really does move all three ticks, and by exactly one: without them the whole file is a row
   of assertions that nothing moved, which is also what a seam that stopped measuring looks
   like. Same trap as "a filter test needs a fixture only that filter can reject".
+- **A resize record holding widths alone passes everything a diff is padded by.** Header
+  padding and the winbar's fitting are the visible half of a pane's size and both are width,
+  so a guard comparing widths only reads as complete. Emission is bounded by the *viewport*,
+  which is a height: a window that grew taller shows rows whose marks were never written, and
+  nothing repaints them until the reviewer scrolls. Dropping the height from `view.lua`'s
+  `dimensions()` must red `repaint_spec`'s `a window that changed only its height` and nothing
+  else in the suite — it left the whole suite green before that block was written.
 - **Moving the cursor from a script does not fire `CursorMoved`.** Neither
   `nvim_win_set_cursor` nor a `normal! j` inside `nvim_win_call` raises it under `nvim -l` —
   measured rather than assumed, the same way `scrollbind` was. So anything claiming to cost

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ make perf                                             # timing report at two siz
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 1,245 cases in ~5 seconds.
+The whole suite is about 1,430 cases in ~5 seconds.
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -49,6 +49,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
 | `bounded_spec` | Emission bounded by the viewport: what a paint writes and what it leaves out, the bound it shares with the harvest, what a scroll adds and what scrolling back does not, both panes at once — on a diff taller than the window, guarded |
+| `repaint_spec` | When a paint runs on a resize and when it must not: either event with nothing resized, in both layouts; a pane that really changed width; one terminal resize, which fires both events, repainting once; an event that arrives before anything moved; a window resized in another tab page; and the file tree summoned and dismissed |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit, and the **preamble**: above the header, the empty one that renders nothing, and the same arguments rendering the same message |
 | `state_spec` | Persistence across a real restart, blob invalidation, corrupt files, scopes a view never opened |
@@ -383,6 +384,23 @@ so the out-of-core language path is still checked locally without ever failing C
   whatever changed the width has returned — and in a headless spec, which never pumps the
   loop, it does not land at all. Anything that changes a window's width has to repaint for
   itself; the resize autocmd is for the reviewer dragging a border, nothing else.
+- **`VimResized` is not the same, and the difference decides what a resize test can drive.**
+  Setting `columns` or `lines` from a script fires it *synchronously*, so a spec that changes
+  either one with a review open has already run the resize callback by the time its next line
+  runs. `nvim_win_set_width` fires neither event. `repaint_spec` uses both facts: it changes a
+  pane's width outright where it wants to fire an event by hand, and it changes `columns`
+  where it wants the real trigger — measured rather than assumed, because the first version
+  of its terminal-resize case changed `columns` in the `describe` body and then counted the
+  paints of two events that had nothing left to do, which reported *zero* repaints and read
+  as the guard working perfectly.
+- **A repaint test needs a seam a counter cannot fake, and change ticks are it.**
+  `repaint_spec` reads `nvim_buf_get_changedtick` on the two panes and the file tree, because
+  a paint rewrites each of those buffers exactly once. A counter on the view would measure the
+  line it was written beside rather than the work, and would still read as correct if the
+  paint stopped writing anything. Its first block spends three cases pinning that a paint
+  really does move all three ticks, and by exactly one: without them the whole file is a row
+  of assertions that nothing moved, which is also what a seam that stopped measuring looks
+  like. Same trap as "a filter test needs a fixture only that filter can reject".
 - **Moving the cursor from a script does not fire `CursorMoved`.** Neither
   `nvim_win_set_cursor` nor a `normal! j` inside `nvim_win_call` raises it under `nvim -l` —
   measured rather than assumed, the same way `scrollbind` was. So anything claiming to cost

--- a/tests/codereview/repaint_spec.lua
+++ b/tests/codereview/repaint_spec.lua
@@ -193,6 +193,33 @@ describe("a pane that really changed width", function()
   end)
 end)
 
+-- Only a pane's *width* is drawn into the diff -- the header padding, the winbar's fitting --
+-- so a record holding widths alone reads as complete. Emission is bounded by the viewport,
+-- and a viewport is a height: a window that grew taller is showing rows whose marks were
+-- never written, and nothing repaints until the reviewer scrolls. This is the ordinary case
+-- and not an exotic one -- measured over a pty, a `:split` beside the review took the after
+-- pane from 42x37 to 42x18 and gave it back, with the width the same at every step. Dropping
+-- the height from the record reds these two cases and nothing else in the suite.
+describe("a window that changed only its height", function()
+  local before_lines = vim.o.lines
+  local before = dims()
+  local seen = paints(function()
+    vim.o.lines = before_lines + 8
+  end)
+  local after = dims()
+
+  it("really changed a height and left every width alone", function()
+    assert.is_true(after.win[2] ~= before.win[2], "no review window changed height")
+    for name, wh in pairs(after) do
+      assert.same(before[name][1], wh[1], name .. " changed width as well")
+    end
+  end)
+
+  it("repaints once", function()
+    assert.same(1, seen)
+  end)
+end)
+
 -- The halving. One terminal resize fires both events -- `VimResized` first, and with the
 -- windows already reporting their new dimensions at it, both measured over a pty. So the
 -- first callback repaints and records, and the second finds nothing left to do.
@@ -222,12 +249,14 @@ describe("one terminal resize, which fires both events", function()
   end)
 end)
 
--- The trap the issue asks to be checked rather than assumed. The pty says the windows are
--- already resized when the first event arrives -- but a guard that wrote the record in the
--- callback rather than in the paint would still fail here: the first callback would record
--- dimensions nothing had moved yet, and the change that followed would then find them
--- already recorded and repaint nothing at all. The record is written by the paint, so an
--- event that finds nothing changed leaves it where it was.
+-- The trap the issue asks to be checked rather than assumed, from the side a spec can reach.
+-- The pty says the windows are already resized when the first event arrives, so the order
+-- below does not happen on a real resize -- what it pins is that the guard is a *comparison*
+-- and never a latch. Coalescing the pair with a flag, or a scheduled repaint, is the obvious
+-- alternative and it reads as equivalent: it halves the count just as well. Here it would
+-- swallow the event that carries the real change, and the review would be left drawn for a
+-- terminal that is no longer that size. An event that finds nothing changed must cost
+-- nothing and consume nothing.
 describe("a resize event that arrives before anything moved", function()
   local before_cols = vim.o.columns
   local seen = paints(function()

--- a/tests/codereview/repaint_spec.lua
+++ b/tests/codereview/repaint_spec.lua
@@ -1,0 +1,307 @@
+-- When a paint runs on a resize, and when it must not.
+--
+-- One question, in a file of its own, because the answer is a rule that crosses everything:
+-- the panes, the file tree, both layouts and every path that changes a window. `bounded_spec`
+-- is the prior art -- one crosscutting rule, asserted through a seam that no implementation
+-- detail can move.
+--
+-- The seam is `nvim_buf_get_changedtick` on the two panes and the file tree. A paint rewrites
+-- each of those buffers exactly once, so a tick that has not moved is a paint that did not
+-- run. Nothing here counts calls, wraps `paint` or reaches into the view: a counter would
+-- measure the thing it was written beside, and this has to measure the work.
+--
+-- **Why the rule exists.** The view's resize autocommand listens to `VimResized` *and*
+-- `WinResized`, and one terminal resize fires both -- measured over a pty, three resizes
+-- giving `WinResized=3 VimResized=3`, and written up in `docs/design-notes.md`. So the
+-- callback ran twice for one resize and repainted twice. It also has no pattern and no
+-- buffer, so a window resized in another tab page ran it too.
+--
+-- **What this file can and cannot say.** `WinResized` is fired from the main loop, which a
+-- headless Neovim never pumps, so it never lands here and every case that wants one fires it
+-- itself. `VimResized` is not: a scripted change of `columns` or `lines` fires it
+-- synchronously, so half of a terminal resize is driven through the real trigger. Neither is
+-- enough for the double-fire claim itself, which is a fact about a real terminal and is
+-- measured over a pty instead. What is asserted here is its consequence: the second of the
+-- two callbacks finds the dimensions already recorded and does nothing.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+h.cd_fixture("mkfixture")
+
+require("codereview").setup({ syntax = false })
+
+local view = require("codereview.view")
+
+view.open("branch")
+local V = view.current()
+
+---@param buf integer|nil
+---@return integer|nil
+local function tick(buf)
+  if buf and vim.api.nvim_buf_is_valid(buf) then
+    return vim.api.nvim_buf_get_changedtick(buf)
+  end
+  return nil
+end
+
+---How many full paints ran while `fn` ran.
+---
+---Counted on the after pane's change tick, which one paint moves by exactly one: `write_pane`
+---rewrites the whole buffer in a single call. The first case below pins that the before pane
+---and the file tree move with it, so what this counts is a repaint of the whole review rather
+---than of one buffer of it.
+---@param fn fun()
+---@return integer
+local function paints(fn)
+  local before = assert(tick(V.buf))
+  fn()
+  return assert(tick(V.buf)) - before
+end
+
+---@param event "VimResized"|"WinResized"
+local function fire(event)
+  vim.api.nvim_exec_autocmds(event, {})
+end
+
+---The widths and heights of every review window there is.
+---@return table
+local function dims()
+  local out = {}
+  for _, name in ipairs({ "win", "before_win", "panel_win" }) do
+    local win = V[name]
+    if win and vim.api.nvim_win_is_valid(win) then
+      out[name] = { vim.api.nvim_win_get_width(win), vim.api.nvim_win_get_height(win) }
+    end
+  end
+  return out
+end
+
+-- Everything below reads a change tick as "a paint ran". Without this the file is a row of
+-- assertions that nothing moved, and nothing moving is what a broken seam looks like too.
+describe("the seam this spec is read through", function()
+  local before, after
+
+  before = { after = tick(V.buf), panel = tick(V.panel_buf) }
+  view.paint()
+  after = { after = tick(V.buf), panel = tick(V.panel_buf) }
+
+  it("has a file tree to read", function()
+    assert.is_truthy(V.panel_buf, "the review opened without a file tree")
+  end)
+
+  it("moves the after pane's change tick by exactly one", function()
+    assert.same(before.after + 1, after.after)
+  end)
+
+  it("moves the file tree's with it", function()
+    assert.same(before.panel + 1, after.panel)
+  end)
+end)
+
+describe("a resize event in the unified layout with nothing resized", function()
+  it("opened unified", function()
+    assert.same("unified", V.layout)
+  end)
+
+  it("repaints nothing on VimResized", function()
+    assert.same(
+      0,
+      paints(function()
+        fire("VimResized")
+      end)
+    )
+  end)
+
+  it("repaints nothing on WinResized", function()
+    assert.same(
+      0,
+      paints(function()
+        fire("WinResized")
+      end)
+    )
+  end)
+end)
+
+describe("a resize event in the split layout with nothing resized", function()
+  view.toggle_layout()
+
+  it("really is in the split layout", function()
+    assert.same("split", V.layout)
+    assert.is_truthy(V.before_buf, "the split layout has no before pane")
+  end)
+
+  -- The before pane exists only here, so this is where the seam's third buffer is pinned.
+  it("has a before pane a paint rewrites too", function()
+    local was = assert(tick(V.before_buf))
+    view.paint()
+    assert.same(was + 1, tick(V.before_buf))
+  end)
+
+  it("repaints nothing on VimResized", function()
+    assert.same(
+      0,
+      paints(function()
+        fire("VimResized")
+      end)
+    )
+  end)
+
+  it("repaints nothing on WinResized", function()
+    assert.same(
+      0,
+      paints(function()
+        fire("WinResized")
+      end)
+    )
+  end)
+end)
+
+describe("a pane that really changed width", function()
+  local was = vim.api.nvim_win_get_width(V.win)
+  local wide = was + 12
+  vim.api.nvim_win_set_width(V.win, wide)
+
+  it("really resized the pane", function()
+    assert.same(wide, vim.api.nvim_win_get_width(V.win))
+    assert.is_true(wide ~= was)
+  end)
+
+  it("repaints once", function()
+    assert.same(
+      1,
+      paints(function()
+        fire("WinResized")
+      end)
+    )
+  end)
+
+  -- A file header is padded to its pane, so this is what a repaint the guard skipped would
+  -- have cost the reviewer.
+  it("pads the file headers to the new width", function()
+    local row = assert(V.render.file_rows[1])
+    local line = vim.api.nvim_buf_get_lines(V.buf, row - 1, row, false)[1]
+    assert.same(wide, vim.fn.strdisplaywidth(line))
+  end)
+
+  it("repaints nothing when the event fires again", function()
+    assert.same(
+      0,
+      paints(function()
+        fire("WinResized")
+      end)
+    )
+  end)
+end)
+
+-- The halving. One terminal resize fires both events -- `VimResized` first, and with the
+-- windows already reporting their new dimensions at it, both measured over a pty. So the
+-- first callback repaints and records, and the second finds nothing left to do.
+--
+-- Half of this is driven through the real trigger: a scripted change of `columns` fires
+-- `VimResized` for itself, synchronously. `WinResized` is fired from the main loop and never
+-- lands in a headless spec, so the spec lands it, in the order the pty measured.
+describe("one terminal resize, which fires both events", function()
+  local before_cols = vim.o.columns
+  local before_dims = dims()
+  local seen = paints(function()
+    vim.o.columns = before_cols + 20
+    fire("WinResized")
+  end)
+  local after_dims = dims()
+
+  it("really widened a review window", function()
+    assert.is_true(vim.o.columns ~= before_cols)
+    assert.is_true(
+      not vim.deep_equal(before_dims, after_dims),
+      "no review window changed size, so this case measures nothing"
+    )
+  end)
+
+  it("repaints exactly once for the two events", function()
+    assert.same(1, seen)
+  end)
+end)
+
+-- The trap the issue asks to be checked rather than assumed. The pty says the windows are
+-- already resized when the first event arrives -- but a guard that wrote the record in the
+-- callback rather than in the paint would still fail here: the first callback would record
+-- dimensions nothing had moved yet, and the change that followed would then find them
+-- already recorded and repaint nothing at all. The record is written by the paint, so an
+-- event that finds nothing changed leaves it where it was.
+describe("a resize event that arrives before anything moved", function()
+  local before_cols = vim.o.columns
+  local seen = paints(function()
+    fire("WinResized")
+    vim.o.columns = before_cols - 20
+  end)
+
+  it("really narrowed a review window", function()
+    assert.is_true(vim.o.columns ~= before_cols)
+  end)
+
+  it("still repaints exactly once", function()
+    assert.same(1, seen)
+  end)
+end)
+
+-- The autocommand has no pattern and no buffer, so it runs for a window the review has
+-- nothing to do with. Measured over a pty: a `:split` in another tab page fired `WinResized`
+-- twice with every review window the size it already was -- two full repaints of a review
+-- the reviewer was not even looking at.
+describe("a window resized in another tab page", function()
+  local before_dims = dims()
+  vim.cmd("tabnew")
+  vim.cmd("split")
+  local after_dims = dims()
+
+  it("left every review window the size it was", function()
+    assert.same(before_dims, after_dims)
+  end)
+
+  it("repaints nothing", function()
+    assert.same(
+      0,
+      paints(function()
+        fire("WinResized")
+      end)
+    )
+  end)
+
+  vim.cmd("tabclose")
+end)
+
+-- The tree takes its columns from the panes and gives them back, so both directions are a
+-- real change of width. `toggle_panel` repaints for itself -- `WinResized` is fired from the
+-- main loop and lands after it has returned -- and the guard must not be what stops it.
+describe("the file tree summoned and dismissed", function()
+  it("repaints when the tree is dismissed", function()
+    assert.same(
+      1,
+      paints(function()
+        view.toggle_panel()
+      end)
+    )
+    assert.is_true(V.panel_win == nil or not vim.api.nvim_win_is_valid(V.panel_win))
+  end)
+
+  it("repaints when the tree comes back", function()
+    assert.same(
+      1,
+      paints(function()
+        view.toggle_panel()
+      end)
+    )
+    assert.is_truthy(V.panel_win)
+  end)
+
+  -- The panes changed width twice and the repaints that followed recorded it, so the event
+  -- the main loop lands afterwards has nothing left to do.
+  it("repaints nothing when the event lands after it", function()
+    assert.same(
+      0,
+      paints(function()
+        fire("WinResized")
+      end)
+    )
+  end)
+end)


### PR DESCRIPTION
Closes #123. Parent: #119.

## What was wrong

One terminal resize fires `VimResized` **and** `WinResized`. The view's resize
autocommand listens to both, with no pattern and no buffer, so a reviewer who
resized their terminal once paid for two complete repaints: both panes
re-rendered, both buffers rewritten, the whole file tree rebuilt, twice. The
missing pattern costs a third case — a window resized in another tab page, where
the review is not even on screen, repainted it too.

## What was measured

The issue asks for the event order to be measured and not assumed, because a
guard placed against the wrong one halves nothing while reading as correct. It
was measured first, by driving a real Neovim over a pty and resizing the pty.

`VimResized` arrives first, and the windows already report their new dimensions
when it lands, so `WinResized` reads the same numbers a moment later:

```
resize to 100x36   VimResized  after 22x33  before 42x33  tree 34x33
                   WinResized  after 22x33  before 42x33  tree 34x33
```

So the trap does not bite, and the record can be written where the first
callback paints. Had it been the other way round, the first callback would have
recorded stale dimensions and the second would have repainted anyway.

Same harness, after the change — three terminal resizes, still six events:

| | events | full paints |
| --- | --- | --- |
| 3 terminal resizes | 3 `VimResized` + 3 `WinResized` | 6 → **3** |
| `:split` in another tab page | 2 `WinResized` | 2 → **0** |
| `:split` in the review's own tab page | 1 `WinResized` | 1 → 1 |
| a float over the review | none | 0 → 0 |

The third row is the guard working rather than failing: that split takes the
after pane from 42x37 to 42x18, so a repaint is owed. Only a split that leaves
every review window the size it was is free.

## The change

`paint` records the width and height of every review window it drew at, and the
callback returns when it finds them unchanged. The record is written by the
**paint** and never by the callback, which is what keeps the other repainting
paths in step: the layout toggle and the file tree's arrival both change a pane's
width and repaint for themselves, so the event the main loop lands afterwards has
nothing left to do.

## The spec

`repaint_spec` owns one question — when a paint runs and when it must not. The
seam is `nvim_buf_get_changedtick` on the file tree's buffer and both panes':
a paint rewrites each exactly once, so no counter, no wrapper and no reach into
internals. Its first block pins that a paint really does move all three ticks,
by exactly one, or the rest of the file is a row of assertions that nothing
moved — which is also what a broken seam looks like.

Every case was red before the change: 9 of them, each reporting one paint where
none was owed, or two where one was.

## Mutation checks

Applied one at a time, reverting between.

| Mutation | Result |
| --- | --- |
| Guard removed | 9 cases red |
| Record written in the callback instead of the paint | 3 red |
| Compare `columns`/`lines` instead of the windows' sizes | 2 red — the pane that really changed width |
| Height dropped from the record | **green** — see below |
| File tree dropped from the record | **green** — see below |

Dropping the height left the whole suite green. Only a pane's width is drawn
into the diff, so a widths-only record reads as complete, while emission is
bounded by the viewport and a viewport is a height. A block was added for it,
and that mutation now reds exactly one case.

The file tree's place in the record stays unpinned and cannot be pinned here:
narrowing the tree hands its columns to a pane (34 → 20 put the before pane at
37 → 51), and its height is the panes' height. So the record differs on a pane
whether or not the tree is in it. That is a fact about where the windows are, not
a case waiting to be written, and it is in `tests/README.md` beside the fixture
gaps it belongs with.

## Documentation

The double-fire and the event order are in `docs/design-notes.md`, with the
numbers. `tests/README.md` gains the spec's row and three traps this work turned
up — including that `VimResized`, unlike `WinResized`, **is** fired
synchronously by a scripted change of `columns` or `lines`, which is what lets
half of a terminal resize be driven through the real trigger.

## Not in scope

The file tree flickering while scrolling inside a single long file. It is
unreproduced across two measured sessions, the cause is unknown, and nothing here
claims to fix it or asserts that it is fixed.

`make all` passes: exit 0, 0 failures, 0 errors, 1431 cases.