### PR TITLE
feat(view): trim a branch review to the commits you have not read

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,6 +13,22 @@ What a review covers — a branch, the staged or unstaged changes, the whole wor
 whatever changed since the last **batch** went out, or any git revspec.
 _Avoid_: mode, filter, range (a range is a span of lines, see **Range**)
 
+**Trim**:
+The commits taken off the start of a **branch** scope. The default is none. The reviewer
+picks the oldest commit they still want to read, and the commits before it leave the review.
+The word is subtractive, which is what the reviewer does: they remove commits from a whole
+that is there by default. "Trimmed to four commits" and "reset the trim" both read
+correctly, and the verb and the noun are one word. A trim has one end, and it is the start —
+so uncommitted and untracked work stay in the review under every trim. Said of a **branch**
+scope only: the working-tree scopes have no commits to take. A modifier on that scope and
+never a scope of its own, because a sixth name would have to answer what it means with
+nothing picked, and because `gs` is a key held down and must not get a new stop. Not
+_filter_ and not _mode_: both are on **Scope**'s avoid list. Not _range_, which is the lines
+an annotation covers, and not _span_, which is the changed characters inside a paired line.
+Not _selection_ either: that is on **Range**'s avoid list, and reusing it invites the
+collision that list exists to prevent.
+_Avoid_: filter, mode, range, span, selection, cutoff
+
 **Review view**:
 The syntax-highlighted diff of a scope, with annotations projected onto its lines. Means
 the whole surface in either **layout**.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ inside the view to cycle between them in place.
 Files are marked reviewed **against their git blob**, so a mark stops meaning anything
 once the file changes underneath it.
 
+**A branch review can be trimmed to the commits you have not read.** Press `gc`, move to the
+oldest commit you still want to read, and press `<CR>`: the review draws again from that
+commit forward, and the scope label says so — `branch vs origin/master · last 4`. The commit
+you pick is **in** the diff. The top row of the list is "All commits", which gives the whole
+branch back, and so does the bottom row. Uncommitted and untracked work stay in the review
+under every trim, because a trim has one end and it is the start. Your reviewed marks survive
+one: a file the commits you dropped never changed keeps its mark, and a file that has moved
+since you marked it loses one whether you trimmed or not. The trim lasts for the session.
+
 **`since-batch` is the one to reach for while an agent is working.** Submitting records a
 snapshot of the working tree, and this scope diffs against it — so what you get is the
 agent's response to your review, without the work you already had in flight when you sent
@@ -615,7 +624,7 @@ worth a look before we ship this
 | `gp` | Show or hide the file tree |
 | `gl` | Switch between the unified and split layouts |
 | `gb` | Read the last dispatched batch back |
-| `gc` | List the commits on the branch |
+| `gc` | List the commits on the branch, and trim the review to one |
 | `gA` | Show or hide archived entries, for the rest of the session |
 | `<CR>` | Open the real file here, in a new tab |
 | `gd` | Read this file in your own diff tool — only bound with [`open_diff`](#adapters) wired |
@@ -663,7 +672,7 @@ is to stop looking at them, so the useful motion is "the next thing I have not d
 | `gp` | Dismiss the tree, landing back in the diff |
 | `gl` | Switch between the unified and split layouts |
 | `gb` | Read the last dispatched batch back |
-| `gc` | List the commits on the branch |
+| `gc` | List the commits on the branch, and trim the review to one |
 | `gA` | Show or hide archived entries, for the rest of the session |
 | `q` | Close |
 
@@ -719,9 +728,16 @@ The listing is `--first-parent` from the merge base, so a merge is one row and t
 that arrived through it are not listed beside your own. There is **no limit on the rows**: a
 long branch keeps its oldest commits on screen, at the bottom of the list.
 
+`<CR>` trims the review to the row under the cursor: the review draws again from that commit
+forward, and that commit is **in** the diff. The top row is "All commits" and removes the
+trim; the bottom row means the same thing, because the oldest commit resolves to the merge
+base and not to its own parent. The row your review currently starts at is marked with `▸`,
+and the cursor opens on it — on "All commits" while the whole branch is in the review.
+
 | Key | Action |
 | --- | --- |
-| `q` / `<Esc>` | Close |
+| `<CR>` | Review from this commit forward |
+| `q` / `<Esc>` | Close, changing nothing |
 
 Two cases open nothing and say why in one sentence: `gc` outside a branch review, where
 there is no branch behind the diff to list, and `gc` on a branch whose `HEAD` is the merge

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -252,6 +252,23 @@ number now belongs to unrelated code. A hunk is always inlined for the same reas
 to an agent whose working directory is not this one; anything outside its tree falls back
 to an absolute path with the code inlined.
 
+**A scope's identity and its pre-image are two refs, and only one of them may be re-derived.**
+A **trim** moves a `branch` scope's `before` up the branch and leaves `identity` at the merge
+base. Anything asking *where does this branch start* — the commit list, the progress key —
+has to read the identity: the pre-image is what a trim narrows, so a commit list built from
+it shortens every time a reviewer trims and takes away the rows they need to widen it again.
+Anything asking *what is this review reading* has to read the pre-image. Neither may be
+recomputed from `origin/HEAD` a second time: a `git fetch` in another window moves the default
+branch, and a surface that re-derives the base then draws against a base the review is not
+using. That is why `git.branch_commits` takes the base and no longer resolves one.
+
+**Keying progress on the pre-image fails silently rather than loudly.** The per-scope progress
+key is `name .. ":" .. identity`. Spelled with `before` it agrees with the plugin for every
+scope that carries no trim, so it reads correctly everywhere until a trimmed branch review is
+opened — and then it names a key nothing was ever written under, and an assertion over it
+compares two empty tables and passes. `tests/codereview/state_spec.lua` built its key by hand
+and had exactly this shape before #140.
+
 **That cwd is realpath'd first, and only that side.** Every `abs_path` in the queue is
 already canonical — `git rev-parse --show-toplevel` answers with symlinks resolved, and
 buffer capture realpaths for the same reason — but a target's `cwd` is whatever the adapter

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -33,7 +33,7 @@ change there is felt through.
 | `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named, and how a winbar is assembled from typed segments | pure |
 | `state.lua` | Persisted review progress, and the blob comparisons over it — staleness, and touchedness kept in a function of its own | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
-| `trim_float.lua` | The float over the branch's commits: the first-parent listing from the merge base, one row per commit, and the two refusals that open nothing | stateful (float) |
+| `trim_float.lua` | The float over the branch's commits: the first-parent listing from the base handed in, one row per commit, the row a **trim** starts at, and the pick that applies one | stateful (float) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
 | `view.lua` | The review view: the `CRView` it owns, the paint, navigation, delivery, opening and closing | stateful (windows) |
 | `view_layout.lua` | Where the review's windows are: the panes, the before pane, the toggle between the unified and split layouts, which of them is muted, and which group each lights its row in | stateful (windows) |
@@ -71,15 +71,16 @@ footer it draws names the batch's target, and routing is delivery's. Function-lo
 sides, as above. The alternative was handing the composer in from every caller, which buys
 nothing and spreads the one rule ADR-0003 exists to keep in one place.
 
-`keymaps`, `queue_float`, `view_layout` and `view_panel` would each be a fourth. All four run
-the view's exported actions, and all four take them as an argument — `view` hands itself in —
-rather than requiring `view` for them. That is deliberate, and it is what leaves `keymaps` a
-function of its arguments and the configured annotation types. `queue_float` reads no view
-state either: the one field it needs, the window a float is open in, stays on `view` behind
-two accessors, because closing a float on submit is a rule about the view's windows.
-`trim_float` is not even a candidate: it runs no view action yet, so what it takes is the
-repository whose commits it lists, and the view keeps the one refusal only the view can make
-— the **scope** on screen.
+`keymaps`, `queue_float`, `trim_float`, `view_layout` and `view_panel` would each be a
+fourth. All five run the view's exported actions, and all five take them as an argument —
+`view` hands itself in — rather than requiring `view` for them. That is deliberate, and it is
+what leaves `keymaps` a function of its arguments and the configured annotation types.
+`queue_float` reads no view state either: the one field it needs, the window a float is open
+in, stays on `view` behind two accessors, because closing a float on submit is a rule about
+the view's windows. `trim_float` reads none at all: what it takes beside the view is the
+repository and the commit the branch starts at, both as plain values, because a second
+derivation of *where does this branch start* is a second chance to answer it differently.
+The view keeps the one refusal only the view can make — the **scope** on screen.
 `view_layout` and `view_panel` do read view state, but never their own copy of it: the
 `CRView` table is handed in beside the view and mutated in place, exactly as `syntax` and
 `state` are handed it, so there is still one table and `view` still owns it. The one edge

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -95,6 +95,22 @@ function M.merge_base(a, b, root)
   return line({ "merge-base", a, b }, root)
 end
 
+---How many commits `from` is behind `HEAD` on the branch's own line of work.
+---
+---What the scope label reports as `last N`, derived rather than remembered: a reviewer who
+---commits again after trimming has one more commit in their review than they picked, and a
+---number stored at pick time would keep saying the old one.
+---
+---`--first-parent` for the reason the listing is: a merge is one commit, and counting what
+---arrived through it would report a number no row of the commit list adds up to.
+---@param from string
+---@param root string
+---@return integer|nil nil when `from` names no commit this repository has
+function M.count_commits(from, root)
+  local out = line({ "rev-list", "--count", "--first-parent", from .. "..HEAD" }, root)
+  return out and tonumber(out) or nil
+end
+
 ---A commit object recording the working tree as it stands, minted and nothing else.
 ---
 ---`git stash create` writes the commit and prints its sha; that is the whole of what it
@@ -154,10 +170,11 @@ end
 ---side is a file on disk.
 ---
 ---Every scope also carries an identity: the ref that tells the view which scope it reads
----progress for. Today it is `before` in each of them. That is what the progress key has
----always held, so a key written before this field existed still finds its reviewed marks.
----It is a field of its own because the two can move apart. If a scope moves its pre-image,
----the identity does not move with it, and the reviewer keeps the marks they made.
+---progress for. It is `before` in every scope but a trimmed `branch`, which is what the
+---progress key has always held, so a key written before this field existed still finds its
+---reviewed marks. It is a field of its own because the two do move apart, and `branch` is
+---where: a **trim** moves the pre-image up the branch and the identity stays at the merge
+---base, so the reviewer keeps every mark they made on the review they are narrowing.
 ---@param spec string
 ---@param root string
 ---@return CRScope|nil, string|nil err
@@ -227,15 +244,31 @@ function M.resolve_scope(spec, root)
     if not base then
       return nil, ("no merge base with %s"):format(branch)
     end
+
+    -- The **trim**, read here rather than taken as an argument -- the shape `since-batch`
+    -- already has, and for the reason recorded for it: handing the value in would put the
+    -- one scope that needs it into every caller of scope resolution, and scope resolution
+    -- is exactly what has to stay one function. A trim naming a commit this repository does
+    -- not have is not a trim, and the whole branch is the answer; saying so out loud belongs
+    -- with the trim that outlives a session, which is where a rewritten commit can reach.
+    local trim = require("codereview.state").trim(root)
+    local kept = trim and M.count_commits(trim, root)
+
     return {
       name = "branch",
-      label = ("branch vs %s"):format(branch),
-      args = { base },
-      before = base,
+      -- Short, because the winbar is width-constrained and the summary is what a narrow
+      -- pane gives up first. It is also the only thing that stops a trim from being a trap.
+      label = kept and ("branch vs %s · last %d"):format(branch, kept) or ("branch vs %s"):format(branch),
+      args = { kept and trim or base },
+      -- The parent of the oldest commit still being read, so that commit is in the diff.
+      before = kept and trim or base,
+      -- Both of these follow from a trim having one end, and it is the start: the work in
+      -- the tree is on the other side of the review and no trim reaches it.
       after = nil,
       untracked = true,
-      -- The merge base, which is what says *this branch*. A scope that starts at a later
-      -- commit is the same branch review, and it reads the same progress back.
+      -- The merge base, which is what says *this branch*, and it does not move when the
+      -- pre-image does. A trimmed review is the same branch review and reads the same
+      -- progress back, which is what leaves a reviewer's marks where they left them.
       identity = base,
     }
   end
@@ -509,6 +542,7 @@ end
 ---@field sha string      Short sha, abbreviated by git to whatever this repository needs
 ---@field when string     How long ago it was authored, in git's own words
 ---@field subject string  The commit's first line
+---@field before string   What a review **trimmed** to this commit reads from
 
 ---Every commit the branch carries, newest first.
 ---
@@ -519,21 +553,20 @@ end
 ---**There is no limit.** A limit would put the oldest commits on a long branch out of reach,
 ---which is the one thing a list a reviewer picks from must never do.
 ---
----The merge base is resolved here rather than taken from a scope. What a reviewer is being
----shown is the branch, and a scope's pre-image is free to be something narrower than the
----branch -- so reading it would quietly shorten the list the moment it was.
+---The base is handed in and never derived here. The one answer to *where does this branch
+---start* is the scope's own identity, and a second derivation can disagree with it: a
+---`git fetch` in another window moves the default branch, and the list would then be drawn
+---against a base the review on screen is not using. What must **not** be handed in is the
+---scope's pre-image, which is exactly what a trim narrows -- reading that would shorten the
+---list every time a reviewer trimmed, and take the rows they need to widen it again away.
+---
+---Each commit carries what a trim starting at it reads from: its own parent, so the commit
+---is in the diff -- except the oldest, which reads from the base. On a branch with merges
+---those are different commits, and only the base means *all of it*.
 ---@param root string
+---@param base string Where the branch starts: the scope's identity
 ---@return CRCommit[]|nil commits, string|nil err
-function M.branch_commits(root)
-  local branch = M.default_branch(root)
-  if not branch then
-    return nil, "could not determine the default branch"
-  end
-  local base = M.merge_base(branch, "HEAD", root)
-  if not base then
-    return nil, ("no merge base with %s"):format(branch)
-  end
-
+function M.branch_commits(root, base)
   -- The fields are separated by a unit separator, and the subject comes last. A subject is
   -- one line and can hold anything else at all, including whatever a friendlier separator
   -- would be built out of -- so the one field that could contain the delimiter is the one
@@ -541,7 +574,7 @@ function M.branch_commits(root)
   local out, err = run({
     "log",
     "--first-parent",
-    "--format=%h%x1f%ar%x1f%s",
+    "--format=%h%x1f%p%x1f%ar%x1f%s",
     base .. "..HEAD",
     -- A long branch's log is closer to a diff than to a metadata query.
   }, { cwd = root, timeout = DIFF_TIMEOUT_MS })
@@ -551,10 +584,23 @@ function M.branch_commits(root)
 
   local commits = {}
   for _, entry in ipairs(vim.split(out, "\n", { trimempty = true })) do
-    local sha, when, subject = entry:match("^(%S+)\31(.-)\31(.*)$")
+    local sha, parents, when, subject = entry:match("^(%S+)\31(.-)\31(.-)\31(.*)$")
     if sha then
-      commits[#commits + 1] = { sha = sha, when = when, subject = subject }
+      commits[#commits + 1] = {
+        sha = sha,
+        -- The *first* parent, which is the one the listing walks. A merge names two, and
+        -- the second one is the branch that arrived rather than the branch being read.
+        before = parents:match("^%S+") or base,
+        when = when,
+        subject = subject,
+      }
     end
+  end
+  -- The oldest listed commit's parent is off the end of the range, and on a branch with
+  -- merges it is not the merge base. Picking the last row means the whole branch, so what
+  -- it reads from is the base itself.
+  if #commits > 0 then
+    commits[#commits].before = base
   end
   return commits, nil
 end

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -90,6 +90,12 @@ local LINKS = {
   CodeReviewQueueIndex = "LineNr",
   CodeReviewQueueState = "Comment",
 
+  -- The row the commit list calls out: where the review the reviewer is already in starts.
+  -- Its own group rather than the index's, because it answers *you are here* and not *this
+  -- is which one* -- and it is the one thing in that float a reviewer is looking for before
+  -- they change anything.
+  CodeReviewTrimMark = "Special",
+
   -- Annotation types, mapped onto diagnostic severities so the visual weight already
   -- matches the intent: a bug reads as loud as an error, a nitpick as quiet as a hint.
   CodeReviewBug = "DiagnosticError",

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -120,7 +120,7 @@ function M.diff(buf, view)
     -- `gc` for the **commits**, from the same `g` family. It takes the comment operator,
     -- which is dead in a nomodifiable buffer for the reason `a` became the annotation
     -- prefix: nothing here can be commented out, so the key costs a keystroke and no motion.
-    ["gc"] = { view.commit_list, "List the commits on the branch" },
+    ["gc"] = { view.commit_list, "List the commits on the branch, and trim the review" },
     -- `gA` for **archived** entries, and uppercase because `ga` is `:ascii`. It overrides
     -- the configured switch for the session rather than editing it.
     ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
@@ -213,7 +213,7 @@ function M.panel(buf, view)
     ["gp"] = { view.toggle_panel, "Hide the file tree" },
     ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
     ["gb"] = { view.last_batch, "Read the last batch back" },
-    ["gc"] = { view.commit_list, "List the commits on the branch" },
+    ["gc"] = { view.commit_list, "List the commits on the branch, and trim the review" },
     ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
     ["R"] = { view.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { view.close, "Close the review" },

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -232,6 +232,34 @@ function M.clear_global()
   archive_writes = archive_writes + 1
 end
 
+--- The trim ---------------------------------------------------------------------
+
+---The **trim** on each repository's branch review: the ref the review reads from, which is
+---the parent of the oldest commit the reviewer still wants to read.
+---
+---A ref rather than a count or a commit, because that is what a scope needs: `before` has to
+---be something the diff, the blob hashing and the highlighter's whole-file fetch can all
+---read content out of, and none of them can read a marker. It is the *parent* of the picked
+---commit, so the commit picked is in the diff and the ref needs no arithmetic at open time.
+---
+---**Session-only, and per process.** Keeping a trim across restarts is a feature of its own:
+---a stored trim has to be checked against `HEAD` before it is used, because a rebase, an
+---amend or a force-push leaves it pointing at a commit that was rewritten, and resolving
+---against one of those silently is worse than opening the whole branch.
+local trims = {}
+
+---@param root string
+---@return string|nil before nil when the whole branch is in the review
+function M.trim(root)
+  return trims[root]
+end
+
+---@param root string
+---@param before string|nil nil removes the trim
+function M.set_trim(root, before)
+  trims[root] = before
+end
+
 --- The archive ------------------------------------------------------------------
 
 ---Add a batch to an archive, dropping the oldest once it is full.

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -1,13 +1,10 @@
----The commits on the branch, read from inside the review.
+---The commits on the branch, read from inside the review, and the **trim** picked off them.
 ---
 ---A module of its own, in the shape of `queue_float.lua`: a float needs a buffer, a window
----and keys, and none of the review view's mutable state. The repository to ask about is
----handed in as a plain string, so nothing here reads the view -- which is what keeps this
----module out of the cycle `view` and `annotate` already sit in.
----
----**Nothing here picks a row yet.** When a key that acts on one arrives it arrives the way
----the queue float's keys did: the view hands itself in and the float runs its exported
----actions, rather than requiring `view` for them.
+---and keys, and none of the review view's mutable state. What it acts through is handed in
+----- the view module for the one action `<CR>` runs, and the repository and the commit the
+---branch starts at as plain values -- so nothing here reads the view, which is what keeps
+---this module out of the cycle `view` and `annotate` already sit in.
 ---
 ---What a row carries is the short sha, the subject and the relative date. Not the author --
 ---you are reading your own branch. Not the added and deleted counts -- they cost a second
@@ -28,13 +25,22 @@ end
 ---disturb the diff's, the tree's or the queue float's.
 local NS_TRIM = vim.api.nvim_create_namespace("codereview_trim")
 
----One column to the left of every row, reserved so a later change can mark a row there
----without moving anything beside it. Nothing draws in it yet.
+---One column to the left of every row, where the row the current **trim** starts at is
+---called out. Blank on every other row, so nothing beside it moves when one is marked.
 local GUTTER = " "
+
+---What that column holds on the row the review currently starts at.
+local MARK = "▸"
 
 ---Two spaces between the sha and the subject, and at least two between the subject and the
 ---date, so the three read as three columns rather than as one sentence.
 local GAP = "  "
+
+---The top row, which removes the trim.
+---
+---Above the commits rather than below them: it is the state a review opens in, and a
+---reviewer widening a long branch back out should not have to walk to the bottom to do it.
+local ALL = "All commits"
 
 ---Turn the commits into the float's rows.
 ---
@@ -46,9 +52,10 @@ local GAP = "  "
 ---any width in either ruler, and the two part company at the first accented character.
 ---@param commits CRCommit[]
 ---@param width integer Columns the float has to draw into
+---@param at integer Which commit the review starts at; 0 for none, which is `ALL`
 ---@return { lines: string[], marks: table[] }
-local function build(commits, width)
-  local lines, marks = {}, {}
+local function build(commits, width, at)
+  local lines, marks = { GUTTER .. ALL }, {}
   -- Padded to the widest sha in the listing. git abbreviates to whatever the repository
   -- needs, and it needs more of them on a big one, so the column cannot be assumed.
   local sha_width = 0
@@ -58,21 +65,25 @@ local function build(commits, width)
   local indent = #GUTTER + sha_width + #GAP
   local body = math.max(8, width - indent - #GUTTER)
 
-  for _, commit in ipairs(commits) do
+  for i, commit in ipairs(commits) do
     local when = commit.when or ""
     local room = body - (when ~= "" and vim.fn.strdisplaywidth(when) + #GAP or 0)
     local subject = render.truncate(commit.subject, math.max(8, room))
-    local head = GUTTER .. ("%-" .. sha_width .. "s"):format(commit.sha) .. GAP .. subject
+    local gutter = i == at and MARK or GUTTER
+    local head = gutter .. ("%-" .. sha_width .. "s"):format(commit.sha) .. GAP .. subject
     if when ~= "" then
       head = head .. (" "):rep(math.max(#GAP, room - vim.fn.strdisplaywidth(subject) + #GAP)) .. when
     end
 
     lines[#lines + 1] = head
     local row = #lines - 1
+    if i == at then
+      marks[#marks + 1] = { row = row, col = 0, opts = { end_col = #MARK, hl_group = "CodeReviewTrimMark" } }
+    end
     marks[#marks + 1] = {
       row = row,
-      col = #GUTTER,
-      opts = { end_col = #GUTTER + #commit.sha, hl_group = "CodeReviewQueueIndex" },
+      col = #gutter,
+      opts = { end_col = #gutter + #commit.sha, hl_group = "CodeReviewQueueIndex" },
     }
     if when ~= "" then
       marks[#marks + 1] = {
@@ -88,19 +99,20 @@ end
 
 --- The float --------------------------------------------------------------------
 
----List the commits on the branch, newest first.
+---List the commits on the branch, newest first, and trim the review to the one picked.
 ---
 ---Refuses rather than opening onto one unusable row: a branch whose `HEAD` is the merge
 ---base has done no work of its own, which is an ordinary state and not a failure, and a
 ---float holding nothing a reviewer can act on would leave them wondering which of the two
 ---had gone wrong.
 ---
----The cursor opens on the newest commit, which is where a fresh window puts it and where the
----row a reviewer wants nearly always is, so reading this list costs no movement. Nothing
----places it there, because nothing yet would want it anywhere else.
+---The cursor opens on the row the review currently starts at, so reading this list costs no
+---movement -- on `ALL` while the whole branch is in scope, which is the row that says so.
+---@param view table The view module, which `<CR>` runs the trim through
 ---@param root string The repository the branch belongs to
-function M.open(root)
-  local commits, err = git.branch_commits(root)
+---@param base string Where the branch starts: the review's own scope identity
+function M.open(view, root, base)
+  local commits, err = git.branch_commits(root, base)
   if not commits then
     info(err or "could not read the commits on this branch")
     return
@@ -108,6 +120,19 @@ function M.open(root)
   if #commits == 0 then
     info("This branch has no commits of its own — its HEAD is the merge base")
     return
+  end
+
+  -- Which row the review starts at, read back out of the stored trim rather than off the
+  -- scope's pre-image. The two agree, but only the stored trim tells a review trimmed to the
+  -- oldest commit from a review that was never trimmed at all -- one review, two rows, and
+  -- the cursor belongs on a different one in each.
+  local trim = require("codereview.state").trim(root)
+  local at = 0
+  for i, commit in ipairs(commits) do
+    if trim and commit.before == trim then
+      at = i
+      break
+    end
   end
 
   local buf = vim.api.nvim_create_buf(false, true)
@@ -128,7 +153,7 @@ function M.open(root)
     title_pos = "center",
     -- Only what works. A key that is not built is not advertised: a footer offering one is
     -- a promise the float cannot keep.
-    footer = " q close ",
+    footer = " ⏎ review from here · q close ",
     footer_pos = "center",
   })
   -- The rows are fitted to a width they know, so that every one of them stays one row.
@@ -136,12 +161,15 @@ function M.open(root)
   -- reviewer counting rows against commits would find one too many.
   vim.wo[win].wrap = false
 
-  local painted = build(commits, vim.api.nvim_win_get_width(win))
+  local painted = build(commits, vim.api.nvim_win_get_width(win), at)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, painted.lines)
   vim.bo[buf].modifiable = false
   for _, m in ipairs(painted.marks) do
     pcall(vim.api.nvim_buf_set_extmark, buf, NS_TRIM, m.row, m.col, m.opts)
   end
+  -- Placed rather than left where a fresh window puts it, which is row one: that is the
+  -- right row only while nothing is trimmed.
+  pcall(vim.api.nvim_win_set_cursor, win, { at + 1, 0 })
 
   local function close()
     if vim.api.nvim_win_is_valid(win) then
@@ -149,6 +177,18 @@ function M.open(root)
     end
   end
 
+  ---Apply the row under the cursor and close.
+  ---
+  ---Closed first, and then the trim: applying it repaints the review and puts the cursor
+  ---back in it, and a float still on screen would take that focus straight back off it.
+  local function pick()
+    local row = vim.api.nvim_win_get_cursor(win)[1]
+    local commit = commits[row - 1]
+    close()
+    view.trim_to(commit and commit.before or nil)
+  end
+
+  vim.keymap.set("n", "<CR>", pick, { buffer = buf, desc = "Review from this commit forward" })
   vim.keymap.set("n", "q", close, { buffer = buf, desc = "Close the commit list" })
   vim.keymap.set("n", "<Esc>", close, { buffer = buf, desc = "Close the commit list" })
 end

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1628,11 +1628,14 @@ function M.review_queue()
   queue_float.open(M)
 end
 
----List the commits on the branch, from inside a review.
+---List the commits on the branch, from inside a review, and trim it to the one picked.
 ---
----The surface is `trim_float`'s, and the repository is handed to it rather than looked up:
----the review already knows which one it is reading, and a second answer to that question is
----a second chance to answer it differently.
+---The surface is `trim_float`'s, and both the repository and the commit the branch starts at
+---are handed to it rather than looked up: the review already knows both, and a second answer
+---to either question is a second chance to answer it differently -- a `git fetch` in another
+---window moves the default branch, and a list derived a second time would then be drawn
+---against a base this review is not reading. The **identity** is what is handed over and
+---never the pre-image, because the pre-image is exactly what a trim narrows.
 ---
 ---What stays here is the one refusal only the view can make. Which **scope** is on screen
 ---is this module's own state, and a commit list is about a branch: on `staged`, `unstaged`,
@@ -1647,7 +1650,26 @@ function M.commit_list()
     info(("Commits are listed for a branch review — this review is %s"):format(v.scope.label))
     return
   end
-  trim_float.open(v.root)
+  trim_float.open(M, v.root, v.scope.identity)
+end
+
+---Read the branch review from `before` forward, or from the merge base with nothing passed.
+---
+---Set and then applied through `set_scope`, which is the same entry point a **scope** change
+---goes through, because that path already re-reads the diff, invalidates the syntax caches
+---and seeds the per-scope progress table. A path of its own would eventually forget one of
+---the three, and which one it forgot would be invisible until a reviewer met it.
+---
+---Nothing here re-reads the trim to draw anything: resolution does that, so the label and
+---the diff are answering out of the same store on the same pass.
+---@param before string|nil nil removes the trim
+function M.trim_to(before)
+  local v = M.current()
+  if not v then
+    return
+  end
+  require("codereview.state").set_trim(v.root, before)
+  M.set_scope("branch")
 end
 
 ---Read the last dispatched **batch** back, from inside a review.

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,7 +68,8 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colours one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
-| `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the cursor's opening row, the keys that close it, `gc` from the diff and from the tree, and the two refusals that open nothing |
+| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — the picked commit in the diff, the oldest row at the merge base, the identity that does not move with the pre-image, the label — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, and where `gs` goes from it |
+| `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the row that removes the trim, the row a trim is marked on, the cursor's opening row, the keys, `gc` from the diff and from the tree, and the two refusals that open nothing |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
@@ -102,7 +103,7 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mkcommits.sh`** — repo whose *history* is the point, and the smallest of the four: no
   file statuses, no binary, no rename. A branch of four commits over the default branch,
   one of them a merge that brings in a fifth commit from a side branch cut off master's
-  tip. Used by `trim_float_spec`. Two rules need exactly that shape and can be seen in
+  tip. Used by `trim_spec` and `trim_float_spec`. Two rules need exactly that shape and can be seen in
   nothing else: a listing that dropped `--first-parent` draws the commit the merge brought
   in as a row of its own, and the merge base is a different commit from the oldest listed
   commit's parent, which is what resolving the oldest row has to notice. Its commits are
@@ -586,15 +587,23 @@ so the out-of-core language path is still checked locally without ever failing C
   in both panes on its row passes with the before pane never drawing anything, because the
   case is then reading the after pane twice. `spans_spec` uses `src/nonl.md`, the fixture's
   only pair that changes something on each side.
-- **The commit list's opening row cannot be measured while every listing starts at the
-  top.** A fresh window puts the cursor on row 1, so `trim_float_spec`'s "opens the cursor
-  on the first row" is satisfied by placing it there, by placing it nowhere, and by deleting
-  every line that could place it — measured: removing an explicit `nvim_win_set_cursor`
-  from `trim_float.lua` reds nothing in the suite, which is why there is no such line. The
-  case is kept because it is the claim a reviewer can see, and it gets its teeth the moment
-  the float has a row it must open somewhere other than the top. Same shape as "no fixture
-  is both tall and multilingual" — a gap in what can be observed, not an assertion to
-  delete.
+- **The commit list's opening row can only be measured from a row that is not the top.** A
+  fresh window puts the cursor on row 1, so `trim_float_spec`'s "opens the cursor on the row
+  that removes the trim" — the case made with no **trim** set — is satisfied by placing it
+  there, by placing it nowhere, and by deleting every line that could place it. It was
+  measured as toothless while it was the only such case, and it is kept because it is the
+  claim a reviewer can see. What gives the rule teeth is the block below it, which trims to
+  the *oldest* row and only then reopens the float: deleting the `nvim_win_set_cursor` in
+  `trim_float.lua` reds that block and nothing else in the suite. Same trap as "a filter test
+  needs a fixture only that filter can reject".
+- **A trim is a hidden input to branch scope resolution, and every claim about one runs
+  through the same module-level store.** `git.resolve_scope("branch", …)` reads
+  `state.trim(root)`, which is per process and never written to disk, so a spec that sets one
+  and does not clear it hands it to every block below — including blocks that open a review
+  and expect the whole branch. `trim_spec` and `trim_float_spec` both reset it at the seams
+  between their halves. Eight other call sites resolve `branch` with nothing set, and each
+  spec process gets a state directory of its own, so they stay correct — but a `branch` scope
+  behaving oddly should send the reader to the stored trim before anywhere else.
 - **Two entries of different types are separated by a group, not by a row.** The queue
   float's boundary between entries is one blank row carrying no bar, and an assertion about
   it needs two entries of the *same* annotation type — give them different ones and what

--- a/tests/codereview/state_spec.lua
+++ b/tests/codereview/state_spec.lua
@@ -226,10 +226,17 @@ describe("marks belonging to a scope this view never opened", function()
     view.toggle_reviewed()
   end
 
+  ---The key the plugin files this scope's progress under.
+  ---
+  ---Built from the scope's **identity** and never from its pre-image, which is the same
+  ---rule the view itself follows. The two agree for every scope that carries no **trim**,
+  ---so a key spelled with `before` reads correctly here and quietly stops naming anything
+  ---the moment a trimmed branch review is opened -- and the assertions below then compare
+  ---two empty tables instead of failing.
   ---@return string
   local function scope_key_of()
     local V = assert(view.current())
-    return V.scope.name .. ":" .. V.scope.before
+    return V.scope.name .. ":" .. V.scope.identity
   end
 
   view.close()

--- a/tests/codereview/trim_float_spec.lua
+++ b/tests/codereview/trim_float_spec.lua
@@ -6,6 +6,10 @@
 -- compared against what git itself reports for the same range, because a hardcoded list of
 -- subjects says nothing about the *rule* that produced them.
 --
+-- What a pick *resolves to* is `trim_spec`'s, at the seam where the ref arithmetic is. What
+-- is here is the surface: the row a reviewer moves to, the row the float marks, and the key
+-- they press.
+--
 -- The fixture is `mkcommits`, whose history is the whole point of it: a branch of four
 -- commits, one of them a merge, over a merge base that is not the oldest commit's parent.
 -- Both rules this file pins are invisible without it -- see the script's own header.
@@ -13,10 +17,12 @@ local h = require("tests.helpers")
 
 h.ui(110, 40)
 local fixture = h.cd_fixture("mkcommits")
+local root = assert(vim.uv.fs_realpath(fixture))
 
 require("codereview").setup({ syntax = false })
 
 local codereview = require("codereview")
+local state = require("codereview.state")
 local view = require("codereview.view")
 
 --- What git says, which is what the float is judged against ---------------------
@@ -55,6 +61,31 @@ end
 ---@return string[]
 local function lines(buf)
   return vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+end
+
+---The rows that stand for a commit: everything below the row that removes the trim.
+---@param buf integer
+---@return string[]
+local function commit_rows(buf)
+  local all = lines(buf)
+  return vim.list_slice(all, 2, #all)
+end
+
+---Which rows the float has marked, read off the column every row reserves for it.
+---
+---The column and not the glyph: what is being claimed is that one row is called out and the
+---rest are not, and naming the character would be this file reciting the implementation
+---back to itself.
+---@param buf integer
+---@return integer[] 1-based row numbers
+local function marked(buf)
+  local out = {}
+  for i, row in ipairs(lines(buf)) do
+    if row:sub(1, 1) ~= " " then
+      out[#out + 1] = i
+    end
+  end
+  return out
 end
 
 ---@param win integer
@@ -133,10 +164,17 @@ describe("gc inside a branch review", function()
   codereview.open()
   local review = assert(view.current(), "no review view opened")
   local win, buf = commits_by_key(review.win)
-  local rows = lines(buf)
+  local rows = commit_rows(buf)
 
   it("draws one row per commit on the branch's own line of work", function()
     assert.same(#first_parent, #rows, table.concat(rows, "\n"))
+  end)
+
+  -- The row that gives the whole branch back. It sits above the commits rather than below
+  -- them because it is the state the review opens in, and a reviewer removing a trim should
+  -- not have to walk a long branch to reach it.
+  it("puts the row that removes the trim above them all", function()
+    assert.is_truthy(lines(buf)[1]:find("All commits", 1, true), lines(buf)[1])
   end)
 
   it("lists them newest first", function()
@@ -193,8 +231,15 @@ describe("gc inside a branch review", function()
     assert.is_truthy(rows[#rows]:find("5 days ago", 1, true), rows[#rows])
   end)
 
-  it("opens the cursor on the first row", function()
+  -- With no trim in play the review starts at the merge base, which is what the top row
+  -- says -- so that is where the cursor belongs. The row it opens on with a trim *set* is
+  -- the case with teeth, and it is below.
+  it("opens the cursor on the row that removes the trim", function()
     assert.same(1, vim.api.nvim_win_get_cursor(win)[1])
+  end)
+
+  it("marks no row while the whole branch is in the review", function()
+    assert.same({}, marked(buf), table.concat(lines(buf), "\n"))
   end)
 
   it("says how many commits are listed", function()
@@ -241,26 +286,117 @@ describe("the keys on the float", function()
     assert.same(review, view.current())
   end)
 
-  -- Picking a row is a feature that is not built. What must not happen is `<CR>` doing
-  -- something *else* -- closing the float, or moving the review off the scope it is on.
-  it("picks nothing on <CR>", function()
+  -- Closing without applying: looking at the commit list has to be safe, so the two keys
+  -- that close it leave the review reading exactly what it was reading.
+  it("leaves the review on the scope it was on", function()
     local win = commits_by_key(review.win)
-    local scope = assert(view.current()).scope.name
-    h.feed("<CR>")
-    assert.is_true(vim.api.nvim_win_is_valid(win), "<CR> closed the float")
-    assert.same(scope, assert(view.current()).scope.name)
-    vim.api.nvim_win_close(win, true)
+    local label = assert(view.current()).scope.label
+    h.feed("q")
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+    assert.same(label, assert(view.current()).scope.label)
   end)
 
-  it("advertises the key that closes it, and nothing that does not work yet", function()
+  it("advertises both the key that applies a trim and the key that closes it", function()
     local win = commits_by_key(review.win)
     local footer = chrome(win, "footer")
     h.feed("q")
     assert.is_truthy(footer:find("q close", 1, true), footer)
-    assert.is_nil(footer:find("⏎", 1, true), footer)
+    assert.is_truthy(footer:find("⏎", 1, true), footer)
   end)
 
   codereview.close()
+end)
+
+--- Picking a row ----------------------------------------------------------------
+
+-- What a pick *resolves to* is `trim_spec`'s. What is here is that the key reaches it: the
+-- float closes, and the review behind it is reading something narrower than it was.
+describe("<CR> on a commit", function()
+  state.set_trim(root, nil)
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local before = review.scope.label
+  local files_before = #review.files
+
+  local win = commits_by_key(review.win)
+  -- The newest commit, which is the row directly under "All commits".
+  vim.api.nvim_win_set_cursor(win, { 2, 0 })
+  h.feed("<CR>")
+
+  it("closes the float", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+  end)
+
+  it("leaves the review open, and on the branch", function()
+    assert.same("branch", assert(view.current()).scope.name)
+  end)
+
+  it("draws the diff again, narrower than it was", function()
+    assert.is_true(#assert(view.current()).files < files_before)
+  end)
+
+  it("says on the label that the review is trimmed", function()
+    assert.are_not.same(before, assert(view.current()).scope.label)
+    assert.is_truthy(assert(view.current()).scope.label:find("last 1", 1, true))
+  end)
+end)
+
+-- Finding the row the trim starts at is the whole reason the cursor is placed at all, and a
+-- fresh window already opens on row one -- so this block sets a trim that is *not* the top
+-- row before it looks. Asserted from anywhere else, the case passes against a float that
+-- places the cursor nowhere.
+describe("the float opened with a trim already set", function()
+  local review = assert(view.current(), "the review closed")
+  local at = #first_parent -- the oldest commit, which is the last row of the listing
+  local win, buf = commits_by_key(review.win)
+  vim.api.nvim_win_set_cursor(win, { at + 1, 0 })
+  h.feed("<CR>")
+
+  local reopened, rebuf = commits_by_key(assert(view.current()).win)
+
+  it("really is trimmed to a row other than the first", function()
+    assert.is_true(at > 1, "the fixture has too few commits for this claim")
+    assert.is_truthy(assert(view.current()).scope.label:find(("last %d"):format(at), 1, true))
+  end)
+
+  it("marks the row the trim starts at, and only that one", function()
+    assert.same({ at + 1 }, marked(rebuf), table.concat(lines(rebuf), "\n"))
+  end)
+
+  it("marks the commit the reviewer picked", function()
+    local row = lines(rebuf)[at + 1]
+    assert.is_truthy(row:find(first_parent[at].subject, 1, true), row)
+  end)
+
+  it("opens the cursor on it", function()
+    assert.same(at + 1, vim.api.nvim_win_get_cursor(reopened)[1])
+  end)
+
+  h.feed("q")
+end)
+
+-- The top row and the last row mean the same review, and this is the surface a reviewer goes
+-- back through to say so.
+describe("<CR> on the row that removes the trim", function()
+  local review = assert(view.current(), "the review closed")
+  local win = commits_by_key(review.win)
+  vim.api.nvim_win_set_cursor(win, { 1, 0 })
+  h.feed("<CR>")
+  local after = assert(view.current())
+
+  it("gives the whole branch back", function()
+    assert.is_nil(after.scope.label:find("last", 1, true), after.scope.label)
+  end)
+
+  it("leaves nothing marked when the float is opened again", function()
+    local reopened, rebuf = commits_by_key(after.win)
+    assert.same({}, marked(rebuf), table.concat(lines(rebuf), "\n"))
+    assert.same(1, vim.api.nvim_win_get_cursor(reopened)[1])
+    h.feed("q")
+  end)
+
+  codereview.close()
+  state.set_trim(root, nil)
 end)
 
 --- From the file tree -----------------------------------------------------------
@@ -369,6 +505,41 @@ describe("gc on a branch with no commits of its own", function()
   vim.cmd("cd " .. vim.fn.fnameescape(here))
 end)
 
+--- One answer to where the branch starts ---------------------------------------
+
+-- The list is drawn against the review's own **scope** identity and never against a base
+-- worked out a second time. The two agree until something moves the default branch, which a
+-- `git fetch` in another window does -- and a list that re-derived would then be listing a
+-- branch the diff behind it is not reading.
+--
+-- The ref is moved onto the branch's own line of work, which is what pulls the merge base
+-- forward, and it is put back before the block ends.
+describe("the default branch moving under an open review", function()
+  local was = assert(h.git_lines(fixture, { "rev-parse", "master" })[1])
+  local onto = first_parent[#first_parent - 1].sha
+
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  h.git_lines(fixture, { "branch", "-f", "master", onto })
+
+  local _, buf = commits_by_key(review.win)
+  local rows = commit_rows(buf)
+  h.feed("q")
+
+  it("really did move the merge base out from under it", function()
+    local now = h.git_lines(fixture, { "merge-base", "master", "HEAD" })[1]
+    assert.are_not.same(base, now)
+    assert.is_true(#log({ "--first-parent", now .. "..HEAD" }) < #first_parent)
+  end)
+
+  it("lists the commits the review is reading, and not the ones the moved ref would give", function()
+    assert.same(#first_parent, #rows, table.concat(rows, "\n"))
+  end)
+
+  h.git_lines(fixture, { "branch", "-f", "master", was })
+  codereview.close()
+end)
+
 --- No cap ----------------------------------------------------------------------
 
 -- The oldest commits on a long branch have to stay reachable, which is the one thing this
@@ -385,7 +556,7 @@ describe("a branch longer than a capped list would show", function()
   codereview.open()
   local review = assert(view.current(), "no review view opened")
   local win, buf = commits_by_key(review.win)
-  local rows = lines(buf)
+  local rows = commit_rows(buf)
 
   it("grew the branch past any cap worth writing", function()
     assert.same(#first_parent + FILLER, #log({ "--first-parent", base .. "..HEAD" }))

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -1,0 +1,543 @@
+-- The **trim**: the commits taken off the start of a branch review.
+--
+-- Two halves, and the seams are the two that already exist. The first is scope resolution,
+-- where the ref arithmetic lives and where an error is invisible in a rendered diff -- the
+-- picked commit is in, the oldest row means the merge base and not a parent, and removing
+-- the trim gives the review back. The second is the review view, where everything a
+-- reviewer can see is: which files the diff draws, what the label says, which reviewed
+-- marks survived, what the queue still lists.
+--
+-- What is asserted is what a reviewer can observe. Never the shape of a git invocation, and
+-- never the shape of what the trim is stored in: a trim is set through the state module and
+-- read back through resolution, which is the same round trip `since-batch` makes through
+-- the archive.
+--
+-- The fixture is `mkcommits`, whose history is the point: its merge base is a different
+-- commit from its oldest listed commit's parent, so the oldest-row rule is observable at
+-- all -- see the script's own header.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+local fixture = h.cd_fixture("mkcommits")
+local root = assert(vim.uv.fs_realpath(fixture))
+
+local annotate = require("codereview.annotate")
+local codereview = require("codereview")
+local git = require("codereview.git")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+local NOTE = "a note written while the review was trimmed"
+
+codereview.setup({
+  compose = function(_, on_accept)
+    on_accept(nil, NOTE)
+  end,
+  send = function() end,
+})
+
+--- What git says, which is what the trim is judged against ----------------------
+
+local UNIT = "\31"
+
+local base = assert(h.git_lines(fixture, { "merge-base", "master", "HEAD" })[1], "no merge base")
+
+---The branch's own line of work, newest first.
+---@return { sha: string, subject: string }[]
+local function branch_log()
+  local out = {}
+  local fmt = "--format=%H" .. UNIT .. "%s"
+  for _, l in ipairs(h.git_lines(fixture, { "log", "--first-parent", fmt, base .. "..HEAD" })) do
+    local sha, subject = l:match("^(%S+)" .. UNIT .. "(.*)$")
+    out[#out + 1] = { sha = assert(sha, l), subject = subject }
+  end
+  return out
+end
+
+local commits = branch_log()
+
+---@param rev string
+---@return string
+local function full(rev)
+  return assert(h.git_lines(fixture, { "rev-parse", rev })[1], rev)
+end
+
+---@param rev string
+---@return string
+local function parent_of(rev)
+  return full(rev .. "^")
+end
+
+---The commit with that subject, and how many commits are kept by a trim starting at it.
+---
+---By subject rather than by index: which row of the listing a commit sits on moves the
+---moment anything below adds one, and every claim here is about a commit a reviewer would
+---recognise by what it says.
+---@param subject string
+---@return { sha: string, subject: string } commit, integer kept
+local function commit_named(subject)
+  for i, c in ipairs(commits) do
+    if c.subject == subject then
+      return c, i
+    end
+  end
+  error("no commit on this branch says " .. subject)
+end
+
+--- Reading a scope back ----------------------------------------------------------
+
+---Set the trim and resolve the branch scope through it, exactly as opening a review does.
+---@param before string|nil nil is no trim
+---@return CRFile[] files, CRScope scope
+local function under_trim(before)
+  state.set_trim(root, before)
+  local scope = assert(git.resolve_scope("branch", root))
+  local files = assert(git.collect(scope, root, {}))
+  return files, scope
+end
+
+---@param files CRFile[]
+---@return string[]
+local function paths(files)
+  return vim.tbl_map(function(f)
+    return f.path
+  end, files)
+end
+
+---@param files CRFile[]
+---@param path string
+---@return string|nil status nil when the scope does not hold that file at all
+local function status_of(files, path)
+  for _, f in ipairs(files) do
+    if f.path == path then
+      return f.status
+    end
+  end
+end
+
+--- The fixture the resolution rules lean on --------------------------------------
+
+describe("the history this spec reads", function()
+  it("puts four commits on the branch's own line of work", function()
+    assert.same(4, #commits, vim.inspect(commits))
+  end)
+
+  -- The reason the fixture's side branch is cut from master's tip: resolving the oldest row
+  -- is a rule about the merge base, and a history where the two are one commit cannot tell
+  -- the right answer from the wrong one.
+  it("keeps the merge base and the oldest commit's parent as different commits", function()
+    assert.are_not.same(base, parent_of(commits[#commits].sha))
+  end)
+end)
+
+--- Where a trim can start ---------------------------------------------------------
+
+describe("the commits a trim can start at", function()
+  local listed = assert(git.branch_commits(root, base))
+
+  it("offers one per commit on the branch's own line of work", function()
+    assert.same(#commits, #listed)
+  end)
+
+  -- The stored value is the *parent* of the picked commit, so the commit a reviewer picked
+  -- is in the diff and nothing has to be done to the ref at open time.
+  it("starts every commit but the oldest at that commit's own parent", function()
+    for i = 1, #listed - 1 do
+      assert.same(parent_of(listed[i].sha), full(listed[i].before), listed[i].subject)
+    end
+  end)
+
+  it("starts the oldest at the merge base, and not at its parent", function()
+    local oldest = listed[#listed]
+    assert.same(base, full(oldest.before))
+    assert.are_not.same(parent_of(oldest.sha), full(oldest.before))
+  end)
+end)
+
+--- What a trim resolves to --------------------------------------------------------
+
+describe("a trim starting at a commit part-way up the branch", function()
+  local picked, kept = commit_named("test: cover the config reader")
+  local files, scope = under_trim(parent_of(picked.sha))
+
+  -- The commit picked added `src/config_spec.lua`; the one before it added the host line to
+  -- `src/config.lua`. So the two files say which side of the pick each commit landed on.
+  it("puts the picked commit's own work in the diff", function()
+    assert.is_true(vim.tbl_contains(paths(files), "src/config_spec.lua"), vim.inspect(paths(files)))
+  end)
+
+  it("leaves the commit before it out", function()
+    assert.is_false(vim.tbl_contains(paths(files), "src/config.lua"), vim.inspect(paths(files)))
+  end)
+
+  it("says in its label how many commits are left", function()
+    assert.is_truthy(scope.label:find(("last %d"):format(kept), 1, true), scope.label)
+  end)
+
+  it("still names the branch it is a review of", function()
+    assert.is_truthy(scope.label:find("branch vs ", 1, true), scope.label)
+  end)
+end)
+
+describe("a trim starting at the oldest commit", function()
+  local listed = assert(git.branch_commits(root, base))
+  local files, scope = under_trim(listed[#listed].before)
+
+  it("reads from the merge base", function()
+    assert.same(base, scope.before)
+  end)
+
+  -- `src/lexer.lua` exists at the merge base and does not exist at the oldest commit's
+  -- parent, so a trim resolved to that parent draws it as a file the branch added rather
+  -- than as the change the branch made to it. The status is where the wrong ref shows.
+  it("shows the branch's change to a file the merge base already had", function()
+    assert.same("M", status_of(files, "src/lexer.lua"), vim.inspect(paths(files)))
+  end)
+
+  it("is the same review as the whole branch", function()
+    local whole = under_trim(nil)
+    assert.same(paths(whole), paths(files))
+  end)
+end)
+
+describe("no trim at all", function()
+  local files, scope = under_trim(nil)
+
+  it("reads from the merge base", function()
+    assert.same(base, scope.before)
+  end)
+
+  it("says nothing about a trim", function()
+    assert.is_nil(scope.label:find("last", 1, true), scope.label)
+  end)
+
+  it("holds every file the branch changed", function()
+    assert.same({ "README.md", "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }, paths(files))
+  end)
+end)
+
+describe("what a trim never moves", function()
+  local picked = commit_named("Merge branch 'lexer' into feature")
+  local _, trimmed = under_trim(parent_of(picked.sha))
+  local _, whole = under_trim(nil)
+
+  -- The one field the whole feature rests on. The pre-image moves under a trim and the
+  -- identity does not, which is what leaves the reviewed marks where the reviewer left them.
+  it("keeps the identity at the merge base, trimmed or not", function()
+    assert.same(base, trimmed.identity)
+    assert.same(whole.identity, trimmed.identity)
+  end)
+
+  it("really did move the pre-image, so that is a claim about two different refs", function()
+    assert.are_not.same(trimmed.before, trimmed.identity)
+  end)
+
+  it("leaves the post-image the working tree", function()
+    assert.is_nil(trimmed.after)
+  end)
+
+  it("keeps untracked work in the scope", function()
+    assert.is_true(trimmed.untracked)
+  end)
+end)
+
+describe("the scopes gs moves through", function()
+  it("holds the five named scopes and no sixth", function()
+    assert.same({ "branch", "staged", "unstaged", "worktree", "since-batch" }, git.SCOPES)
+  end)
+
+  it("is the same cycle under a trim as without one", function()
+    state.set_trim(root, nil)
+    local without = git.cycle(root)
+    state.set_trim(root, parent_of(commits[1].sha))
+    assert.same(without, git.cycle(root))
+    state.set_trim(root, nil)
+  end)
+end)
+
+--- The review a trim is applied inside --------------------------------------------
+
+-- The work the reviewer has not read yet: one commit on top of the branch, changing a file
+-- the branch's older commits had already changed. That overlap is what makes the two
+-- reviewed-mark rules different claims -- one file the new commit moved, one it did not.
+--
+-- The marks are made *before* it is committed, so the blob a mark records is the blob the
+-- commit then moves. A mark made afterwards would compare equal whatever the trim did.
+
+state.set_trim(root, nil)
+codereview.open()
+local V = assert(view.current(), "the review view did not open")
+
+---Mark the file at `path` reviewed in the open view.
+---@param path string
+local function toggle_reviewed_on(path)
+  local W = assert(view.current(), "no review view open")
+  local index = assert(h.file_index(W, path), path .. " is not in this scope")
+  vim.api.nvim_win_set_cursor(W.win, { W.render.file_rows[index], 0 })
+  view.toggle_reviewed()
+end
+
+toggle_reviewed_on("src/config.lua")
+toggle_reviewed_on("src/lexer.lua")
+local marked = { config = V.reviewed["src/config.lua"], lexer = V.reviewed["src/lexer.lua"] }
+
+vim.fn.writefile({
+  "local year = 2025",
+  "local strict = false",
+  "local depth = 3",
+}, vim.fs.joinpath(fixture, "src/lexer.lua"))
+h.git_lines(fixture, { "add", "-A" })
+h.git_lines(fixture, { "commit", "-q", "-m", "fix: loosen the lexer" })
+
+local UNREAD = "fix: loosen the lexer"
+
+---Open the commit list from the diff, put the cursor on the row that says `subject`, and
+---press `<CR>` -- which is the only way a reviewer ever applies a trim.
+---@param subject string "All commits" for the top row
+---@return integer win The float's window, which the pick should have closed
+local function trim_by_key(subject)
+  vim.api.nvim_set_current_win(assert(view.current()).win)
+  h.feed("gc")
+  local win = vim.api.nvim_get_current_win()
+  assert.are_not.same("", vim.api.nvim_win_get_config(win).relative, "gc opened no float")
+  local rows = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, -1, false)
+  local at
+  for i, row in ipairs(rows) do
+    if row:find(subject, 1, true) then
+      at = i
+      break
+    end
+  end
+  vim.api.nvim_win_set_cursor(win, { assert(at, subject .. " is on no row: " .. table.concat(rows, "\n")), 0 })
+  h.feed("<CR>")
+  return win
+end
+
+describe("the review the trim is applied in", function()
+  it("opened on the whole branch", function()
+    assert.same("branch", V.scope.name)
+    assert.same(4, #V.files, vim.inspect(paths(V.files)))
+  end)
+
+  it("recorded a mark against the blob each file had then", function()
+    assert.is_string(marked.config)
+    assert.is_string(marked.lexer)
+  end)
+
+  it("committed work that really did move one of those blobs and not the other", function()
+    local now = git.hash_worktree({ "src/config.lua", "src/lexer.lua" }, root)
+    assert.same(marked.config, now["src/config.lua"])
+    assert.are_not.same(marked.lexer, now["src/lexer.lua"])
+  end)
+end)
+
+describe("picking the commit the reviewer has not read", function()
+  local float = trim_by_key(UNREAD)
+  local W = assert(view.current(), "the review view closed")
+
+  it("closes the float", function()
+    assert.is_false(vim.api.nvim_win_is_valid(float))
+  end)
+
+  it("draws the diff again, from that commit forward", function()
+    assert.same({ "src/lexer.lua" }, paths(W.files))
+  end)
+
+  it("says on the winbar that the review is trimmed", function()
+    assert.is_truthy(h.winbar(W.win):find("last 1", 1, true), h.winbar(W.win))
+  end)
+
+  it("keeps the mark on the file the commit did not touch", function()
+    assert.same(marked.config, W.reviewed["src/config.lua"])
+  end)
+
+  it("drops the mark on the file it did", function()
+    assert.is_nil(W.reviewed["src/lexer.lua"])
+  end)
+
+  it("highlights the trimmed diff like any other review", function()
+    assert.is_true(#h.syntax_marks(W) > 0)
+  end)
+
+  it("navigates by hunk inside it", function()
+    vim.api.nvim_win_set_cursor(W.win, { 1, 0 })
+    view.jump("hunk", true)
+    assert.same("hunk", W.render.anchors[vim.api.nvim_win_get_cursor(W.win)[1]].kind)
+  end)
+
+  it("collapses a file inside it", function()
+    local rows = #W.render.lines
+    vim.api.nvim_win_set_cursor(W.win, { W.render.file_rows[1], 0 })
+    view.toggle_expand()
+    assert.is_true(#view.current().render.lines < rows)
+    view.toggle_expand()
+  end)
+
+  it("draws it in the split layout too", function()
+    view.toggle_layout()
+    local split = assert(view.current())
+    assert.is_true(split.before_win ~= nil and vim.api.nvim_win_is_valid(split.before_win))
+    assert.same(#split.render.lines, #split.before_render.lines)
+    view.toggle_layout()
+    assert.same("unified", view.current().layout)
+  end)
+end)
+
+-- The label is the only thing that stops a trim from being a trap, and the winbar it sits on
+-- is width-constrained and cut by the fit rule -- so what the trim adds to it has to be
+-- short enough to cost the bar nothing. The bar is padded to its pane by arithmetic, so a
+-- label that no longer fits shows up as a bar that is not its pane's width.
+describe("the label a trim adds", function()
+  local W = assert(view.current())
+  local was = vim.api.nvim_win_get_width(W.win)
+
+  it("is drawn in full on a pane with room for it", function()
+    local text, width = h.winbar(W.win)
+    assert.is_truthy(text:find("branch vs ", 1, true), text)
+    assert.is_truthy(text:find("last 1", 1, true), text)
+    assert.same(was, width)
+  end)
+
+  it("still lays the bar out on a pane too narrow for all of it", function()
+    vim.api.nvim_win_set_width(W.win, 50)
+    view.paint()
+    local narrow = vim.api.nvim_win_get_width(W.win)
+    assert.is_true(narrow < was, ("the pane did not narrow: %d"):format(narrow))
+    local _, width = h.winbar(W.win)
+    assert.same(narrow, width)
+    vim.api.nvim_win_set_width(W.win, was)
+    view.paint()
+  end)
+end)
+
+describe("uncommitted and untracked work under a trim", function()
+  vim.fn.writefile(
+    { "local cfg = require('config')", "assert(cfg.host)" },
+    vim.fs.joinpath(fixture, "src/config_spec.lua")
+  )
+  vim.fn.writefile({ "local loose = true" }, vim.fs.joinpath(fixture, "src/loose.lua"))
+  view.refresh()
+  local W = assert(view.current())
+
+  it("keeps the uncommitted change in the review", function()
+    assert.is_number(h.file_index(W, "src/config_spec.lua"), vim.inspect(paths(W.files)))
+  end)
+
+  it("keeps the untracked file in the review", function()
+    assert.same("U", status_of(W.files, "src/loose.lua"), vim.inspect(paths(W.files)))
+  end)
+
+  it("is still trimmed while it holds them", function()
+    assert.is_truthy(W.scope.label:find("last 1", 1, true), W.scope.label)
+  end)
+end)
+
+describe("annotating under a trim", function()
+  queue.clear()
+  local W = assert(view.current())
+  local index = assert(h.file_index(W, "src/lexer.lua"))
+  vim.api.nvim_win_set_cursor(W.win, { W.render.file_rows[index], 0 })
+  annotate.annotate("bug")
+  local trimmed = vim.deepcopy(assert(queue.all()[1], "nothing was captured under the trim"))
+
+  it("captures what it was aimed at", function()
+    assert.same({ "bug", "file", "src/lexer.lua", NOTE }, {
+      trimmed.type,
+      trimmed.kind,
+      trimmed.path,
+      trimmed.note,
+    })
+  end)
+
+  -- Ids apart, because they are issued in order and nothing else about an entry is. An
+  -- entry that recorded how the reviewer had narrowed their reading would differ here, and
+  -- nothing weaker than a comparison of the whole entry would notice.
+  it("produces the entry the same file produces with no trim at all", function()
+    trim_by_key("All commits")
+    queue.clear()
+    local X = assert(view.current())
+    local at = assert(h.file_index(X, "src/lexer.lua"))
+    vim.api.nvim_win_set_cursor(X.win, { X.render.file_rows[at], 0 })
+    annotate.annotate("bug")
+    local whole = vim.deepcopy(assert(queue.all()[1], "nothing was captured with the trim removed"))
+    trimmed.id, whole.id = nil, nil
+    assert.same(whole, trimmed)
+  end)
+end)
+
+describe("removing the trim", function()
+  local W = assert(view.current())
+
+  it("gives the whole branch back", function()
+    assert.is_number(h.file_index(W, "src/config.lua"), vim.inspect(paths(W.files)))
+  end)
+
+  it("says nothing about a trim on the winbar", function()
+    assert.is_nil(h.winbar(W.win):find("last", 1, true), h.winbar(W.win))
+  end)
+
+  -- The whole point of the identity: the mark was made before the trim, held through it,
+  -- and is still here afterwards.
+  it("still holds the mark the reviewer made before trimming", function()
+    assert.same(marked.config, W.reviewed["src/config.lua"])
+  end)
+
+  it("draws that file collapsed, which is what a reviewer sees of it", function()
+    assert.is_false(W.expanded["src/config.lua"])
+  end)
+end)
+
+describe("the queue under a trim", function()
+  queue.clear()
+  local W = assert(view.current())
+  local index = assert(h.file_index(W, "src/config.lua"))
+  vim.api.nvim_win_set_cursor(W.win, { W.render.file_rows[index], 0 })
+  annotate.annotate("bug")
+
+  trim_by_key(UNREAD)
+  local X = assert(view.current())
+
+  local msgs, restore = h.capture_notify()
+  view.review_queue()
+  restore()
+  local float = vim.api.nvim_get_current_win()
+  local rows = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(float), 0, -1, false)
+  h.feed("q")
+
+  it("really did take that file out of the review", function()
+    assert.is_nil(h.file_index(X, "src/config.lua"), vim.inspect(paths(X.files)))
+  end)
+
+  it("still holds the annotation", function()
+    assert.same(1, queue.count())
+  end)
+
+  it("still lists it in the float", function()
+    assert.is_truthy(table.concat(rows, "\n"):find(NOTE, 1, true), table.concat(rows, "\n"))
+  end)
+
+  it("says nothing about it being out of scope", function()
+    assert.is_false(h.notified(msgs, "scope"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "stale"), vim.inspect(msgs))
+  end)
+end)
+
+describe("cycling scope from a trimmed review", function()
+  it("goes to the next scope, with no stop of its own", function()
+    assert.same("branch", assert(view.current()).scope.name)
+    view.set_scope(nil)
+    assert.same("staged", assert(view.current()).scope.name)
+  end)
+
+  it("brings the trim back when the cycle returns to the branch", function()
+    view.set_scope(nil)
+    view.set_scope(nil)
+    view.set_scope(nil)
+    local W = assert(view.current())
+    assert.same("branch", W.scope.name)
+    assert.is_truthy(W.scope.label:find("last 1", 1, true), W.scope.label)
+  end)
+end)
+
+codereview.close()


### PR DESCRIPTION
A branch review shows every commit on the branch. That is correct on the first pass and
wrong on the second: the changes already read sit between the changes that have not been,
and a reviewed mark cannot help — a mark is per file, and one file is touched by old work
and new.

`gc` already listed the branch's commits. `<CR>` on a row now **trims** the review: it draws
again from that commit forward, and the scope label says so — `branch vs origin/master ·
last 4`.

## The rules this lands

- **The picked commit is in the diff.** What is stored is that commit's *parent*, so
  `before` needs no arithmetic at open time.
- **The oldest row resolves to the merge base**, not to that commit's parent. On a branch
  with merges those are different commits, and only the merge base means *all of it*. The
  top row, "All commits", means the same as the bottom one.
- **Resolution reads the trim itself** and keeps the two arguments it takes today, exactly
  as `since-batch` reads the archive. Handing the value in would put the one scope that
  needs it into every caller of scope resolution.
- **The identity stays at the merge base under every trim**, so the per-scope progress key
  does not move and a reviewer keeps the marks they made. Which of them are still true is
  the blob rule's answer, and no part of that path learns what a trim is.
- **`after` stays nil and `untracked` stays true**, which is what keeps uncommitted and
  untracked work in the review: a trim has one end, and it is the start.
- **The pick applies through `set_scope`** — the same entry point a scope change goes
  through, which already re-reads the diff, invalidates the syntax caches and seeds the
  progress table.
- **`gs` cycles the same five scopes.** The trim is a modifier, not a sixth scope.
- **No special rule for annotations, and no warning.** The queue float lists the whole queue
  with no scope involved, and reconciliation already judges only the files the current scope
  includes. A trim inherits both.

The trim lasts the session. Keeping it per branch, and dropping a stored one that no longer
points into the branch, is #141.

## One thing that changed underneath

`git.branch_commits` now takes the base it lists against instead of deriving one. There were
two answers to *where does this branch start* — the scope's identity, captured when the
scope was resolved, and a fresh `origin/HEAD` lookup on every `gc` — and they can disagree:
a `git fetch` in another window moves the default branch, and the list would then be drawn
against a base the review on screen is not reading. `trim_float_spec` moves the ref under an
open review and asserts the list did not follow.

## Tests

Two seams, both of which already existed. `trim_spec` carries the resolution rules and the
view behaviour; `trim_float_spec` gains the new row, the marked row, the cursor and the key.
`state_spec` built its progress key by hand out of `scope.before` — correct only while no
scope moves its pre-image, and silently wrong the moment one does; it now uses the identity.

`make all` is green: exit 0, no `Tests Failed`, 1528 cases.

Closes #140