### PR TITLE
feat(state): keep a trim per branch, and drop a rewritten one

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,9 @@ picks the oldest commit they still want to read, and the commits before it leave
 The word is subtractive, which is what the reviewer does: they remove commits from a whole
 that is there by default. "Trimmed to four commits" and "reset the trim" both read
 correctly, and the verb and the noun are one word. A trim has one end, and it is the start —
-so uncommitted and untracked work stay in the review under every trim. Said of a **branch**
+so uncommitted and untracked work stay in the review under every trim. Kept per branch, and
+dropped when its commit leaves the branch: a trim belongs to one reading of one branch, and a
+rewritten commit is not that reading. Said of a **branch**
 scope only: the working-tree scopes have no commits to take. A modifier on that scope and
 never a scope of its own, because a sixth name would have to answer what it means with
 nothing picked, and because `gs` is a key held down and must not get a new stop. Not

--- a/README.md
+++ b/README.md
@@ -83,7 +83,14 @@ you pick is **in** the diff. The top row of the list is "All commits", which giv
 branch back, and so does the bottom row. Uncommitted and untracked work stay in the review
 under every trim, because a trim has one end and it is the start. Your reviewed marks survive
 one: a file the commits you dropped never changed keeps its mark, and a file that has moved
-since you marked it loses one whether you trimmed or not. The trim lasts for the session.
+since you marked it loses one whether you trimmed or not.
+
+**A trim is kept for the branch**, so the next session opens where your reading stopped, and
+each branch keeps its own — trimming one says nothing about another. It is checked before it
+is used: a rebase, an amend or a force-push leaves it naming a commit the branch no longer
+holds, and then it is dropped, the full branch opens, and a sentence says the trim was lost.
+On a detached `HEAD` there is no branch name to keep it under, so the trim works for the
+session and one message says it is not kept.
 
 **`since-batch` is the one to reach for while an agent is working.** Submitting records a
 snapshot of the working tree, and this scope diffs against it — so what you get is the
@@ -741,7 +748,8 @@ and the cursor opens on it — on "All commits" while the whole branch is in the
 
 Two cases open nothing and say why in one sentence: `gc` outside a branch review, where
 there is no branch behind the diff to list, and `gc` on a branch whose `HEAD` is the merge
-base, which has no commits of its own.
+base, which has no commits of its own. A third opens and works: on a detached `HEAD` the
+list is there and the trim applies, and one message says it is not kept.
 
 ## Configuration
 

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -262,6 +262,17 @@ recomputed from `origin/HEAD` a second time: a `git fetch` in another window mov
 branch, and a surface that re-derives the base then draws against a base the review is not
 using. That is why `git.branch_commits` takes the base and no longer resolves one.
 
+**A stored trim is checked on every read, and dropping it is what keeps the sentence to one.**
+The two tempting shortcuts are one shortcut: memoise the branch's trim for the session, and
+latch the sentence beside it. The memo is wrong because a reviewer can rebase in another
+window with the review open — the trim then names a commit that was rewritten, and resolution
+reads it from memory without ever asking `HEAD` about it again, which is the exact failure the
+check exists to refuse. The latch is unnecessary once the failing trim is removed from the
+document as well as from the answer: the next read finds nothing to fail, so the sentence
+cannot repeat, and there is no key to invalidate when the reviewer moves to another branch.
+What it costs is a `symbolic-ref` and a document read per branch resolve, which is what
+`state.restore` already spends on every scope change.
+
 **Keying progress on the pre-image fails silently rather than loudly.** The per-scope progress
 key is `name .. ":" .. identity`. Spelled with `before` it agrees with the plugin for every
 scope that carries no trim, so it reads correctly everywhere until a trimmed branch review is

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -31,7 +31,7 @@ change there is felt through.
 | `queue.lua` | The queue itself — module-level, not per-view, so reopening a view scatters nothing | stateful (memory) |
 | `queue_float.lua` | The float over the queue: an entry as a run of bar-marked rows, and the keys that drop, jump, copy and submit | stateful (float) |
 | `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named, and how a winbar is assembled from typed segments | pure |
-| `state.lua` | Persisted review progress, and the blob comparisons over it — staleness, and touchedness kept in a function of its own | stateful (disk) |
+| `state.lua` | Persisted review progress, the blob comparisons over it — staleness, and touchedness kept in a function of its own — and each branch's **trim**, checked against `HEAD` before it is handed back | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `trim_float.lua` | The float over the branch's commits: the first-parent listing from the base handed in, one row per commit, the row a **trim** starts at, and the pick that applies one | stateful (float) |
 | `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
@@ -59,9 +59,12 @@ Forcing the two apart costs more than it returns.
 
 `git` and `state` are the second, and much the smaller: `state` mints a snapshot and hashes
 blobs through `git`, and `git` reads the newest snapshot back out of the archive to resolve
-the `since-batch` scope. Function-local on both sides, as above. The alternative is handing
-the snapshot in from outside, which would put the one scope that needs it into every caller
-of `resolve_scope` — and scope resolution is exactly what must stay one function.
+the `since-batch` scope. The **trim** rides the same edge in both directions — `git` reads the
+branch's stored trim to resolve `branch`, and `state` asks `git` which branch that is and
+whether `HEAD` still descends from what it stored. Function-local on both sides, as above. The
+alternative is handing the snapshot in from outside, which would put the one scope that needs
+it into every caller of `resolve_scope` — and scope resolution is exactly what must stay one
+function.
 
 `delivery` and `composer` are the third, and the smallest. A **preamble** is composed at
 submit time, so the submit has to reach whichever composer is wired — and the plugin's own

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -95,6 +95,25 @@ function M.merge_base(a, b, root)
   return line({ "merge-base", a, b }, root)
 end
 
+---Whether `HEAD` still descends from `commit`.
+---
+---What a stored **trim** is checked with before a review reads from it. A rebase, an amend
+---and a force-push all end in the same place: the commit the trim was picked off is not in
+---this branch any more, and a diff against one of those is a diff nobody asked for.
+---
+---One answer out of two failures, deliberately. `merge-base --is-ancestor` exits 1 when the
+---commit is real and off this line of work, and 128 when the repository has nothing under
+---that name at all -- which is what a `git gc` after a rebase leaves a stored trim naming.
+---Both mean *not a commit this review can read from*, and the reviewer has one thing to be
+---told either way. The exit code is the whole answer, so an empty stdout is a yes here and
+---only `nil` is a no.
+---@param commit string
+---@param root string
+---@return boolean
+function M.is_ancestor(commit, root)
+  return run({ "merge-base", "--is-ancestor", commit, "HEAD" }, { cwd = root }) ~= nil
+end
+
 ---How many commits `from` is behind `HEAD` on the branch's own line of work.
 ---
 ---What the scope label reports as `last N`, derived rather than remembered: a reviewer who
@@ -248,9 +267,9 @@ function M.resolve_scope(spec, root)
     -- The **trim**, read here rather than taken as an argument -- the shape `since-batch`
     -- already has, and for the reason recorded for it: handing the value in would put the
     -- one scope that needs it into every caller of scope resolution, and scope resolution
-    -- is exactly what has to stay one function. A trim naming a commit this repository does
-    -- not have is not a trim, and the whole branch is the answer; saying so out loud belongs
-    -- with the trim that outlives a session, which is where a rewritten commit can reach.
+    -- is exactly what has to stay one function. What comes back is already checked: the
+    -- store drops a trim `HEAD` no longer descends from and says so, so a commit this
+    -- repository cannot read from never reaches the arithmetic below.
     local trim = require("codereview.state").trim(root)
     local kept = trim and M.count_commits(trim, root)
 

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -77,7 +77,7 @@ end
 function M.load(root)
   local file = M.path(root)
   if vim.fn.filereadable(file) == 0 then
-    return { version = VERSION, scopes = {}, queue = {}, archive = {} }
+    return { version = VERSION, scopes = {}, queue = {}, archive = {}, trims = {} }
   end
   local ok, decoded = pcall(function()
     return vim.json.decode(table.concat(vim.fn.readfile(file), "\n"), {
@@ -88,14 +88,17 @@ function M.load(root)
     -- A corrupt or older file is discarded rather than migrated: the cost of losing
     -- review progress is far lower than the cost of restoring marks that mean something
     -- different than they did when written.
-    return { version = VERSION, scopes = {}, queue = {}, archive = {} }
+    return { version = VERSION, scopes = {}, queue = {}, archive = {}, trims = {} }
   end
   decoded.scopes = decoded.scopes or {}
   decoded.queue = decoded.queue or {}
   -- A document written before the archive existed lacks the key entirely, and defaulting
   -- it here is the whole of what it takes to read one: nothing about the marks stored
-  -- beside it means anything different than it did.
+  -- beside it means anything different than it did. The **trims** arrived the same way,
+  -- for the same reason -- a bump would throw away every reviewed mark in the file to add
+  -- a key those files simply lack.
   decoded.archive = decoded.archive or {}
+  decoded.trims = decoded.trims or {}
   return decoded
 end
 
@@ -234,30 +237,94 @@ end
 
 --- The trim ---------------------------------------------------------------------
 
----The **trim** on each repository's branch review: the ref the review reads from, which is
----the parent of the oldest commit the reviewer still wants to read.
+---The **trim** on a branch's review: the ref the review reads from, which is the parent of
+---the oldest commit the reviewer still wants to read.
 ---
 ---A ref rather than a count or a commit, because that is what a scope needs: `before` has to
 ---be something the diff, the blob hashing and the highlighter's whole-file fetch can all
 ---read content out of, and none of them can read a marker. It is the *parent* of the picked
 ---commit, so the commit picked is in the diff and the ref needs no arithmetic at open time.
 ---
----**Session-only, and per process.** Keeping a trim across restarts is a feature of its own:
----a stored trim has to be checked against `HEAD` before it is used, because a rebase, an
----amend or a force-push leaves it pointing at a commit that was rewritten, and resolving
----against one of those silently is worse than opening the whole branch.
-local trims = {}
+---**Kept in the state document, keyed by branch name**, beside the reviewed marks it is a
+---review of. A review spans days, so a reviewer who trimmed on Monday opens the same branch
+---on Tuesday where their reading stopped. Keyed by the branch rather than by the repository
+---because two branches are two readings: trimming one says nothing about the other.
+---
+---The sentences below are said here, which is the one place in this module that says
+---anything. Both are about the **store** and nothing above it can see either fact -- by the
+---time a scope is resolved the trim is either usable or gone -- and saying them here is also
+---what keeps one sentence one sentence: the surfaces that read a trim are the review and the
+---commit list, and a rule copied into both is a rule that says it twice.
+---@param msg string
+local function info(msg)
+  vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
 
+---A trim set while `HEAD` is detached, which has no branch name to key on.
+---
+---It works for the session and reaches no document, because there is nothing to file it
+---under: the next session may be anywhere. Keyed by root, which is all there is.
+local session_trims = {}
+
+---Roots already told that a detached `HEAD` keeps no trim.
+---
+---Said once, when a trim is set. Of the three cases where a trim is refused or limited this
+---is the only one a reviewer could take for a defect -- the other two say what they refused
+---at the moment they refuse it, and this one refuses nothing until the session ends.
+local said_detached = {}
+
+---@param root string
+---@param branch string
+---@param before string|nil nil removes it
+local function store_trim(root, branch, before)
+  local data = M.load(root)
+  data.trims = data.trims or {}
+  data.trims[branch] = before
+  M.save(root, data)
+end
+
+---The branch's trim, checked before it is handed back.
+---
+---**The check is the point of storing it at all.** The commit has to still be one `HEAD`
+---descends from; a rebase, an amend or a force-push leaves it naming a commit that was
+---rewritten, and a review that quietly resolves against one of those is worse than no trim.
+---A trim that fails is dropped from the document as well as from this answer, which is what
+---makes the sentence a reviewer reads a single sentence rather than one per resolve: there
+---is nothing left to fail the next time.
+---
+---Checked on every read rather than once per session, because the history can be rewritten
+---while a review is open -- a reviewer rebases in another window and comes back to the diff.
 ---@param root string
 ---@return string|nil before nil when the whole branch is in the review
 function M.trim(root)
-  return trims[root]
+  local git = require("codereview.git")
+  local branch = git.current_branch(root)
+  if not branch then
+    return session_trims[root]
+  end
+
+  local stored = (M.load(root).trims or {})[branch]
+  if not stored or git.is_ancestor(stored, root) then
+    return stored
+  end
+  store_trim(root, branch, nil)
+  info("The trim was lost — its commit is not in this branch any more, so the full branch is open")
+  return nil
 end
 
 ---@param root string
 ---@param before string|nil nil removes the trim
 function M.set_trim(root, before)
-  trims[root] = before
+  local branch = require("codereview.git").current_branch(root)
+  if not branch then
+    session_trims[root] = before
+    if before and not said_detached[root] then
+      said_detached[root] = true
+      info("HEAD is detached — this trim is not kept for the next session")
+    end
+    return
+  end
+  store_trim(root, branch, before)
 end
 
 --- The archive ------------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/quiet_child.lua` | Spawned eight times by `quiet_spec`, one painted cell each, where two quiet states meet — deliberately not a spec. |
 | `codereview/drafts_child.lua` | Spawned by `drafts_spec` to abandon a half-written note and exit — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
+| `codereview/trim_child.lua` | Spawned twice by `trim_spec` — once to trim two branches and exit, once to report what a later session's branch review holds — deliberately not a spec. |
 | `codereview/winbar_child.lua` | Spawned four times by `split_spec` to read one cell of a pane's winbar — three inside the path for the muting, one on the file's added count for the colour — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
 
@@ -68,7 +69,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colours one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
-| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — the picked commit in the diff, the oldest row at the merge base, the identity that does not move with the pre-image, the label — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, and where `gs` goes from it |
+| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — the picked commit in the diff, the oldest row at the merge base, the identity that does not move with the pre-image, the label — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, and where `gs` goes from it; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
 | `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the row that removes the trim, the row a trim is marked on, the cursor's opening row, the keys, `gc` from the diff and from the tree, and the two refusals that open nothing |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
@@ -108,7 +109,11 @@ interchangeable, and the assertions know which one they are looking at.
   in as a row of its own, and the merge base is a different commit from the oldest listed
   commit's parent, which is what resolving the oldest row has to notice. Its commits are
   dated days apart, as offsets back from the moment the script runs, so a relative date on
-  a row is a fact a spec can check and never goes stale.
+  a row is a fact a spec can check and never goes stale. `trim_spec` builds a **second copy**
+  for the trim a restart brings back, and cuts a `second` branch at `feature`'s tip inside
+  it: two branches over one history is what "each branch keeps its own trim" needs, and
+  neither branch the script builds can offer it — `lexer` has one commit of its own, so
+  every trim on it resolves to the merge base, which is the review it already was.
 - **`mkbig.sh`** — files of a given size, half of every file rewritten. It takes counts as
   well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and 200), so a caller
   asks for the height it needs rather than for a second script. `perf.lua` builds a 60-file,
@@ -596,14 +601,23 @@ so the out-of-core language path is still checked locally without ever failing C
   the *oldest* row and only then reopens the float: deleting the `nvim_win_set_cursor` in
   `trim_float.lua` reds that block and nothing else in the suite. Same trap as "a filter test
   needs a fixture only that filter can reject".
-- **A trim is a hidden input to branch scope resolution, and every claim about one runs
-  through the same module-level store.** `git.resolve_scope("branch", …)` reads
-  `state.trim(root)`, which is per process and never written to disk, so a spec that sets one
-  and does not clear it hands it to every block below — including blocks that open a review
-  and expect the whole branch. `trim_spec` and `trim_float_spec` both reset it at the seams
-  between their halves. Eight other call sites resolve `branch` with nothing set, and each
-  spec process gets a state directory of its own, so they stay correct — but a `branch` scope
-  behaving oddly should send the reader to the stored trim before anywhere else.
+- **A trim is a hidden input to branch scope resolution, and it now reaches the disk.**
+  `git.resolve_scope("branch", …)` reads `state.trim(root)`, which reads the repository's
+  state document keyed by the branch checked out at that moment — so a spec that sets one and
+  does not clear it hands it to every block below, *and* to any child process sharing the
+  state directory, including blocks and children that open a review and expect the whole
+  branch. `trim_spec` and `trim_float_spec` both reset it at the seams between their halves.
+  Eight other call sites resolve `branch` with nothing set, and each spec process gets a state
+  directory and a fixture of its own, so they stay correct — but a `branch` scope behaving
+  oddly should send the reader to the stored trim before anywhere else.
+- **"The trim was not written" cannot be read off a detached `HEAD` alone.** A trim set while
+  `HEAD` is detached is kept in memory and never filed, and it is also never *read* from the
+  document — so a later process opening the same detached checkout finds the whole branch
+  whether or not anything was written. `trim_spec` spawns `trim_child.lua` in `read` mode for
+  the claim a reviewer can see, which is that the session after this one opens the full
+  branch; that has teeth against the implementation worth fearing, a trim filed under the
+  root when there is no branch to file it under. Asserting the document's own shape instead
+  would pin the store rather than the behaviour, which no spec in this suite does.
 - **Two entries of different types are separated by a group, not by a row.** The queue
   float's boundary between entries is one blank row carrying no bar, and an assertion about
   it needs two entries of the *same* annotation type — give them different ones and what

--- a/tests/README.md
+++ b/tests/README.md
@@ -610,6 +610,14 @@ so the out-of-core language path is still checked locally without ever failing C
   Eight other call sites resolve `branch` with nothing set, and each spec process gets a state
   directory and a fixture of its own, so they stay correct — but a `branch` scope behaving
   oddly should send the reader to the stored trim before anywhere else.
+- **"The full branch opened" cannot red on its own for a trim naming a commit that is gone.**
+  The store drops such a trim and says so, but `resolve_scope` also refuses a count it cannot
+  take — the guard #140 left — so the whole branch opens whether or not anything checked the
+  trim. `trim_spec` keeps that case because it is the claim a reviewer can see; the teeth are
+  in the sentence beside it, which reds the moment the check goes. Measured: deleting the
+  check reds the sentence alone, and deleting the check *and* the count guard reds both. Same
+  shape as "the commit list's opening row can only be measured from a row that is not the
+  top".
 - **"The trim was not written" cannot be read off a detached `HEAD` alone.** A trim set while
   `HEAD` is detached is kept in memory and never filed, and it is also never *read* from the
   document — so a later process opening the same detached checkout finds the whole branch

--- a/tests/codereview/trim_child.lua
+++ b/tests/codereview/trim_child.lua
@@ -1,0 +1,82 @@
+-- The second process every claim about a kept **trim** needs, in its two directions: a
+-- Neovim that trims two branches and exits, and a Neovim that opens a branch review and
+-- reports what is in it.
+--
+-- Deliberately a separate process, for the reason state_child is one: a trim that outlives
+-- a session is a claim about what reached the disk, and reading it back in the process that
+-- set it proves nothing about that.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- trim_spec with XDG_STATE_HOME, FIXTURE and MODE in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+local mode = assert(vim.env.MODE, "MODE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+require("codereview").setup({ syntax = false })
+
+local view = require("codereview.view")
+
+---@param args string[]
+local function git(args)
+  local res = vim.system(vim.list_extend({ "git" }, args), { cwd = fixture, text = true }):wait()
+  assert(res.code == 0, table.concat(args, " ") .. ": " .. (res.stderr or ""))
+end
+
+---@param keys string
+local function feed(keys)
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, false, true), "x", false)
+end
+
+---@return string[]
+local function paths()
+  return vim.tbl_map(function(f)
+    return f.path
+  end, assert(view.current(), "no review view open").files)
+end
+
+---Trim the open review to the row that says `subject`, exactly as a reviewer does it: `gc`
+---in the diff, the cursor on that row, `<CR>`.
+---@param subject string
+local function trim_by_key(subject)
+  vim.api.nvim_set_current_win(assert(view.current(), "no review view open").win)
+  feed("gc")
+  local win = vim.api.nvim_get_current_win()
+  assert(vim.api.nvim_win_get_config(win).relative ~= "", "gc opened no float")
+  local rows = vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, -1, false)
+  for i, row in ipairs(rows) do
+    if row:find(subject, 1, true) then
+      vim.api.nvim_win_set_cursor(win, { i, 0 })
+      feed("<CR>")
+      return
+    end
+  end
+  error(subject .. " is on no row of the commit list:\n" .. table.concat(rows, "\n"))
+end
+
+view.open("branch")
+
+if mode == "read" then
+  -- What a reviewer opening this repository again would be looking at. Printed rather than
+  -- asserted here: the spec owns the expectations, and `nvim -l` sends this to stderr.
+  print("paths: " .. table.concat(paths(), ","))
+else
+  -- Two branches over one history, trimmed to two different commits. Which is what says a
+  -- trim belongs to the branch rather than to the repository -- with one trim between them
+  -- the two branches cannot be told apart.
+  trim_by_key("docs: write the readme")
+  git({ "checkout", "-q", "second" })
+  -- The branch under the review changed, so the review is resolved again -- the same entry
+  -- point `gs` back onto the branch goes through.
+  view.set_scope("branch")
+  trim_by_key("test: cover the config reader")
+  -- Left where a reviewer left it, so the process that reads this back opens the branch it
+  -- was reading rather than whichever one this one finished on.
+  git({ "checkout", "-q", "feature" })
+  print("state file: " .. require("codereview.state").path(assert(view.current()).root))
+end
+
+vim.cmd("qa!")

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -541,3 +541,202 @@ describe("cycling scope from a trimmed review", function()
 end)
 
 codereview.close()
+
+--- The trim a session leaves behind -----------------------------------------------
+
+-- Everything below is about what reached the disk, which no assertion made in the process
+-- that wrote it can settle -- the same reason `state_spec` is two processes. `trim_child`
+-- trims, exits, and this process reads the branch back.
+--
+-- A second copy of the fixture, because the one above has been committed into and trimmed
+-- through by every block in this file: a claim about what a *fresh* repository's store
+-- hands back must not be answerable out of what this process already did to it.
+local kept = h.fixture("mkcommits")
+local kept_root = assert(vim.uv.fs_realpath(kept))
+local kept_base = assert(h.git_lines(kept, { "merge-base", "master", "HEAD" })[1], "no merge base")
+
+-- The second branch, cut at the first one's tip: two readings of the same commits, which is
+-- what "each branch keeps its own" needs and what neither branch in the fixture can offer.
+-- `lexer` has one commit of its own, so every trim on it resolves to the merge base -- which
+-- is the review it already was, and says nothing about anything.
+h.git_lines(kept, { "branch", "second" })
+
+-- The whole branch, as the fixture's own commits leave it. Written out rather than derived,
+-- because it is what "the full branch opened" means below.
+local WHOLE = { "README.md", "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }
+
+---Run a Neovim of its own over the kept fixture, sharing this process's throwaway
+---`XDG_STATE_HOME` and nothing else. `--clean` so no user config, and no minimal_init, can
+---hand it a state directory of another.
+---@param mode "write"|"read"
+---@return vim.SystemCompleted
+local function spawn(mode)
+  local proc = vim.system({
+    vim.v.progpath,
+    "--clean",
+    "-l",
+    vim.fs.joinpath(h.root, "tests", "codereview", "trim_child.lua"),
+  }, {
+    cwd = kept,
+    text = true,
+    env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = kept, MODE = mode },
+  })
+  return proc:wait(60000)
+end
+
+---Check a branch out and resolve the review over it again, which is what a reviewer coming
+---back to a branch does.
+---@param name string
+local function checkout(name)
+  h.git_lines(kept, { "checkout", "-q", name })
+  view.set_scope("branch")
+end
+
+local writer = spawn("write")
+
+describe("the process that trimmed two branches", function()
+  it("exits cleanly", function()
+    assert.same(0, writer.code, (writer.stderr or "") .. (writer.stdout or ""))
+  end)
+end)
+
+vim.cmd("cd " .. vim.fn.fnameescape(kept))
+codereview.open()
+
+describe("a branch trimmed in the session before", function()
+  local W = assert(view.current(), "the review view did not open on the kept fixture")
+
+  it("opens where the reading stopped, and not on the whole branch", function()
+    assert.same({ "README.md" }, paths(W.files))
+  end)
+
+  it("says on the winbar that the review is trimmed", function()
+    assert.is_truthy(h.winbar(W.win):find("last 1", 1, true), h.winbar(W.win))
+  end)
+end)
+
+describe("the other branch over the same commits", function()
+  checkout("second")
+  local W = assert(view.current())
+
+  it("opens at its own trim and not at the first branch's", function()
+    assert.same({ "README.md", "src/config_spec.lua", "src/lexer.lua" }, paths(W.files))
+  end)
+
+  it("counts its own commits on the winbar", function()
+    assert.is_truthy(h.winbar(W.win):find("last 3", 1, true), h.winbar(W.win))
+  end)
+end)
+
+describe("the first branch checked out again", function()
+  checkout("feature")
+
+  it("brings its own trim back, untouched by the branch beside it", function()
+    assert.same({ "README.md" }, paths(assert(view.current()).files))
+  end)
+end)
+
+-- A rebase, an amend and a force-push all end in one place: the commit the trim was picked
+-- off is no longer in `HEAD`'s history. A squash is the shortest way to put a fixture there,
+-- and it leaves the merge base where it was, so the full branch is the branch it always was.
+describe("a branch whose commits were rewritten under its trim", function()
+  h.git_lines(kept, { "checkout", "-q", "second" })
+  h.git_lines(kept, { "reset", "--soft", kept_base })
+  h.git_lines(kept, { "commit", "-q", "-m", "feat: the branch, rebased into one commit" })
+
+  local msgs, restore = h.capture_notify()
+  view.set_scope("branch")
+  restore()
+  local W = assert(view.current())
+
+  it("opens the full branch", function()
+    assert.same(WHOLE, paths(W.files))
+  end)
+
+  it("says the trim was lost", function()
+    assert.is_true(h.notified(msgs, "trim was lost"), vim.inspect(msgs))
+  end)
+
+  it("says nothing about a trim on the winbar", function()
+    assert.is_nil(h.winbar(W.win):find("last", 1, true), h.winbar(W.win))
+  end)
+
+  -- Scope resolution runs on every open, every scope change and every trim, and a sentence
+  -- a reviewer meets on each of them is noise.
+  it("says it once, and not again on the next resolve", function()
+    local again, stop = h.capture_notify()
+    view.set_scope("branch")
+    stop()
+    assert.is_false(h.notified(again, "trim was lost"), vim.inspect(again))
+    assert.same(WHOLE, paths(assert(view.current()).files))
+  end)
+end)
+
+describe("the branch beside the one that was rewritten", function()
+  checkout("feature")
+
+  it("kept its own trim through the other branch's rewrite", function()
+    assert.same({ "README.md" }, paths(assert(view.current()).files))
+  end)
+end)
+
+-- What a `git gc` after a rebase leaves behind, and the one case no session can reach on its
+-- own: the commit was there when the trim was picked and this repository has nothing under
+-- that name now. One fact for the reviewer, so one sentence -- the same one.
+describe("a stored trim naming a commit this repository does not have", function()
+  local msgs, restore = h.capture_notify()
+  state.set_trim(kept_root, ("0"):rep(40))
+  view.set_scope("branch")
+  restore()
+
+  it("opens the full branch", function()
+    assert.same(WHOLE, paths(assert(view.current()).files))
+  end)
+
+  it("says the trim was lost, in the sentence a rewritten commit says", function()
+    assert.is_true(h.notified(msgs, "trim was lost"), vim.inspect(msgs))
+  end)
+end)
+
+describe("a trim on a detached HEAD", function()
+  -- Set from a known state rather than from whatever the block above left: this branch has
+  -- no trim, so nothing below can be satisfied by one that was already there.
+  state.set_trim(kept_root, nil)
+  h.git_lines(kept, { "checkout", "-q", "--detach", "feature" })
+  view.set_scope("branch")
+
+  local msgs, restore = h.capture_notify()
+  trim_by_key("docs: write the readme")
+  restore()
+
+  it("trims the review, so the feature is not simply absent", function()
+    assert.same({ "README.md" }, paths(assert(view.current()).files))
+  end)
+
+  it("says the trim is not kept", function()
+    assert.is_true(h.notified(msgs, "not kept"), vim.inspect(msgs))
+  end)
+
+  it("says it once, and not again on the next trim", function()
+    local again, stop = h.capture_notify()
+    trim_by_key("test: cover the config reader")
+    stop()
+    assert.is_false(h.notified(again, "not kept"), vim.inspect(again))
+    assert.same({ "README.md", "src/config_spec.lua", "src/lexer.lua" }, paths(assert(view.current()).files))
+  end)
+
+  -- The claim a reviewer can see: the session after this one opens the whole branch.
+  local reader = spawn("read")
+
+  it("is gone in the session after it", function()
+    local out = (reader.stdout or "") .. (reader.stderr or "")
+    assert.is_truthy(out:find("paths: " .. table.concat(WHOLE, ","), 1, true), out)
+  end)
+
+  it("never became the trim of the branch that was checked out", function()
+    checkout("feature")
+    assert.same(WHOLE, paths(assert(view.current()).files))
+  end)
+end)
+
+codereview.close()


### PR DESCRIPTION
The last slice of #137. A **trim** moves out of a module-local table and into the
repository's state document, keyed by branch name, beside the reviewed marks.

- **Kept per branch.** A reviewer who trimmed on Monday opens the same branch on Tuesday
  where their reading stopped, and each branch keeps its own — trimming one says nothing
  about another. `gs` away to another scope and back still brings it with it, because the
  trim still lives outside the view.
- **Checked before it is used.** The stored commit has to be one `HEAD` still descends from.
  A rebase, an amend, a force-push and a `git gc` after any of them all leave it naming a
  commit this branch cannot read from, and all of them get one answer: the trim is dropped,
  the full branch opens, and one sentence says the trim was lost. That folds in the case #140
  deliberately left silent — a trim naming a commit this repository does not have — rather
  than adding a second sentence that says nearly the same thing.
- **Dropped rather than latched.** Removing the failing trim from the document is what keeps
  that sentence to one: the next resolve finds nothing left to fail, so no latch has to be
  keyed or invalidated. The check itself runs on every read, because a reviewer can rebase in
  another window with the review open.
- **A detached `HEAD`** has no branch name to file a trim under. It works for the session,
  reaches no document, and one message says so when it is set — of the three cases where a
  trim is refused or limited, the only one that could be taken for a defect if it stayed
  silent.

Scope resolution keeps the two arguments it takes today and reads the trim itself, as it
reads the archive for `since-batch`; `state` asks `git` which branch is checked out and
whether `HEAD` descends from what it stored, over the function-local requires the `git`↔`state`
cycle already uses.

Ten new cases in `trim_spec`, over a second copy of `mkcommits` and a second process
(`trim_child.lua`): the restart, the two branches, the rewritten commit and its sentence, and
the detached `HEAD` that trims for the session and is gone in the session after. `make all`
is green — 1546 cases, exit 0, no `Tests Failed`.

Closes #141