### PR TITLE
docs: rename the workflow chain to /to-spec and /to-tickets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,14 @@ Operating instructions for agents working in `codereview-annotator.nvim`.
 Anything with a feature or design decision behind it runs through the skill chain below,
 in order. Do not skip to code.
 
-1. **`/to-prd`** — synthesises the conversation into a PRD and publishes it to the issue
+1. **`/to-spec`** — synthesises the conversation into a spec and publishes it to the issue
    tracker (a GitHub issue here) labelled `ready-for-agent`. It does not interview; it
-   works from what has already been discussed, so do that discussion first.
-2. **`/to-issues`** — breaks the PRD into independently-grabbable issues, one per vertical
-   slice.
+   works from what has already been discussed, so do that discussion first. It stops once
+   on the way to put its test seams to you.
+2. **`/to-tickets`** — breaks the spec into **tickets**: tracer-bullet vertical slices, each
+   declaring the tickets that **block** it. A ticket with no blockers can start at once;
+   the rest wait on theirs. It puts the breakdown to you before it publishes, and publishes
+   blockers first, so every edge names an issue that already exists.
 3. **Branch off the issue id**: `<type>/<issue>-<slug>`, e.g.
    `feat/12-single-annotation-queue`. `<type>` is the Conventional Commits type the work
    will land under, so the branch, the commits and the PR title all agree.
@@ -21,11 +24,12 @@ in order. Do not skip to code.
 5. **Open the PR** with `gh pr create`. The title is a Conventional Commits subject; the
    body closes the issue (`Closes #12`).
 
-Both PRD skills are `disable-model-invocation: true` — **the user invokes them.** Ask for
-`/to-prd` rather than trying to run it, and never hand-roll a PRD to work around that.
+Both skills are `disable-model-invocation: true` — **the user invokes them.** Ask for
+`/to-spec` rather than trying to run it, and never hand-roll a spec or a ticket to work
+around that.
 
 Straight-to-`master` is only for what has no issue behind it: docs corrections,
-formatting, CI plumbing. Anything a PRD was written for gets a branch and a PR.
+formatting, CI plumbing. Anything a spec was written for gets a branch and a PR.
 
 `CONTRIBUTING.md` is the same workflow written for outside contributors. Change both when
 one moves, or they drift.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues in `felipeva/codereview-annotator.nvim`. Use the `gh` CLI for all operations.
+Issues, specs and tickets for this repo all live as GitHub issues in `felipeva/codereview-annotator.nvim`. Use the `gh` CLI for all operations.
 
 ## Conventions
 


### PR DESCRIPTION
## Why

The skill chain `CLAUDE.md` documented no longer exists. `/to-prd` and `/to-issues` were
renamed to `/to-spec` and `/to-tickets`, so an agent reading the workflow was being sent to
two commands that are gone.

The rename is not the whole change. `/to-issues` produced issues that were all grabbable at
once; `/to-tickets` produces tickets that each declare the tickets **blocking** them, so only
the ones with no blockers can start. Recording the new names without that distinction would
leave the next agent expecting a flat list it will not get.

## Notes for the reviewer

Two things were deliberately left alone.

`docs/agents/HANDOFF.md` still says "Accepted in the PRD". That records a PRD that really
existed when the decision was taken, and rewriting it to say "spec" would falsify the record
— the same reason the three `tests:` commits that predate the `commit-msg` hook are left as
they are.

`CONTRIBUTING.md` needed no change. `CLAUDE.md` warns that the two drift when one moves, but
`CONTRIBUTING.md` never named the skills — it says "open an issue first", which is still
true.

`docs/agents/issue-tracker.md` gained "specs and tickets" beside "issues", since all three
are GitHub issues here. Its existing line about fetching "the relevant ticket" needed no edit
and reads better under the new vocabulary than the old one.

## Checklist

- [x] `make all` passes (lint + suite).
- [x] New behaviour has a spec under `tests/codereview/`. — n/a, no behaviour changed
- [x] `README.md` and `doc/codereview.txt` updated, if user-facing behaviour changed. — n/a, agent-facing docs only
- [x] Commits follow Conventional Commits (`make hooks` validates them).