### PR TITLE
feat(view): list the branch's commits behind gc

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ worth a look before we ship this
 | `gp` | Show or hide the file tree |
 | `gl` | Switch between the unified and split layouts |
 | `gb` | Read the last dispatched batch back |
+| `gc` | List the commits on the branch |
 | `gA` | Show or hide archived entries, for the rest of the session |
 | `<CR>` | Open the real file here, in a new tab |
 | `gd` | Read this file in your own diff tool — only bound with [`open_diff`](#adapters) wired |
@@ -662,6 +663,7 @@ is to stop looking at them, so the useful motion is "the next thing I have not d
 | `gp` | Dismiss the tree, landing back in the diff |
 | `gl` | Switch between the unified and split layouts |
 | `gb` | Read the last dispatched batch back |
+| `gc` | List the commits on the branch |
 | `gA` | Show or hide archived entries, for the rest of the session |
 | `q` | Close |
 
@@ -705,6 +707,25 @@ about a place in the code. What is missing is every key that would change someth
 Those two are bound rather than left off so that the queue float's muscle memory gets a
 sentence instead of `E21`. Nothing else is: the batch has gone, and there is nothing left
 to route, drop or send.
+
+### In the commit list
+
+`gc`, in the diff or in the tree, lists the commits on the branch — newest first, one row
+each, with the short sha, the subject and how long ago it was written. Not the author: it is
+your own branch. Not the added and deleted counts: they cost a second pass over the whole
+branch, and the subject is what you recognise.
+
+The listing is `--first-parent` from the merge base, so a merge is one row and the commits
+that arrived through it are not listed beside your own. There is **no limit on the rows**: a
+long branch keeps its oldest commits on screen, at the bottom of the list.
+
+| Key | Action |
+| --- | --- |
+| `q` / `<Esc>` | Close |
+
+Two cases open nothing and say why in one sentence: `gc` outside a branch review, where
+there is no branch behind the diff to list, and `gc` on a branch whose `HEAD` is the merge
+base, which has no commits of its own.
 
 ## Configuration
 

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -33,6 +33,7 @@ change there is felt through.
 | `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named, and how a winbar is assembled from typed segments | pure |
 | `state.lua` | Persisted review progress, and the blob comparisons over it — staleness, and touchedness kept in a function of its own | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
+| `trim_float.lua` | The float over the branch's commits: the first-parent listing from the merge base, one row per commit, and the two refusals that open nothing | stateful (float) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
 | `view.lua` | The review view: the `CRView` it owns, the paint, navigation, delivery, opening and closing | stateful (windows) |
 | `view_layout.lua` | Where the review's windows are: the panes, the before pane, the toggle between the unified and split layouts, which of them is muted, and which group each lights its row in | stateful (windows) |
@@ -43,7 +44,7 @@ change there is felt through.
 - **Require nothing**: `diff`, `drafts`, `panel`, `queue`, `types`.
 - **Above them**, in that order: `git`, `payload`, `render`; then `state`, `config`; then
   `archive`, `delivery`, `keymaps`, `syntax`; then `composer`, `hl`, `fade`, `queue_float`,
-  `view_layout`; then `view_panel`.
+  `trim_float`, `view_layout`; then `view_panel`.
 - **The hubs**: `view` requires thirteen of the modules above, `annotate` nine. A change that
   is not local to a leaf almost certainly reaches one of them.
 - **On top**: `capture`, then `init`.
@@ -76,6 +77,9 @@ rather than requiring `view` for them. That is deliberate, and it is what leaves
 function of its arguments and the configured annotation types. `queue_float` reads no view
 state either: the one field it needs, the window a float is open in, stays on `view` behind
 two accessors, because closing a float on submit is a rule about the view's windows.
+`trim_float` is not even a candidate: it runs no view action yet, so what it takes is the
+repository whose commits it lists, and the view keeps the one refusal only the view can make
+— the **scope** on screen.
 `view_layout` and `view_panel` do read view state, but never their own copy of it: the
 `CRView` table is handed in beside the view and mutated in place, exactly as `syntax` and
 `state` are handed it, so there is still one table and `view` still owns it. The one edge

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -457,4 +457,60 @@ function M.collect(scope, root, opts)
   return files, nil
 end
 
+--- The branch's commits ---------------------------------------------------------
+
+---@class CRCommit
+---@field sha string      Short sha, abbreviated by git to whatever this repository needs
+---@field when string     How long ago it was authored, in git's own words
+---@field subject string  The commit's first line
+
+---Every commit the branch carries, newest first.
+---
+---`--first-parent` from the merge base to `HEAD`. A merge is then one commit and reads as
+---the one change it was, and the work that arrived through it is not listed beside the work
+---the branch did itself.
+---
+---**There is no limit.** A limit would put the oldest commits on a long branch out of reach,
+---which is the one thing a list a reviewer picks from must never do.
+---
+---The merge base is resolved here rather than taken from a scope. What a reviewer is being
+---shown is the branch, and a scope's pre-image is free to be something narrower than the
+---branch -- so reading it would quietly shorten the list the moment it was.
+---@param root string
+---@return CRCommit[]|nil commits, string|nil err
+function M.branch_commits(root)
+  local branch = M.default_branch(root)
+  if not branch then
+    return nil, "could not determine the default branch"
+  end
+  local base = M.merge_base(branch, "HEAD", root)
+  if not base then
+    return nil, ("no merge base with %s"):format(branch)
+  end
+
+  -- The fields are separated by a unit separator, and the subject comes last. A subject is
+  -- one line and can hold anything else at all, including whatever a friendlier separator
+  -- would be built out of -- so the one field that could contain the delimiter is the one
+  -- field nothing is parsed after.
+  local out, err = run({
+    "log",
+    "--first-parent",
+    "--format=%h%x1f%ar%x1f%s",
+    base .. "..HEAD",
+    -- A long branch's log is closer to a diff than to a metadata query.
+  }, { cwd = root, timeout = DIFF_TIMEOUT_MS })
+  if not out then
+    return nil, err
+  end
+
+  local commits = {}
+  for _, entry in ipairs(vim.split(out, "\n", { trimempty = true })) do
+    local sha, when, subject = entry:match("^(%S+)\31(.-)\31(.*)$")
+    if sha then
+      commits[#commits + 1] = { sha = sha, when = when, subject = subject }
+    end
+  end
+  return commits, nil
+end
+
 return M

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -117,6 +117,10 @@ function M.diff(buf, view)
     -- `gb` for the **batch**, from the same `g` family. It opens the surface the command
     -- opens, so a reviewer reads one fact off one surface however they asked for it.
     ["gb"] = { view.last_batch, "Read the last batch back" },
+    -- `gc` for the **commits**, from the same `g` family. It takes the comment operator,
+    -- which is dead in a nomodifiable buffer for the reason `a` became the annotation
+    -- prefix: nothing here can be commented out, so the key costs a keystroke and no motion.
+    ["gc"] = { view.commit_list, "List the commits on the branch" },
     -- `gA` for **archived** entries, and uppercase because `ga` is `:ascii`. It overrides
     -- the configured switch for the session rather than editing it.
     ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
@@ -209,6 +213,7 @@ function M.panel(buf, view)
     ["gp"] = { view.toggle_panel, "Hide the file tree" },
     ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
     ["gb"] = { view.last_batch, "Read the last batch back" },
+    ["gc"] = { view.commit_list, "List the commits on the branch" },
     ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
     ["R"] = { view.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { view.close, "Close the review" },

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -139,9 +139,9 @@ function M.open(root)
     pcall(vim.api.nvim_buf_set_extmark, buf, NS_TRIM, m.row, m.col, m.opts)
   end
 
-  -- Newest first, and the cursor on the newest: the row a reviewer wants is nearly always
-  -- one of the recent ones, so reading this list costs no movement.
-  pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
+  -- The cursor opens on the newest commit, which is where a fresh window puts it and where
+  -- the row a reviewer wants nearly always is -- so reading this list costs no movement.
+  -- Nothing places it here, because there is nothing yet that would want it elsewhere.
 
   local function close()
     if vim.api.nvim_win_is_valid(win) then

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -28,8 +28,8 @@ end
 ---disturb the diff's, the tree's or the queue float's.
 local NS_TRIM = vim.api.nvim_create_namespace("codereview_trim")
 
----One column to the left of every row, reserved so that marking the row a trim starts at
----costs no realignment of everything beside it. Nothing draws in it yet.
+---One column to the left of every row, reserved so a later change can mark a row there
+---without moving anything beside it. Nothing draws in it yet.
 local GUTTER = " "
 
 ---Two spaces between the sha and the subject, and at least two between the subject and the
@@ -94,6 +94,10 @@ end
 ---base has done no work of its own, which is an ordinary state and not a failure, and a
 ---float holding nothing a reviewer can act on would leave them wondering which of the two
 ---had gone wrong.
+---
+---The cursor opens on the newest commit, which is where a fresh window puts it and where the
+---row a reviewer wants nearly always is, so reading this list costs no movement. Nothing
+---places it there, because nothing yet would want it anywhere else.
 ---@param root string The repository the branch belongs to
 function M.open(root)
   local commits, err = git.branch_commits(root)
@@ -138,10 +142,6 @@ function M.open(root)
   for _, m in ipairs(painted.marks) do
     pcall(vim.api.nvim_buf_set_extmark, buf, NS_TRIM, m.row, m.col, m.opts)
   end
-
-  -- The cursor opens on the newest commit, which is where a fresh window puts it and where
-  -- the row a reviewer wants nearly always is -- so reading this list costs no movement.
-  -- Nothing places it here, because there is nothing yet that would want it elsewhere.
 
   local function close()
     if vim.api.nvim_win_is_valid(win) then

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -1,0 +1,156 @@
+---The commits on the branch, read from inside the review.
+---
+---A module of its own, in the shape of `queue_float.lua`: a float needs a buffer, a window
+---and keys, and none of the review view's mutable state. The repository to ask about is
+---handed in as a plain string, so nothing here reads the view -- which is what keeps this
+---module out of the cycle `view` and `annotate` already sit in.
+---
+---**Nothing here picks a row yet.** When a key that acts on one arrives it arrives the way
+---the queue float's keys did: the view hands itself in and the float runs its exported
+---actions, rather than requiring `view` for them.
+---
+---What a row carries is the short sha, the subject and the relative date. Not the author --
+---you are reading your own branch. Not the added and deleted counts -- they cost a second
+---pass over the whole branch to fill, and the subject is what a reviewer recognises.
+local git = require("codereview.git")
+local render = require("codereview.render")
+
+local M = {}
+
+---@param msg string
+local function info(msg)
+  vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
+
+--- Rendering the commits as rows -------------------------------------------------
+
+---Extmarks belonging to this float, in a namespace of its own so clearing them cannot
+---disturb the diff's, the tree's or the queue float's.
+local NS_TRIM = vim.api.nvim_create_namespace("codereview_trim")
+
+---One column to the left of every row, reserved so that marking the row a trim starts at
+---costs no realignment of everything beside it. Nothing draws in it yet.
+local GUTTER = " "
+
+---Two spaces between the sha and the subject, and at least two between the subject and the
+---date, so the three read as three columns rather than as one sentence.
+local GAP = "  "
+
+---Turn the commits into the float's rows.
+---
+---The subject keeps the buffer's own colour, which is the brightest thing this float has,
+---for the reason the **sticky header** leaves the path in the bar's own group: the sha and
+---the date are what a row is found by, and the subject is what it is read for.
+---
+---Its highlight columns are byte offsets, not display columns -- a subject is free to be
+---any width in either ruler, and the two part company at the first accented character.
+---@param commits CRCommit[]
+---@param width integer Columns the float has to draw into
+---@return { lines: string[], marks: table[] }
+local function build(commits, width)
+  local lines, marks = {}, {}
+  -- Padded to the widest sha in the listing. git abbreviates to whatever the repository
+  -- needs, and it needs more of them on a big one, so the column cannot be assumed.
+  local sha_width = 0
+  for _, commit in ipairs(commits) do
+    sha_width = math.max(sha_width, #commit.sha)
+  end
+  local indent = #GUTTER + sha_width + #GAP
+  local body = math.max(8, width - indent - #GUTTER)
+
+  for _, commit in ipairs(commits) do
+    local when = commit.when or ""
+    local room = body - (when ~= "" and vim.fn.strdisplaywidth(when) + #GAP or 0)
+    local subject = render.truncate(commit.subject, math.max(8, room))
+    local head = GUTTER .. ("%-" .. sha_width .. "s"):format(commit.sha) .. GAP .. subject
+    if when ~= "" then
+      head = head .. (" "):rep(math.max(#GAP, room - vim.fn.strdisplaywidth(subject) + #GAP)) .. when
+    end
+
+    lines[#lines + 1] = head
+    local row = #lines - 1
+    marks[#marks + 1] = {
+      row = row,
+      col = #GUTTER,
+      opts = { end_col = #GUTTER + #commit.sha, hl_group = "CodeReviewQueueIndex" },
+    }
+    if when ~= "" then
+      marks[#marks + 1] = {
+        row = row,
+        col = #head - #when,
+        opts = { end_col = #head, hl_group = "CodeReviewQueueState" },
+      }
+    end
+  end
+
+  return { lines = lines, marks = marks }
+end
+
+--- The float --------------------------------------------------------------------
+
+---List the commits on the branch, newest first.
+---
+---Refuses rather than opening onto one unusable row: a branch whose `HEAD` is the merge
+---base has done no work of its own, which is an ordinary state and not a failure, and a
+---float holding nothing a reviewer can act on would leave them wondering which of the two
+---had gone wrong.
+---@param root string The repository the branch belongs to
+function M.open(root)
+  local commits, err = git.branch_commits(root)
+  if not commits then
+    info(err or "could not read the commits on this branch")
+    return
+  end
+  if #commits == 0 then
+    info("This branch has no commits of its own — its HEAD is the merge base")
+    return
+  end
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[buf].bufhidden = "wipe"
+
+  local width = math.min(100, math.max(50, math.floor(vim.o.columns * 0.8)))
+  local height = math.min(28, math.max(10, math.floor(vim.o.lines * 0.7)))
+  local n = #commits
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = math.floor((vim.o.lines - height) / 2 - 1),
+    col = math.floor((vim.o.columns - width) / 2),
+    style = "minimal",
+    border = "rounded",
+    title = (" Commits on this branch · %d commit%s "):format(n, n == 1 and "" or "s"),
+    title_pos = "center",
+    -- Only what works. A key that is not built is not advertised: a footer offering one is
+    -- a promise the float cannot keep.
+    footer = " q close ",
+    footer_pos = "center",
+  })
+  -- The rows are fitted to a width they know, so that every one of them stays one row.
+  -- Letting the window wrap instead would fold a long subject onto a second line, where a
+  -- reviewer counting rows against commits would find one too many.
+  vim.wo[win].wrap = false
+
+  local painted = build(commits, vim.api.nvim_win_get_width(win))
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, painted.lines)
+  vim.bo[buf].modifiable = false
+  for _, m in ipairs(painted.marks) do
+    pcall(vim.api.nvim_buf_set_extmark, buf, NS_TRIM, m.row, m.col, m.opts)
+  end
+
+  -- Newest first, and the cursor on the newest: the row a reviewer wants is nearly always
+  -- one of the recent ones, so reading this list costs no movement.
+  pcall(vim.api.nvim_win_set_cursor, win, { 1, 0 })
+
+  local function close()
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+  end
+
+  vim.keymap.set("n", "q", close, { buffer = buf, desc = "Close the commit list" })
+  vim.keymap.set("n", "<Esc>", close, { buffer = buf, desc = "Close the commit list" })
+end
+
+return M

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -25,6 +25,7 @@ local hl = require("codereview.hl")
 local fade = require("codereview.fade")
 local delivery = require("codereview.delivery")
 local queue_float = require("codereview.queue_float")
+local trim_float = require("codereview.trim_float")
 local view_layout = require("codereview.view_layout")
 local view_panel = require("codereview.view_panel")
 
@@ -1621,6 +1622,28 @@ end
 ---key already bind, and this module handing itself in for the actions the float drives.
 function M.review_queue()
   queue_float.open(M)
+end
+
+---List the commits on the branch, from inside a review.
+---
+---The surface is `trim_float`'s, and the repository is handed to it rather than looked up:
+---the review already knows which one it is reading, and a second answer to that question is
+---a second chance to answer it differently.
+---
+---What stays here is the one refusal only the view can make. Which **scope** is on screen
+---is this module's own state, and a commit list is about a branch: on `staged`, `unstaged`,
+---`worktree` or a revspec there is no branch behind the review to list. Said rather than
+---ignored, so a reviewer learns where the key applies instead of watching nothing happen.
+function M.commit_list()
+  local v = M.current()
+  if not v then
+    return
+  end
+  if v.scope.name ~= "branch" then
+    info(("Commits are listed for a branch review — this review is %s"):format(v.scope.label))
+    return
+  end
+  trim_float.open(v.root)
 end
 
 ---Read the last dispatched **batch** back, from inside a review.

--- a/tests/README.md
+++ b/tests/README.md
@@ -586,6 +586,15 @@ so the out-of-core language path is still checked locally without ever failing C
   in both panes on its row passes with the before pane never drawing anything, because the
   case is then reading the after pane twice. `spans_spec` uses `src/nonl.md`, the fixture's
   only pair that changes something on each side.
+- **The commit list's opening row cannot be measured while every listing starts at the
+  top.** A fresh window puts the cursor on row 1, so `trim_float_spec`'s "opens the cursor
+  on the first row" is satisfied by placing it there, by placing it nowhere, and by deleting
+  every line that could place it — measured: removing an explicit `nvim_win_set_cursor`
+  from `trim_float.lua` reds nothing in the suite, which is why there is no such line. The
+  case is kept because it is the claim a reviewer can see, and it gets its teeth the moment
+  the float has a row it must open somewhere other than the top. Same shape as "no fixture
+  is both tall and multilingual" — a gap in what can be observed, not an assertion to
+  delete.
 - **Two entries of different types are separated by a group, not by a row.** The queue
   float's boundary between entries is one blank row carrying no bar, and an assertion about
   it needs two entries of the *same* annotation type — give them different ones and what

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,6 +68,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colours one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
+| `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the cursor's opening row, the keys that close it, `gc` from the diff and from the tree, and the two refusals that open nothing |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
@@ -77,7 +78,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 
 ## Fixtures
 
-Three repositories, each rebuilt from scratch by its script. They are not
+Four repositories, each rebuilt from scratch by its script. They are not
 interchangeable, and the assertions know which one they are looking at.
 
 - **`mkfixture.sh`** — flat `src/`-only repo covering every file status at once:
@@ -98,6 +99,15 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mktree.sh`** — nested repo whose *shape* is the point: `apps/api/src` and
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec`, `focus_spec` and `queue_jump_panel_spec`.
+- **`mkcommits.sh`** — repo whose *history* is the point, and the smallest of the four: no
+  file statuses, no binary, no rename. A branch of four commits over the default branch,
+  one of them a merge that brings in a fifth commit from a side branch cut off master's
+  tip. Used by `trim_float_spec`. Two rules need exactly that shape and can be seen in
+  nothing else: a listing that dropped `--first-parent` draws the commit the merge brought
+  in as a row of its own, and the merge base is a different commit from the oldest listed
+  commit's parent, which is what resolving the oldest row has to notice. Its commits are
+  dated days apart, as offsets back from the moment the script runs, so a relative date on
+  a row is a fact a spec can check and never goes stale.
 - **`mkbig.sh`** — files of a given size, half of every file rewritten. It takes counts as
   well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and 200), so a caller
   asks for the height it needs rather than for a second script. `perf.lua` builds a 60-file,

--- a/tests/codereview/trim_float_spec.lua
+++ b/tests/codereview/trim_float_spec.lua
@@ -1,0 +1,406 @@
+-- The float that lists the commits on the branch: its rows, its keys, and where the cursor
+-- opens.
+--
+-- What is asserted is what a reviewer can see -- which rows are there, what a row says, what
+-- sentence was shown -- and never the shape of the git invocation behind them. The rows are
+-- compared against what git itself reports for the same range, because a hardcoded list of
+-- subjects says nothing about the *rule* that produced them.
+--
+-- The fixture is `mkcommits`, whose history is the whole point of it: a branch of four
+-- commits, one of them a merge, over a merge base that is not the oldest commit's parent.
+-- Both rules this file pins are invisible without it -- see the script's own header.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkcommits")
+
+require("codereview").setup({ syntax = false })
+
+local codereview = require("codereview")
+local view = require("codereview.view")
+
+--- What git says, which is what the float is judged against ---------------------
+
+local UNIT = "\31"
+
+---One `git log` line per commit, as `{ sha, when, subject }`.
+---@param args string[] Appended to the log invocation
+---@return { sha: string, when: string, subject: string }[]
+local function log(args)
+  local out = {}
+  for _, l in ipairs(h.git_lines(fixture, vim.list_extend({ "log", "--format=%h%x1f%ar%x1f%s" }, args))) do
+    local sha, when, subject = l:match("^(%S+)" .. UNIT .. "(.-)" .. UNIT .. "(.*)$")
+    out[#out + 1] = { sha = assert(sha, l), when = when, subject = subject }
+  end
+  return out
+end
+
+local base = assert(h.git_lines(fixture, { "merge-base", "master", "HEAD" })[1], "no merge base")
+---The branch's own line of work, newest first: what the float has to draw.
+local first_parent = log({ "--first-parent", base .. "..HEAD" })
+---Everything in the same range, which holds one more commit -- the one the merge brought in.
+local everything = log({ base .. "..HEAD" })
+
+---@param commits { subject: string }[]
+---@return string[]
+local function subjects(commits)
+  return vim.tbl_map(function(c)
+    return c.subject
+  end, commits)
+end
+
+--- Reading the float ------------------------------------------------------------
+
+---@param buf integer
+---@return string[]
+local function lines(buf)
+  return vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+end
+
+---@param win integer
+---@param field "title"|"footer"
+---@return string
+local function chrome(win, field)
+  local value = vim.api.nvim_win_get_config(win)[field]
+  return value and tostring(value[1][1]) or ""
+end
+
+---@param buf integer
+---@return table<string, boolean> Every left-hand side bound in normal mode
+local function bound(buf)
+  local lhs = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+    lhs[vim.keycode(m.lhs)] = true
+  end
+  return lhs
+end
+
+---Press `gc` in `from` and hand back the float it opened.
+---
+---Guarded as a *float* rather than merely as another window: a key that is not bound at all
+---leaves focus where it was, and "somewhere other than the diff" would then be satisfied by
+---the file tree.
+---@param from integer The window to press it in
+---@return integer win, integer buf
+local function commits_by_key(from)
+  vim.api.nvim_set_current_win(from)
+  h.feed("gc")
+  local win = vim.api.nvim_get_current_win()
+  assert.are_not.same(from, win, "gc opened no window of its own")
+  assert.are_not.same("", vim.api.nvim_win_get_config(win).relative, "gc opened no float")
+  return win, vim.api.nvim_win_get_buf(win)
+end
+
+--- The fixture the rest of this file leans on -----------------------------------
+
+-- Every claim below is a claim about a *rule*, and each of these is what makes the
+-- corresponding rule observable at all. Without the guards, a listing that dropped
+-- `--first-parent` and a listing that kept it are the same listing.
+describe("the history this spec reads", function()
+  it("puts four commits on the branch's own line of work", function()
+    assert.same(4, #first_parent, vim.inspect(subjects(first_parent)))
+  end)
+
+  it("holds one more commit than that in the same range", function()
+    assert.same(5, #everything, vim.inspect(subjects(everything)))
+  end)
+
+  it("brought that one in through the merge, so first-parent listing can be seen at all", function()
+    local merged = vim.tbl_filter(function(s)
+      return not vim.tbl_contains(subjects(first_parent), s)
+    end, subjects(everything))
+    assert.same({ "fix: tighten the lexer" }, merged)
+  end)
+
+  -- Not asserted by anything here, and the reason the lexer branch is cut from master's tip
+  -- rather than from the branch point: resolving the oldest row is a rule about the merge
+  -- base, and a fixture where the two are one commit cannot tell the two answers apart.
+  it("keeps the merge base and the oldest listed commit's parent as different commits", function()
+    local oldest = first_parent[#first_parent].sha
+    local parent = assert(h.git_lines(fixture, { "rev-parse", oldest .. "^" })[1])
+    local merge_base = assert(h.git_lines(fixture, { "rev-parse", base })[1])
+    assert.are_not.same(merge_base, parent)
+  end)
+
+  it("names an author no row is allowed to carry", function()
+    assert.same("Fixture Author", h.git_lines(fixture, { "log", "-1", "--format=%an" })[1])
+  end)
+end)
+
+--- The rows --------------------------------------------------------------------
+
+describe("gc inside a branch review", function()
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local win, buf = commits_by_key(review.win)
+  local rows = lines(buf)
+
+  it("draws one row per commit on the branch's own line of work", function()
+    assert.same(#first_parent, #rows, table.concat(rows, "\n"))
+  end)
+
+  it("lists them newest first", function()
+    local shas = vim.tbl_map(function(row)
+      return row:match("%x+")
+    end, rows)
+    assert.same(
+      vim.tbl_map(function(c)
+        return c.sha
+      end, first_parent),
+      shas
+    )
+  end)
+
+  -- The merge is one row and reads as the one change it was; what came in under it is the
+  -- other branch's business.
+  it("leaves out what arrived through the merge", function()
+    local text = table.concat(rows, "\n")
+    assert.is_truthy(text:find("Merge branch 'lexer'", 1, true), text)
+    assert.is_nil(text:find("fix: tighten the lexer", 1, true), text)
+  end)
+
+  it("carries the short sha, the subject and the relative date on every row", function()
+    for i, c in ipairs(first_parent) do
+      local row = rows[i]
+      assert.is_truthy(row:find(c.sha, 1, true), row)
+      assert.is_truthy(row:find(c.subject, 1, true), row)
+      assert.is_truthy(row:find(c.when, 1, true), row)
+    end
+  end)
+
+  -- Whitespace is stripped from both sides rather than the padding being reproduced here:
+  -- the claim is that a row holds those three facts and nothing else, and reproducing the
+  -- arithmetic that lays them out would assert the implementation against itself.
+  it("carries nothing else", function()
+    for i, c in ipairs(first_parent) do
+      assert.same((c.sha .. c.subject .. c.when):gsub("%s+", ""), (rows[i]:gsub("%s+", "")), rows[i])
+    end
+  end)
+
+  it("names the author nowhere", function()
+    for _, row in ipairs(rows) do
+      assert.is_nil(row:find("Fixture Author", 1, true), row)
+    end
+  end)
+
+  -- Relative rather than absolute: telling yesterday's work from last week's is what the
+  -- date is on the row for, and the fixture's commits are days apart so the two spellings
+  -- cannot be confused for each other.
+  it("dates a row in words rather than as a stamp", function()
+    for _, row in ipairs(rows) do
+      assert.is_truthy(row:find("ago", 1, true), row)
+    end
+    assert.is_truthy(rows[#rows]:find("5 days ago", 1, true), rows[#rows])
+  end)
+
+  it("opens the cursor on the first row", function()
+    assert.same(1, vim.api.nvim_win_get_cursor(win)[1])
+  end)
+
+  it("says how many commits are listed", function()
+    assert.is_truthy(chrome(win, "title"):find(tostring(#first_parent), 1, true), chrome(win, "title"))
+  end)
+
+  it("leaves the review it was pressed in on screen", function()
+    assert.same(review, view.current())
+    assert.is_true(vim.api.nvim_win_is_valid(review.win))
+  end)
+
+  it("is bound in the diff and in the file tree", function()
+    assert.is_true(bound(review.buf)[vim.keycode("gc")] == true, "gc is not bound in the diff")
+    assert.is_true(bound(assert(review.panel_buf))[vim.keycode("gc")] == true, "gc is not bound in the tree")
+  end)
+
+  if vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+  codereview.close()
+end)
+
+--- The keys --------------------------------------------------------------------
+
+describe("the keys on the float", function()
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+
+  it("closes on q", function()
+    local win = commits_by_key(review.win)
+    h.feed("q")
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+
+  it("closes on <Esc>", function()
+    local win = commits_by_key(review.win)
+    h.feed("<Esc>")
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+
+  -- Closing the float must not close the review behind it: `q` is the review's own key for
+  -- that, and the float is on top of it.
+  it("leaves the review open behind it", function()
+    assert.same(review, view.current())
+  end)
+
+  -- Picking a row is a feature that is not built. What must not happen is `<CR>` doing
+  -- something *else* -- closing the float, or moving the review off the scope it is on.
+  it("picks nothing on <CR>", function()
+    local win = commits_by_key(review.win)
+    local scope = assert(view.current()).scope.name
+    h.feed("<CR>")
+    assert.is_true(vim.api.nvim_win_is_valid(win), "<CR> closed the float")
+    assert.same(scope, assert(view.current()).scope.name)
+    vim.api.nvim_win_close(win, true)
+  end)
+
+  it("advertises the key that closes it, and nothing that does not work yet", function()
+    local win = commits_by_key(review.win)
+    local footer = chrome(win, "footer")
+    h.feed("q")
+    assert.is_truthy(footer:find("q close", 1, true), footer)
+    assert.is_nil(footer:find("⏎", 1, true), footer)
+  end)
+
+  codereview.close()
+end)
+
+--- From the file tree -----------------------------------------------------------
+
+-- The trim is reachable from wherever the cursor is, so the key answers the same way in
+-- both of the review's windows.
+describe("gc in the file tree", function()
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+
+  local win, buf = commits_by_key(review.win)
+  local from_diff = lines(buf)
+  h.feed("q")
+
+  local tree_win, tree_buf = commits_by_key(assert(review.panel_win, "no file tree"))
+  local from_tree = lines(tree_buf)
+  h.feed("q")
+
+  it("opens the same rows the diff opens", function()
+    assert.same(from_diff, from_tree)
+  end)
+
+  it("really did read the tree's window, not the diff's", function()
+    assert.are_not.same(win, tree_win)
+  end)
+
+  codereview.close()
+end)
+
+--- The two refusals -------------------------------------------------------------
+
+-- A sentence rather than a surprise, which is what this plugin already prefers. Each one
+-- says a different fact, so each gets its own answer.
+--
+-- A revspec rather than one of the working-tree scopes: the fixture is a clean checkout, so
+-- `staged`, `unstaged` and `worktree` have nothing in them to open a review on -- and a
+-- revspec is the scope a reviewer reaches for when they already know which commit they
+-- want, which is the neighbouring surface this key exists beside.
+describe("gc outside a branch review", function()
+  codereview.open("HEAD~1")
+  local review = assert(view.current(), "no review view opened")
+  local before = vim.api.nvim_get_current_win()
+
+  local msgs, restore = h.capture_notify()
+  h.feed("gc")
+  restore()
+  local after = vim.api.nvim_get_current_win()
+
+  it("is on a scope that is not the branch", function()
+    assert.same("revspec", review.scope.name)
+  end)
+
+  it("opens nothing", function()
+    assert.same(before, after)
+    assert.same("", vim.api.nvim_win_get_config(after).relative)
+  end)
+
+  it("says where the commit list applies", function()
+    assert.is_true(h.notified(msgs, "branch review"), vim.inspect(msgs))
+  end)
+
+  codereview.close()
+end)
+
+-- A branch whose `HEAD` is the merge base has no commits of its own, and a float holding no
+-- row a reviewer could use is worse than the sentence that explains why there is none.
+--
+-- Its own repository, checked out on the default branch with work in the tree: a review has
+-- to open before a key inside it can be pressed, and a *clean* checkout of the default
+-- branch has nothing in scope to open one on.
+describe("gc on a branch with no commits of its own", function()
+  local flat = h.fixture("mkcommits")
+  h.git_lines(flat, { "checkout", "-q", "master" })
+  vim.fn.writefile({ "local port = 9090" }, vim.fs.joinpath(flat, "src/config.lua"))
+  local here = vim.fn.getcwd()
+  vim.cmd("cd " .. vim.fn.fnameescape(flat))
+
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local before = vim.api.nvim_get_current_win()
+
+  local msgs, restore = h.capture_notify()
+  h.feed("gc")
+  restore()
+  local after = vim.api.nvim_get_current_win()
+
+  it("is a branch review all the same", function()
+    assert.same("branch", review.scope.name)
+  end)
+
+  it("really is a checkout whose HEAD is the merge base", function()
+    local head = assert(h.git_lines(flat, { "rev-parse", "HEAD" })[1])
+    assert.same(head, h.git_lines(flat, { "merge-base", "master", "HEAD" })[1])
+  end)
+
+  it("opens nothing", function()
+    assert.same(before, after)
+    assert.same("", vim.api.nvim_win_get_config(after).relative)
+  end)
+
+  it("says the branch carries no commits of its own", function()
+    assert.is_true(h.notified(msgs, "no commits of its own"), vim.inspect(msgs))
+  end)
+
+  codereview.close()
+  vim.cmd("cd " .. vim.fn.fnameescape(here))
+end)
+
+--- No cap ----------------------------------------------------------------------
+
+-- The oldest commits on a long branch have to stay reachable, which is the one thing this
+-- float must never fail at -- so the branch is grown past any number a cap would plausibly
+-- be set to and every commit is still expected on screen.
+--
+-- Last in the file, because it commits to the fixture every block above reads.
+describe("a branch longer than a capped list would show", function()
+  local FILLER = 60
+  for i = 1, FILLER do
+    h.git_lines(fixture, { "commit", "-q", "--allow-empty", "-m", ("chore: filler %d"):format(i) })
+  end
+
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local win, buf = commits_by_key(review.win)
+  local rows = lines(buf)
+
+  it("grew the branch past any cap worth writing", function()
+    assert.same(#first_parent + FILLER, #log({ "--first-parent", base .. "..HEAD" }))
+  end)
+
+  it("draws a row for every one of them", function()
+    assert.same(#first_parent + FILLER, #rows)
+  end)
+
+  -- The failure a cap actually causes: not a short list, but the oldest commit on the
+  -- branch being unreachable.
+  it("still holds the oldest commit on the branch", function()
+    assert.is_truthy(rows[#rows]:find(first_parent[#first_parent].subject, 1, true), rows[#rows])
+  end)
+
+  h.feed("q")
+  codereview.close()
+end)

--- a/tests/fixtures/mkcommits.sh
+++ b/tests/fixtures/mkcommits.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Rebuild the HISTORY fixture repo used by trim_float_spec (the branch's commit list).
+#
+# Distinct from mkfixture.sh, which builds a flat src/-only repo covering every file
+# status, and from mktree.sh, whose directory shape is the point. Here the *history* is
+# the point, so this is the smallest of the four: no statuses, no binary, no rename.
+#
+# The shape it builds, and why each part of it is there:
+#
+#   B0  chore: seed the repository        master
+#   B1  chore: bump the year              master, and the merge base
+#   c1  feat: read the config file        feature
+#   c2  test: cover the config reader     feature
+#   s1  fix: tighten the lexer            lexer, off B1 -- arrives through the merge
+#   M   Merge branch 'lexer'              feature
+#   c3  docs: write the readme            feature
+#
+# `--first-parent B1..HEAD` is c3, M, c2, c1. Two rules that are otherwise untestable ride
+# on that:
+#
+#   * s1 is in `B1..HEAD` and NOT on the first-parent line, so a listing that forgot
+#     `--first-parent` lists a fifth row. Without a merge the two listings are one listing
+#     and nothing can tell them apart.
+#   * The merge base is B1, while the oldest listed commit's parent is B0. The two are
+#     different commits, which is what a trim that resolves the oldest row has to notice.
+#     The lexer branch is cut from master's tip rather than from the branch point for this
+#     reason alone: it is what pulls the merge base forward past B0.
+#
+# The commits are dated apart from each other, so the relative date on a row is a fact a
+# reader can check rather than "0 seconds ago" five times over. Each date is an offset back
+# from the moment this script runs, which is what keeps "5 days ago" saying that however
+# long the fixture has existed -- a fixed calendar date would drift into a different
+# sentence every day.
+#
+# Regenerate with this script rather than hand-editing a fixture repo.
+set -e
+# Hermetic: no user or system git config. Without this the fixture inherits things that
+# change what it is (commit.gpgsign, diff.renames, core.autocrlf, hooks) -- gpg signing in
+# particular fails outright on a machine with no key, which is every CI runner.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+R="${1:?usage: mkcommits.sh <path>}"
+rm -rf "$R"; mkdir -p "$R"; cd "$R"
+git init -q -b master
+# Two words, and neither of them a letter that could turn up inside a subject: a row that
+# must not name the author is asserted against this string.
+git config user.email fixture@example.com; git config user.name "Fixture Author"
+
+# commit <seconds ago> <subject> -- authored and committed at the same moment, because it
+# is the *author* date that `%ar` reports and the *committer* date that `git log` orders by.
+#
+# Seconds back from now rather than "5 days ago": the environment variables take a raw
+# `<epoch> <zone>`, and only `git commit --date` reads git's friendlier date words.
+NOW="$(date +%s)"
+commit() {
+  local when="$((NOW - $1)) +0000"
+  GIT_AUTHOR_DATE="$when" GIT_COMMITTER_DATE="$when" git commit -qm "$2"
+}
+DAY=86400
+HOUR=3600
+
+mkdir -p src
+
+# --- master ---
+printf 'local port = 8080\n' > src/config.lua
+git add -A
+commit $((6 * DAY)) "chore: seed the repository"
+
+# --- the branch's own work ---
+git checkout -qb feature
+printf 'local port = 8080\nlocal host = "localhost"\n' > src/config.lua
+git add -A
+commit $((5 * DAY)) "feat: read the config file"
+
+printf 'local cfg = require("config")\nassert(cfg.port)\n' > src/config_spec.lua
+git add -A
+commit $((4 * DAY)) "test: cover the config reader"
+
+# --- master moves on, and the side branch is cut from where it moved to ---
+git checkout -q master
+printf 'local year = 2024\n' > src/lexer.lua
+git add -A
+commit $((3 * DAY)) "chore: bump the year"
+
+git checkout -qb lexer
+printf 'local year = 2025\nlocal strict = true\n' > src/lexer.lua
+git add -A
+commit $((2 * DAY)) "fix: tighten the lexer"
+
+# --- the merge, and one commit after it ---
+git checkout -q feature
+MERGED="$((NOW - 20 * HOUR)) +0000"
+GIT_AUTHOR_DATE="$MERGED" GIT_COMMITTER_DATE="$MERGED" \
+  git merge -q --no-ff -m "Merge branch 'lexer' into feature" lexer
+
+printf '# The project\n' > README.md
+git add -A
+commit $((1 * HOUR)) "docs: write the readme"
+
+BASE="$(git merge-base master HEAD)"
+echo "history fixture: $R"
+echo "  on the first-parent line: $(git log --first-parent --format=%h "$BASE..HEAD" | wc -l | tr -d ' ') (expect 4)"
+echo "  in the range at all:      $(git log --format=%h "$BASE..HEAD" | wc -l | tr -d ' ') (expect 5)"
+echo "  merge base:               $(git rev-parse --short "$BASE") (chore: bump the year)"
+echo "  oldest listed commit:     $(git log --first-parent --format=%h "$BASE..HEAD" | tail -1)"

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -11,7 +11,7 @@ M.root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
 ---
 ---Anything after the script name is passed to it after the path, which is how `mkbig` is
 ---asked for a diff of a particular height: it takes a file count and a line count.
----@param script "mkfixture"|"mktree"|"mkbig"
+---@param script "mkfixture"|"mktree"|"mkbig"|"mkcommits"
 ---@param ... string
 ---@return string dir
 function M.fixture(script, ...)
@@ -23,7 +23,7 @@ function M.fixture(script, ...)
 end
 
 ---Build a fixture and make it the current directory.
----@param script "mkfixture"|"mktree"|"mkbig"
+---@param script "mkfixture"|"mktree"|"mkbig"|"mkcommits"
 ---@param ... string
 ---@return string dir
 function M.cd_fixture(script, ...)


### PR DESCRIPTION
A reviewer presses `gc` in a review or in the file tree, and a float lists the commits on
the branch, newest first. Each row carries the short sha, the subject and the relative date
— not the author, and not the added and deleted counts.

The listing is `--first-parent` from the merge base to `HEAD`, so a merge is one row and
the work that arrived through it is not listed beside the work the branch did itself.
**There is no cap on the rows**: a cap would put the oldest commits on a long branch out of
reach, which is the one thing a list a reviewer picks from must never do.

`q` and `<Esc>` close it. No row can be picked yet — `<CR>` is unbound, and picking is #140.

Two refusals, each a sentence and no float: `gc` outside a `branch` review, where there is
no branch behind the diff to list, and `gc` on a branch whose `HEAD` is the merge base,
which has no commits of its own.

## Shape

`lua/codereview/trim_float.lua` is a new module in the shape of `queue_float.lua`: a float
needs a buffer, a window and keys and none of the view's mutable state. It takes the
repository as a plain string and requires `view` for nothing, so it takes no part in the
cycle `view` and `annotate` already sit in. The one refusal only the view can make — the
scope on screen — stays in the view. The commit listing itself is one new function in
`git.lua`, well away from the scopes section.

## The fixture

`tests/fixtures/mkcommits.sh` is new rather than more commits on the flat fixture, which
nineteen specs read and none of them asserts a history on. Its shape is the point, and two
rules can be seen in nothing else:

- the merge brings in a commit that is in the range and off the first-parent line, so a
  listing that dropped `--first-parent` draws a fifth row;
- the merge base is a different commit from the oldest listed commit's parent, which is what
  resolving the oldest row has to notice — #140 needs that.

Its commits are dated days apart, as offsets back from the moment the script runs, so a
relative date on a row is a fact a spec can check and never goes stale.

## Verifying

`make all` — lint plus the full suite — exits 0 with no `Tests Failed`, 1,464 cases.

Every new assertion was written red first and mutation-checked separately. Dropping
`--first-parent` reds 7 cases; capping the listing at 20 rows reds the two no-cap cases;
putting the author on a row reds 2; an absolute date instead of a relative one reds 3;
dropping the sha reds 3; removing either refusal reds 2 each; unbinding `gc` in the diff
reds 6 and errors 3 more; unbinding it in the tree reds 1 and errors 1; unbinding `q`,
`<Esc>`, binding `<CR>` to anything, and advertising an unbuilt key each red their own case.

One assertion is deliberately kept without teeth and written down in `tests/README.md`: a
fresh window already opens the cursor on row 1, so "opens the cursor on the first row"
cannot fail today. Measured — an explicit `nvim_win_set_cursor` reds nothing when removed,
which is why there is no such line.

Closes #139