### PR TITLE
docs: restructure the README and spell American throughout

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,7 +23,7 @@ body:
     id: proposal
     attributes:
       label: What you have in mind
-      description: The behaviour you want, including keys, commands or config if relevant.
+      description: The behavior you want, including keys, commands or config if relevant.
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,6 @@ README this touches. Delete if there is nothing.
 ## Checklist
 
 - [ ] `make all` passes (lint + suite).
-- [ ] New behaviour has a spec under `tests/codereview/`.
-- [ ] `README.md` and `doc/codereview.txt` updated, if user-facing behaviour changed.
+- [ ] New behavior has a spec under `tests/codereview/`.
+- [ ] `README.md` and `doc/codereview.txt` updated, if user-facing behavior changed.
 - [ ] Commits follow Conventional Commits (`make hooks` validates them).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Anything with a feature or design decision behind it runs through the skill chai
 in order. Do not skip to code.
 
 1. **`/to-spec`** — synthesises the conversation into a spec and publishes it to the issue
-   tracker (a GitHub issue here) labelled `ready-for-agent`. It does not interview; it
+   tracker (a GitHub issue here) labeled `ready-for-agent`. It does not interview; it
    works from what has already been discussed, so do that discussion first. It stops once
    on the way to put its test seams to you.
 2. **`/to-tickets`** — breaks the spec into **tickets**: tracer-bullet vertical slices, each

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,12 +47,12 @@ _side_: a diff line's side is already add/del/ctx, and one word must not do two 
 _Avoid_: side, column, window
 
 **Muted**:
-Said of a **pane** that does not have focus: its colours pulled toward the background through
+Said of a **pane** that does not have focus: its colors pulled toward the background through
 a highlight namespace of its own, so the pane with focus is the bright one and a reviewer
 never has to press a key to find out where they are. A muted pane still lights the row its
-cursor is on — see **counterpart row**, the one colour in it that the muting does not answer
+cursor is on — see **counterpart row**, the one color in it that the muting does not answer
 for. Said of a pane and never of the file
-tree: the tree is never muted, it draws in the active colorscheme's own colours under every
+tree: the tree is never muted, it draws in the active colorscheme's own colors under every
 focus, and focus landing in it mutes the panes instead. Never said of a file, and never of
 anything drawn *on* the diff. Not _dimmed_: an archived **entry** is already drawn dimmed on
 the diff, and one word must not do two jobs — the same collision that kept _side_ reserved
@@ -60,10 +60,10 @@ for a diff line's add/del/ctx when the split layout needed a word for its window
 _faded_ either: that is the file the cursor is not in. The three are different mechanisms as
 well as different statements: dimming is a highlight group the render chooses per entry,
 fading is the group a mark carries, muting is every group at once in one window.
-_Avoid_: dimmed, greyed, faded, inactive
+_Avoid_: dimmed, grayed, faded, inactive
 
 **Faded**:
-Said of a file the cursor is not in: the colours of its rows pulled toward the background, so
+Said of a file the cursor is not in: the colors of its rows pulled toward the background, so
 the file being read has a visible boundary and the file just left stops competing with it.
 Said of a *file* and never of a window or of an **entry**, and the unit is the file and never
 the **hunk** — a cursor crossing from one hunk to the next inside one file changes nothing on
@@ -72,7 +72,7 @@ Drawn by changing which group a mark carries, never by a foreground laid over th
 foreground above the syntax replay would win where a parser painted and lose where none did.
 Not _muted_, which is a **pane** without focus, and not _dimmed_, which is an archived entry.
 The blend is the muting's, at a strength of its own.
-_Avoid_: muted, dimmed, greyed, inactive, unfocused
+_Avoid_: muted, dimmed, grayed, inactive, unfocused
 
 **Filler**:
 A blank row emitted in one pane where the other has no counterpart — a pure addition, a
@@ -83,7 +83,7 @@ _Avoid_: padding, spacer
 **Counterpart row**:
 The row in a **muted** pane opposite the one the cursor is on, lit with a group of its own so
 it reads as secondary to the focused pane's. The panes are cursorbound, so which row it is
-stays Neovim's business and only which colour it is lit in is the plugin's — nothing is
+stays Neovim's business and only which color it is lit in is the plugin's — nothing is
 emitted onto the diff for it and no mark is added. Where the opposite row is a **filler**,
 the lit blank row is what says *nothing existed here before*, which is the case it exists
 for. Said of a row in a pane and never of the file tree's lit row: the tree is not
@@ -103,7 +103,7 @@ beside it.
 _Avoid_: breadcrumb, pinned header, floating header
 
 **Span**:
-The run of characters within a paired line that differs from its counterpart, emphasised so
+The run of characters within a paired line that differs from its counterpart, emphasized so
 the eye lands on the change rather than on the line. Not _range_: a **range** is already a
 span of *lines* an annotation covers, and one word must not do two jobs — the same collision
 that kept _side_ reserved for a diff line's add/del/ctx when the split layout needed a word

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ make format                                          # stylua, in place
 make perf                                            # timing report at two sizes, not part of CI
 ```
 
-New behaviour needs a spec. [`tests/README.md`](tests/README.md) covers the layout, the
+New behavior needs a spec. [`tests/README.md`](tests/README.md) covers the layout, the
 fixture scripts, what is deliberately not covered, and the traps worth knowing before you
 change a fixture — read it before adding one. The short version:
 
@@ -78,7 +78,7 @@ commits and the PR title all agree.
 - The title is a Conventional Commits subject — it becomes the squash commit.
 - The body closes the issue (`Closes #12`) and says why, not what.
 - Keep it to one vertical slice. Two unrelated changes are two PRs.
-- Update `README.md` and `doc/codereview.txt` when you change user-facing behaviour; both
+- Update `README.md` and `doc/codereview.txt` when you change user-facing behavior; both
   are hand-written and neither is generated from the other.
 
 ## Code style

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 [![Neovim 0.12+](https://img.shields.io/badge/Neovim-0.12%2B-57A143?logo=neovim&logoColor=white)](https://neovim.io)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Review a diff in Neovim, leave typed notes on it, and hand the whole review to a coding
-agent as one message.**
+**Review a diff in Neovim. Annotate what needs work. Send the whole review to a coding agent
+as one message.**
 
-One syntax-highlighted diff of everything a branch changed — unified or side by side — with
-vim-native navigation, a file tree, reviewed-file collapsing, and a batch submit at the end.
+You get one syntax-highlighted diff of everything a branch changed, unified or side by side.
+It has vim-native navigation, a file tree, reviewed-file collapsing, and a batch submit at
+the end.
 
 ```
 ┌─ tree ──────────────┐┌─ branch vs origin/master · ✓2/7 · +9 -4 ──────────────────┐
@@ -26,9 +27,19 @@ vim-native navigation, a file tree, reviewed-file collapsing, and a batch submit
 └─────────────────────┘└───────────────────────────────────────────────────────────┘
 ```
 
-Everything is drawn natively in Neovim — no terminal window, no browser, no web view.
+Neovim draws everything. There is no terminal window, no browser and no web view.
 
-## Quick start
+## Contents
+
+- [Install](#install) · [Your first review](#your-first-review) · [Keymaps](#keymaps)
+- [What you can review](#what-you-can-review) · [Annotations](#annotations) ·
+  [The queue and the batch](#the-queue-and-the-batch)
+- [Reading the diff](#reading-the-diff) · [Configuration](#configuration) ·
+  [Adapters](#adapters) · [Persistence](#persistence)
+
+## Install
+
+With [lazy.nvim](https://github.com/folke/lazy.nvim):
 
 ```lua
 {
@@ -38,288 +49,190 @@ Everything is drawn natively in Neovim — no terminal window, no browser, no we
 }
 ```
 
-That is the whole setup. Six things get you through a review:
+That is the whole configuration. Nothing else is required.
 
-| Do this | What happens |
+**Requirements:** Neovim 0.12 or later, and `git`. Treesitter parsers are optional. A file
+without a parser falls back to flat diff colors.
+
+## Your first review
+
+Six keys get you through a review.
+
+1. Run `:CodeReview`. It opens the diff of everything your branch changed.
+2. Move to a line that needs work. Press `ab` to annotate it as a bug.
+3. Write the note in the composer. Press `<C-s>` to queue it.
+4. Press `R` to mark the file reviewed. The file collapses out of the way.
+5. Press `]F` to jump to the next file you have not reviewed.
+6. Press `Q` to read the queue, then `<C-s>` to submit the batch.
+
+`af`, `as`, `an` and `ai` annotate as a fix, a suggestion, a nitpick and an issue. Press `q`
+to close the review.
+
+> **Note:** With no [adapters](#adapters) wired, the review still draws, annotates and
+> queues. The submitted batch goes to the `+` register instead of an agent. It stays queued,
+> because nothing consumed it.
+
+## Keymaps
+
+### In the diff
+
+| Key | Action |
 | --- | --- |
-| `:CodeReview` | Opens the diff of everything your branch changed |
-| `ab` | Annotates the line under the cursor as a **bug** (`af` fix, `as` suggestion, `an` nitpick, `ai` issue) |
-| `R` | Marks this file reviewed — it collapses out of the way |
-| `]F` | Jumps to the next file you have **not** reviewed |
-| `Q` | Opens the queue, listing everything you have written so far |
-| `<C-s>` | Submits the batch |
+| `ab` `af` `as` `an` `ai` | Annotate as bug / fix / suggestion / nitpick / issue |
+| `aa` | Annotate. Pick the type from a menu, or decline one |
+| `x` | Drop the annotation under the cursor |
+| `R` | Toggle reviewed on this file, which collapses it |
+| `za` | Toggle expansion without marking the file reviewed |
+| `gs` | Cycle scope and draw again in place |
+| `gr` | Read the diff again from git |
+| `gp` | Show or hide the file tree |
+| `gl` | Switch between the unified and split layouts |
+| `gb` | Read the last dispatched batch back |
+| `gc` | List the commits on the branch, and trim the review to one |
+| `gA` | Show or hide archived entries, for the rest of the session |
+| `<CR>` | Open the real file here, in a new tab |
+| `gd` | Read this file in your own diff tool ([`open_diff`](#adapters) only) |
+| `Q` | Read the queue |
+| `gy` | Copy the batch to the `+` register, without submitting it |
+| `<C-t>` | Choose the delivery target |
+| `<C-s>` | Submit the batch |
+| `<C-a>` | Submit the batch under a [preamble](#the-preamble) |
+| `q` | Close |
 
-Nothing else is required. With no [adapters](#adapters) wired the review still renders,
-annotates and queues; the submitted batch lands in the `+` register instead of an agent,
-and stays queued because nothing consumed it.
+### Moving around
 
-**Requirements** — Neovim **0.12+** and `git`. Treesitter parsers are optional: files
-without one fall back to flat diff colours.
+| Key | Action |
+| --- | --- |
+| `]f` `[f` | Next / previous file |
+| `]F` `[F` | Next / previous **unreviewed** file, which wraps |
+| `]h` `[h` | Next / previous hunk |
+| `]a` `[a` | Next / previous annotation |
+| `<C-p>` | Jump to a file by name, from a list |
+| `<Tab>` | Move between the diff and the tree |
 
-## Features
+### In the composer
 
-### Review any diff, not just a branch
+| Key | Action |
+| --- | --- |
+| `<C-s>` | Queue the note and close, or send it on an [immediate send](#send-one-annotation-now) |
+| `<C-t>` | Choose where this note goes |
+| `@` | Reference another file ([`pick_file`](#adapters) only) |
+| `<C-d>` | Discard a restored draft |
+| `q` / `<Esc>` | Abandon. Keep what you wrote as a draft |
 
-`:CodeReview` opens the branch review. Pass a scope to open something else, or press `gs`
-inside the view to cycle between them in place.
+The composer opens in insert mode. `<C-s>` and `<C-t>` work in insert and normal mode alike.
+
+<details>
+<summary>The file tree, the queue float, the last-batch float and the commit list</summary>
+
+**In the file tree**
+
+| Key | Action |
+| --- | --- |
+| `<CR>` / `o` | Open the file, or fold the directory |
+| `gd` | Read this file in your own diff tool ([`open_diff`](#adapters) only) |
+| `h` / `zc` | Collapse the directory. On a file, collapse its parent |
+| `l` / `zo` | Expand the directory |
+| `za` | Toggle the directory |
+| `zM` / `zR` | Collapse / expand every directory |
+| `]f` `[f` | Next / previous file. Skip directory rows |
+| `R` | Toggle reviewed. On a directory, toggle the whole subtree |
+| `<C-p>` | Jump to a file by name |
+| `<Tab>` | Back to the diff |
+| `gp` | Dismiss the tree and land back in the diff |
+| `gl` `gb` `gc` `gA` | The same as in the diff |
+| `q` | Close |
+
+If you jump to a file that was collapsed because it is reviewed, the plugin expands it. You
+asked to look at it.
+
+**In the queue float**
+
+| Key | Action |
+| --- | --- |
+| `<CR>` | Jump to the annotation under the cursor |
+| `x` | Drop it |
+| `gy` | Copy the batch to the `+` register, without submitting it |
+| `<C-t>` | Choose the delivery target |
+| `<C-s>` | Submit the batch |
+| `<C-a>` | Submit the batch under a [preamble](#the-preamble) |
+| `q` / `<Esc>` | Close. Keep the queue |
+
+`gy` leaves the float open, because it takes nothing out of the queue.
+
+**In the last-batch float**
+
+| Key | Action |
+| --- | --- |
+| `q` / `<Esc>` | Close |
+| `x` `<C-s>` | Bound only to say why they do nothing here |
+
+**In the commit list**
+
+| Key | Action |
+| --- | --- |
+| `<CR>` | Review from this commit forward |
+| `q` / `<Esc>` | Close and change nothing |
+
+</details>
+
+Annotation keys carry an `a` prefix, because bare `b`, `f`, `n` and `s` shadow motions inside
+the buffer. [Why, and why `]F` is the motion that matters](docs/rationale.md#annotation-keys).
+
+## What you can review
+
+`:CodeReview` opens the branch review. Pass a scope to open something else. Inside the view,
+press `gs` to cycle between the scopes in place.
 
 | Command | What it shows |
 | --- | --- |
 | `:CodeReview` | Everything the branch changed against its base |
 | `:CodeReview staged` | The index |
-| `:CodeReview unstaged` | Working tree vs index |
+| `:CodeReview unstaged` | Working tree against the index |
 | `:CodeReview worktree` | Everything uncommitted |
 | `:CodeReview since-batch` | What changed since the last batch went out |
 | `:CodeReview HEAD~3` | Any git revspec |
 | `:CodeReview main...feature` | Any range |
 
-Files are marked reviewed **against their git blob**, so a mark stops meaning anything
-once the file changes underneath it.
+The plugin marks a file reviewed against its git blob. If the file changes underneath the
+mark, the mark stops meaning anything.
 
-**A branch review can be trimmed to the commits you have not read.** Press `gc`, move to the
-oldest commit you still want to read, and press `<CR>`: the review draws again from that
-commit forward, and the scope label says so — `branch vs origin/master · last 4`. The commit
-you pick is **in** the diff. The top row of the list is "All commits", which gives the whole
-branch back, and so does the bottom row. Uncommitted and untracked work stay in the review
-under every trim, because a trim has one end and it is the start. Your reviewed marks survive
-one: a file the commits you dropped never changed keeps its mark, and a file that has moved
-since you marked it loses one whether you trimmed or not.
+### Trim a branch review
 
-**A trim is kept for the branch**, so the next session opens where your reading stopped, and
-each branch keeps its own — trimming one says nothing about another. It is checked before it
-is used: a rebase, an amend or a force-push leaves it naming a commit the branch no longer
-holds, and then it is dropped, the full branch opens, and a sentence says the trim was lost.
-On a detached `HEAD` there is no branch name to keep it under, so the trim works for the
-session and one message says it is not kept.
+A branch review can start at any commit you choose. Press `gc` to list the commits on the
+branch, newest first. Move to the oldest commit you still want to read, and press `<CR>`.
 
-**`since-batch` is the one to reach for while an agent is working.** Submitting records a
-snapshot of the working tree, and this scope diffs against it — so what you get is the
-agent's response to your review, without the work you already had in flight when you sent
-it. It behaves like every other scope in every other respect: highlighted, navigable,
-collapsible, annotatable, and drawn in both layouts. `gs` reaches it once something has
-been dispatched from the repository, and never before that; asking for it by name with
-nothing dispatched says so in a sentence.
+The review draws again from that commit forward, and the commit you pick is **in** the diff.
+The scope label says so: `branch vs origin/master · last 4`. The top row of the list is "All
+commits", which gives the whole branch back, and the bottom row does the same.
 
-### Unified or side by side
+The list marks the row your review starts at with `▸`, and the cursor opens on that row. With
+the whole branch in the review, the cursor opens on "All commits".
 
-`layout = "unified"` (the default) stacks deleted and added lines in one column.
-`layout = "split"` draws the same diff as two **panes** — the before-image on the left, the
-after-image on the right — with corresponding code on the same screen row.
+Uncommitted and untracked work stay in the review under every trim. A trim has one end, and
+it is the start.
 
-```lua
-opts = { layout = "split" }   -- "unified" (default) or "split"; validated at setup()
-```
+The plugin keeps the trim per branch, so the next session opens where your reading stopped.
+Each branch keeps its own trim.
 
-```
-┌─ tree ───────────┐┌─ Before · origin/master ────┐┌─ branch · ✓2/7 ──────────────┐
-│ ▾ apps       1/4 ││     apps/api/src/main.ts    ││ ● ▾ apps/api/src/main.ts +12 │
-│   ▾ api/src  1/2 ││ @@ -19,6 @@                 ││ @@ +19,8 @@ function boot()  │
-│     ● main.ts  3 ││  19 │  const app = express()││  19 │  const app = express() │
-│   ▾ web/src  0/2 ││ ▌20 │ -const cfg = load()   ││ ▌20 │ +const cfg = loadCfg() │
-│     ✓ index.ts   ││                             ││ ▌   │   🐞 why the rename?   │
-│ ○ README.md      ││                             ││ ▌21 │ +cfg.validate()        │
-│ 2/7 reviewed     ││  21 │  app.listen(cfg.port) ││  22 │  app.listen(cfg.port)  │
-└──────────────────┘└─────────────────────────────┘└──────────────────────────────┘
-```
+[What drops a trim, what survives one, and how the commit list is built](docs/rationale.md#trim)
 
-The blank rows on the left are **filler**: the addition has no counterpart in the
-before-image, so the left pane holds its place rather than letting the two drift apart.
-Annotating from a filler row targets the whole file.
+### Review what the agent did
 
-Both panes are syntax-highlighted, scroll together, and behave identically: collapsing,
-reviewed marks, capture and navigation all work the same way, and the pane you are in
-decides what is captured — a deleted line on the left, the post-image line on the right.
+Reach for `since-batch` while an agent is working. A submit records a snapshot of the working
+tree, and this scope diffs against that snapshot. You get the agent's response to your
+review, without the work you already had in flight when you sent it.
 
-**`gl` switches layouts** without losing your place, from either pane or the file tree, so
-you can reach for side-by-side on the one reformatted file without editing your config. The
-choice lasts the rest of the session and resets when Neovim exits.
+`gs` reaches `since-batch` once a batch has gone from the repository, and never before. Ask
+for it by name with nothing dispatched and the plugin says so in one sentence.
 
-<details>
-<summary>The details that occasionally matter</summary>
+[How since-batch behaves in every other respect](docs/rationale.md#since-batch)
 
-Buffer rows mean nothing across layouts — the same line of the same hunk sits at a
-different row in each. What `gl` carries across is the **anchor** (the same line, of the
-same hunk, of the same file), and the row carrying it is found again afterwards. So the
-cursor lands in the pane its line belongs to, switching back is unambiguous, and a cursor
-on filler falls back to that file's header. The landing line is centred, because preserving
-an exact scroll offset across a structural move would be preserving something meaningless.
+## Annotations
 
-Chrome is split too: a hunk header shows its pre-image range on the left and its post-image
-range plus git's section heading on the right, and a renamed file shows its old path on the
-left and its new path on the right — on the winbar as well as in the buffer, so the left
-pane's sticky header names the pre-image path beside the revision it is showing.
+### Annotation types
 
-Horizontal scrolling is **not** synchronised, because doing so would mean changing
-`scrollopt`, a global option this plugin does not own.
-
-One behavioural difference, and only one: a visual **range** cannot span both images,
-because the two runs live in different windows and cannot be in one selection.
-Pure-addition and pure-deletion ranges work, and annotating the hunk header captures both
-images inlined — so what a split range cannot express is still one keystroke away.
-
-A layout is a rendering choice and nothing else, so which one was on screen never reaches
-the receiving agent ([ADR-0002](docs/adr/0002-one-queue-one-entry-shape.md)).
-
-</details>
-
-### See what changed *inside* a changed line
-
-Rename one identifier in an eighty-column line and a plain diff shows you two eighty-column
-lines, one red and one green, with nothing pointing at the four characters that differ. So
-the **spans** that actually differ are emphasised inside the pair, and the rest of the line
-keeps its ordinary red or green — you read the change, not the line.
-
-```
-▌20 │ -const cfg = load()
-▌20 │ +const cfg = loadConfig()
-                       ▔▔▔▔▔▔ emphasised
-```
-
-On by default, in both layouts, and in both panes on the same row.
-
-```lua
-opts = { spans = false }   -- true by default; validated at setup()
-```
-
-Granularity is characters, not words, so an edit inside an identifier is pointed at
-precisely and a re-indentation is visible rather than mysterious. Where two lines share so
-little that emphasising the change would emphasise nearly all of both, they are left plainly
-coloured: that is a replacement, not an edit.
-
-<details>
-<summary>The details that occasionally matter</summary>
-
-**Which lines pair.** The i-th deletion of a contiguous run pairs with the i-th addition of
-the run that follows it — the pairing the split layout already uses to put a deletion and
-its replacement on one row. Using it in both layouts is why the same characters are
-emphasised either side of a `gl`. Where the runs are unequal the surplus lines carry
-nothing, and neither does a pure addition, a pure deletion, or a file that exists on only
-one side: there is nothing to compare them against.
-
-**When it says nothing.** Above **60% of the longer line** inside spans, the pair is left
-alone. The figure was read off real diffs rather than derived — at 70% a quarter of the
-unrelated pairs inside a long run were still being emphasised, and every genuine one-line
-edit above 60% turned out to be a replacement wearing an edit's clothes. A re-indentation is
-nowhere near it: every reformatted pair measured came in under 10%.
-
-**When the work happens.** At parse time, once per git read — never during a repaint. On a
-12,000-line diff the spans cost about as much again as a whole repaint, and a repaint runs
-on every resize, expansion, reviewed toggle and scope change. `make perf` reports the figure
-on its own line so a change that moves the work back into the render is visible.
-
-**Two highlight groups**, `CodeReviewAddSpan` and `CodeReviewDelSpan`, both taking
-`DiffText`'s **background and nothing else**. A foreground there would sit beneath the
-treesitter replay: it would lose wherever a parser had painted and win wherever one had not,
-which is emphasis that changes colour depending on which languages you have installed.
-
-The emphasis is a rendering refinement and nothing else. What you capture, what reaches the
-queue and what the payload says are untouched
-([ADR-0002](docs/adr/0002-one-queue-one-entry-shape.md)).
-
-</details>
-
-### A file tree that tracks your progress
-
-The tree collapses single-child directory chains (`apps/api/src`, not three nested rows),
-sorts directories before files, and carries a reviewed tally on every directory — so you
-can see which packages are done without opening them. It follows the diff cursor, and
-`<Tab>` into it lands on the file you were reading.
-
-`gp` dismisses and summons it; `panel.enabled` decides whether a review *opens* with one.
-Collapsed directories belong to the review rather than to the tree, so they are exactly as
-you left them when it comes back.
-
-### The pane you are in is the bright one
-
-A review can hold three windows at once — the before pane, the after pane and the tree — and
-the pane without focus is **muted**: its colours pulled toward the background, so where you
-are is on screen instead of something you have to press a key to find out.
-
-Both panes go on lighting the row their cursor is on. The muted one lights a **counterpart
-row** — the same row, in a group of its own, blended more gently than the muting so it is
-bright enough to find and never competes with the pane you are in. The panes are cursorbound,
-so that row is the one opposite the line you are reading, and on a pure addition it is the
-**filler**: a lit blank row saying nothing was here before, which is the fact you wanted and
-the one you could not otherwise get without counting rows. `counterpart = { enabled = false }`
-goes back to a lit row in the focused pane only.
-
-The file tree is never muted. It is the map of the review — the paths, the icons, the
-per-directory tallies and the `+N -M` counts — so it draws in your colorscheme's own colours
-whichever window you are in, with the row for the file you are reading lit. Move into it and
-the panes mute, both of them in the split layout and the one of them in the unified layout,
-so you can see that your keys now act on the tree.
-
-The colours come from your own colorscheme, blended: nothing here has a palette of its own,
-and a group the plugin cannot know about is left bright rather than guessed at, so an
-unfamiliar theme degrades to *less muted* and never to *wrong*. A float — the composer, the
-queue float, the last-batch float — changes nothing: the bright window is the review window
-you were last in, not the window with the cursor in it.
-
-`muted = { enabled = false }` turns it off whole; `strength` is one number from 0 to 1
-saying how far toward the background a colour goes.
-
-### The file you are in is the only one at full strength
-
-Every other file in the review is **faded**: the colours of its rows pulled toward the
-background, so the file you are reading has a boundary and the file you just left stops
-competing with it. Cross into another file and the fade follows the cursor. Move from one
-hunk to the next inside one file and nothing changes at all — the unit is the file.
-
-A faded file keeps its header row bright, with its path, its `+N -M` and its note count, so
-the review reads as bright headers over quiet bodies with one file at full strength. Its
-hunk headers fade with its body.
-
-The colours are the muting's, blended from your own colorscheme at a strength of its own,
-and a faded file keeps its syntax structure rather than flattening to one tone: what changes
-is which group each mark carries, never the order they are drawn in. A group your theme
-gives no colour of its own is left bright, exactly as it is in a muted window.
-
-`faded = { enabled = false }` turns it off whole; `strength` is its own number, and it is
-gentler than the muting's by default because this covers every file but one.
-
-### The file you are in, on the winbar
-
-A file's header row scrolls off the top as soon as you read past the first screenful of it.
-The **sticky header** keeps it:
-
-```
- ○ ▾ src/routes.lua  +12 -3  [2 notes]        branch vs master · ✓2/7 · +40 -9 · ●2 · → janus
-```
-
-The same icon, chevron, path, `+N -M` and note count the in-buffer header carries, with the
-review summary right-aligned beside it. It names the file the **cursor** is in — not the one
-at the top of the window — so it is the file an annotation would attach to, which is what
-you are reaching for when you annotate twenty lines into a hunk. It works with the tree
-dismissed, and with a review opened without one.
-
-The summary counts in glyphs rather than words — `✓2/7` reviewed, `●2` notes, `↺2` untouched
-— so that three numbers side by side cannot be read as one another. Every one comes from the
-`icons` table, so you can change any of them, and every one is plain Unicode: nothing here
-needs a Nerd Font. The bar does not name the review itself; a bar inside a review does not
-need to.
-
-It is coloured. Added counts green and removed counts red, the note count in the colour notes
-carry everywhere else, the delivery **target** accented, the separators quieter than the
-facts between them, and the path the brightest thing on the left — which is the thing you
-scrolled there to keep. The groups are the plugin's own (`CodeReviewBarIcon`,
-`CodeReviewBarSep`, `CodeReviewBarTarget`, `CodeReviewBarRev`, beside the stat and note-count
-groups the diff already uses), and every one is a default link into your colorscheme, so a
-theme you have never used supplies the colours and changing theme mid-review follows.
-
-In the split layout each pane names its own side, so a rename reads correctly on the side
-holding the old name; the unified layout spells it `old → new`, exactly as the file header
-does. On a pane too narrow for both halves the summary gives way first — starting with what
-the file beside it now says twice — and the path keeps its tail. The before pane's bar names
-the base revision, and never gives it up for the path: half a revision is worse than none of
-a path the other pane is naming anyway.
-
-The bar is chrome of the review window it sits on, so it mutes with that window: on the pane
-without focus the sticky header recedes with everything else in it, colours and all.
-
-### Typed annotations
-
-A type is not decoration — it changes what the receiving agent is told to do with that
-group of notes.
+A type is not decoration. It changes what the receiving agent is told to do with that group.
 
 | Type | Key | Group directive in the payload |
 | --- | --- | --- |
@@ -329,16 +242,17 @@ group of notes.
 | nitpick | `an` | low priority — batch these together |
 | issue | `ai` | do NOT fix — summarize these for tracking |
 
-`aa` opens a picker instead. Its last entry is **`no type`** — a remark worth reading with
-no instruction attached. It behaves like any other entry and its group renders last, under
-a bare `## Untyped (n)` heading. Declining a type is not dismissing: escape still abandons
-the annotation entirely.
+`aa` opens a picker instead. Its last entry is **`no type`**. An untyped annotation says that
+something is worth reading, without saying what to do about it. It behaves like any other
+entry, and its group renders last under a bare `## Untyped (n)` heading.
+
+Declining a type is not dismissing. Press `<Esc>` to abandon the annotation.
 
 <details>
 <summary>Replacing the type set</summary>
 
-`opts.types` replaces the whole set. Only `name` and `key` are required — everything else
-is derived, so adding a type costs two fields:
+`opts.types` replaces the whole set. Only `name` and `key` are required. The plugin derives
+everything else, so a new type costs two fields:
 
 ```lua
 types = {
@@ -352,23 +266,21 @@ types = {
 | --- | --- |
 | `name` | **required** — what `annotate()` takes and what an entry stores |
 | `key` | **required** — pressed after the `a` prefix, so `q` binds `aq` |
-| `label` | the name, title-cased and pluralised: `question` → `Questions` |
+| `label` | the name, title-cased and pluralized: `question` → `Questions` |
 | `icon` | `icons.annotated` |
-| `hl` | `CodeReview<Name>`, auto-linked to `DiagnosticInfo` so it has colour |
+| `hl` | `CodeReview<Name>`, auto-linked to `DiagnosticInfo` so it has color |
 | `directive` | none — the payload heading is then just `## Questions (3)` |
 
-Pluralisation is naive (`+s`, unless the name already ends in one), so a name English
-declines irregularly wants an explicit `label`. Order is the order groups appear in the
-payload, most actionable first.
+Order is the order the groups appear in the payload, most actionable first.
 
-A list that cannot work is rejected at `setup()` naming the entry that caused it — a
-missing `name` or `key`, a duplicate of either, a `key` of `a` (which would shadow the `aa`
+`setup()` rejects a list that cannot work, and names the entry that caused it. The causes are
+a missing `name` or `key`, a duplicate of either, a `key` of `a` (which shadows the `aa`
 picker), or a field of the wrong type. Start from the shipped set with
 `require("codereview.types").defaults`.
 
 </details>
 
-### Five things you can annotate
+### What you can annotate
 
 | Cursor is on | What gets annotated |
 | --- | --- |
@@ -378,20 +290,20 @@ picker), or a field of the wrong type. Start from the shipped set with
 | A file header | The whole file |
 | A filler row (split layout) | The whole file |
 
-Plus a **bare note** with no file behind it at all — see below.
+You can also write a **bare note**, with no file behind it at all.
 
-### Annotate from any buffer, with no review open
+### Annotate from any buffer
 
-Capture does not need a review. `:CodeReviewAnnotate bug` queues a note about the file you
-are looking at; with no type it offers the same picker `aa` does.
+Capture does not need a review. `:CodeReviewAnnotate bug` queues an annotation about the file
+you are looking at. With no type it offers the same picker `aa` does.
 
 ```lua
 require("codereview").annotate("bug")  -- the selection, or the whole file
 require("codereview").annotate()       -- pick the type from a menu, or decline one
 ```
 
-That is the entry point to bind a key to — nothing needs to reach into the plugin's
-internal modules to capture. Bind it in both modes and the selection decides the scope:
+That is the entry point to bind a key to. Nothing needs to reach into the plugin's internal
+modules to capture. Bind it in both modes, and the selection decides the scope:
 
 ```lua
 vim.keymap.set({ "n", "x" }, "<leader>ab", function()
@@ -408,14 +320,16 @@ end, { desc = "Annotate as a bug" })
 | A file outside any checkout | The file, by absolute path |
 | A buffer with nothing on disk | A bare note, with no path at all |
 
-The last two are not second-class: they queue, submit and survive a restart like anything
-else — a scratch buffer is a fine place to leave a thought for the batch. What you get is
-an ordinary annotation, sharing the queue, the payload grouping, the batch and the
-staleness rules with anything captured during a review. The buffer itself is never touched.
+The last two are not second-class. They queue, they submit, and they survive a restart like
+anything else. A scratch buffer is a fine place to leave a thought for the batch.
 
-**Diagnostics ride along.** Errors and warnings overlapping what you captured are attached
-to the note, so they stop being retyped by hand. Hints and info are left out — they are
-rarely why you are annotating, and they bury the diagnostic that is.
+What you get is an ordinary annotation. It shares the queue, the payload grouping, the batch
+and the staleness rules with anything captured during a review. The plugin never touches the
+buffer itself.
+
+**Diagnostics ride along.** The plugin attaches errors and warnings that overlap what you
+captured, so you stop retyping them by hand. It leaves out hints and info, which are rarely
+why you are annotating and which bury the diagnostic that is.
 
 ```
 why is this branch unreachable?
@@ -427,165 +341,122 @@ Diagnostics:
 
 ### Send one annotation now
 
-A thought you want acted on should not have to wait for a batch you have not finished
-assembling. The same entry point sends one annotation on its own instead of queueing it:
+A thought you want acted on must not wait for a batch you have not finished assembling. The
+same entry point sends one annotation on its own instead of queueing it:
 
 ```lua
 require("codereview").annotate("bug", nil, { immediate = true })
 require("codereview").annotate(nil, nil, { immediate = true })  -- or pick the type
 ```
 
-Delivery is a property of the call, not a different door: the same paths, the same blob,
-the same diagnostics, the same drafts and `@` references, and the same picker. What arrives
-is an ordinary review payload that happens to hold one annotation
+Delivery is a property of the call, not a different door. You get the same paths, the same
+blob, the same diagnostics, the same drafts, the same `@` references and the same picker.
+What arrives is an ordinary review payload that holds one annotation
 ([ADR-0004](docs/adr/0004-an-immediate-send-is-a-batch-of-one.md)).
 
-You are asked where it goes **before** the composer opens, so declining costs no typing.
-The queue is untouched — an annotation sent this way never joins it, and whatever is
-already queued is neither delivered nor cleared. If the send does not go through, the note
-is kept as a draft so annotating that file again offers it back.
+The plugin asks where it goes **before** the composer opens, so declining costs no typing.
+The queue is untouched: an annotation sent this way never joins it, and whatever is already
+queued is neither delivered nor cleared. If the send does not go through, the plugin keeps
+the note as a draft and offers it back when you annotate that file again.
 
 ### The composer
 
-Notes are written in a real buffer, not a prompt. Drafts are kept per target and survive
-restarts, and `@` references another file — [`pick_file`](#adapters) supplies the picker.
+You write notes in a real buffer, not a prompt. See [the composer keys](#in-the-composer)
+above.
 
-### The queue and the batch
+The plugin keeps drafts per target, and they survive restarts. `@` references another file,
+and [`pick_file`](#adapters) supplies the picker.
 
-Annotations accumulate in a queue that survives `:qa` and restarts. `Q` opens a float
-listing the batch, where `<CR>` jumps to any entry — closing the float and centring the
-line the annotation is about, expanding the file first if it was collapsed. The queue is
-therefore a way of navigating a review, not only of auditing it before you send.
+## The queue and the batch
 
-Because the queue is shared with the capture path and the float opens with or without a
-review, some of what it lists has nowhere to jump to: a bare note is about no file, there
-may be no review open, or the file may be outside the current scope. Each says which.
+Annotations accumulate in a queue that survives `:qa` and restarts. `Q` opens a float that
+lists the batch. Press `<CR>` to jump to any entry. The float closes, and the plugin centers
+the line the annotation is about. If the file was collapsed, the plugin expands it first.
 
-`gy` — in the diff, in the float, or as `:CodeReviewCopy` from anywhere — puts the payload
-in the `+` register without submitting it. It is the same text `send` would have been
-handed, target and all, and it costs the batch nothing: the queue is untouched, so reading
-what an agent will be told is not a decision to send it.
+The queue is therefore a way of navigating a review, and not only of auditing it before you
+send.
 
-### A batch can carry a preamble
+The queue is shared with the capture path, and the float opens with or without a review. Some
+of what it lists therefore has nowhere to jump to:
 
-`<C-s>` submits with no questions asked. `<C-a>` — in the diff and in the queue float —
-opens the composer first, and submits when you submit the composer. What you write is the
-**preamble**: the prose above the batch, addressed to the agent, that is not an annotation.
-It is where what the batch is about as a whole goes — which part matters most, what to
-ignore, how the pieces relate — instead of an untyped annotation in the middle of the
+- a bare note is about no file,
+- no review is open, or
+- the file sits outside the current scope.
+
+Each entry says which.
+
+**`gy` copies the batch without submitting it.** It works in the diff, in the float, and as
+`:CodeReviewCopy` from anywhere. It puts the payload in the `+` register. This is the same
+text `send` receives, target and all, and it costs the batch nothing. The queue is untouched,
+so reading what an agent will be told is not a decision to send it.
+
+### The preamble
+
+`<C-s>` submits with no questions asked. `<C-a>` opens the composer first, and submits when
+you submit the composer. It works in the diff and in the queue float.
+
+What you write is the **preamble**: the prose above the batch, addressed to the agent, that is
+not an annotation. It says what the batch is about as a whole — which part matters most, what
+to ignore, and how the pieces relate. It replaces an untyped annotation in the middle of the
 findings.
 
-It is rendered above the header, so it is read before them, and it is never queued. A
-preamble is written at the moment the batch goes and forgotten afterwards: the queue holds
-annotations and nothing else.
+The payload draws the preamble above the header, so the agent reads it first.
 
-Abandon the composer and nothing is sent. The queue is whole, nothing is archived, and what
-you wrote is kept as a draft, so the next `<C-a>` offers it back rather than making you
-write it twice. That draft is kept per repository rather than per file, because a preamble
-is about a batch and not about a line of code.
+[What a preamble is not, and what an abandoned composer keeps](docs/rationale.md#the-preamble)
 
-An empty composer still submits and renders nothing at all, leaving the payload exactly
-what `<C-s>` would have sent. `gy` copies no preamble either, because copying is not
-submitting, and an annotation [sent on its own](#send-one-annotation-now) carries none: a
-batch of one has no batch to cover.
+### Read the last batch back
 
-A preamble that went is part of the record. It is kept with its batch and
-[read back with it](#read-the-last-batch-back-after-it-goes) — a float listing the findings
-and not the covering note would be describing a message nobody received. Shown there and
-never edited, for the reason that float refuses everything else.
+A submit clears the queue. That is the moment "what did I actually ask for?" stops having an
+answer anywhere but the agent's transcript.
 
-### Read the last batch back after it goes
+`:CodeReviewLastBatch` gives it one. It lists the annotations of the batch that went last,
+grouped by type exactly as the queue float and the payload group them. It shows the
+[preamble](#the-preamble) the batch went out under, the target it went to, and when it went.
 
-A submit clears the queue, which is the moment "what did I actually ask for?" stops having
-an answer anywhere but the agent's transcript. `:CodeReviewLastBatch` gives it one: the
-annotations of the batch that went last, grouped by type exactly as the queue float and the
-payload group them, under the [preamble](#a-batch-can-carry-a-preamble) it went out under
-where there was one, with the target it went to and when it went in the frame.
+`gb` opens that same float from inside a review, in the diff and in the tree. The command
+needs no review open. A bare note is listed like anything else.
 
-`gb` opens that same float from inside a review, in the diff and in the tree, so which
-window you are in never decides whether the key exists. The command needs no review open —
-a batch is not a window, and what you asked for is worth checking from anywhere. A bare note
-is listed like anything else, even though it was kept in a different store than the
-annotations with a file behind them.
-
-It is **read-only**, and that is a statement about the record rather than a feature left
-out. An archived entry says something happened; a surface that let you drop, edit or
-resubmit one would be claiming the plugin can revise what an agent already received. To
-raise a point again, annotate again — that is an ordinary capture, and it joins the next
-batch.
+The float is **read-only**. [Why](docs/rationale.md#the-last-batch-float)
 
 ### What you already reported stays on the diff
 
 A dispatched batch does not leave the review view. Its entries keep the anchors they were
-bound to and are drawn dimmed beneath the code they were about, projected exactly as live
-annotations are. A reviewer who keeps going while the agent works is otherwise looking at a
-diff with no memory of what it already sent, and reports the same finding twice.
+bound to, and the plugin draws them dimmed beneath the code they were about. It projects them
+exactly as it projects live annotations.
 
-They draw in **every scope**, not only `since-batch` — knowing what has already been said is
-worth as much wherever you are. An anchor carrying both a queued and an archived entry draws
-both, the queued one first: what is still to send outranks what has already gone. `x` there
-drops the queued one and never the archived one; nothing on the diff can revise a batch that
-already went, for the same reason the last-batch float is read-only.
+**`gA` shows or hides them** from inside a review, in the diff and in the tree. On a fresh
+review over code you already annotated they are noise, so one key takes them off and the same
+key brings them back. It repaints at once and runs in both directions. `archived = false`
+turns them off in your configuration instead.
 
-Their two highlight groups are their own — `CodeReviewArchived` for the marker and
-`CodeReviewArchivedNote` for the prose — and are `default = true` links like everything else
-here, so a colorscheme can say how dim "already sent" looks. `archived = false` turns them
-off wholesale, and the diff then renders exactly as it did before the archive existed.
-
-**`gA` reaches that switch from inside a review**, in the diff and in the tree. On a fresh
-review over code you already annotated they are noise — you are looking for what is wrong
-now, and the diff is covered in what was already said — so one key takes them off, and the
-same key brings them back. It repaints at once and runs in both directions: with
-`archived = false` configured, `gA` turns them on.
-
-It overrides the configured value instead of writing it, so your `setup()` call goes on
-saying what you wrote. The override holds for every review you open afterwards — you press
-the key once, not once per review — and it dies with the Neovim process, so a display
-preference never becomes durable state you forgot you set. Off is off entirely, exactly as
-the flag is: the `untouched` tally leaves the winbar with the entries, and no git is spent
-judging them.
+[Which scopes draw them, what `x` does there, and why `gA` overrides rather than writes](docs/rationale.md#archived-entries)
 
 ### Where the agent has and has not been
 
 Each entry of the **last** batch says whether its file has changed since that batch was
-dispatched — `file changed` or `file unchanged` beside the note — and the winbar tallies the
-ones that have not:
+dispatched. The entry reads `file changed` or `file unchanged`, and the winbar tallies the
+files that have not changed:
 
 ```
  branch vs master · ✓2/7 · +40 -12 · ●1 · ↺2 · → janus
 ```
 
-`↺2` is the answer to *did it ignore something*, and it is exact on the case that
-matters: a file the agent never opened. The comparison is **per file**, against the snapshot
-the batch went out with — the same commit `since-batch` diffs against, so a file the tally
-calls touched is exactly a file that scope shows you.
+`↺2` is the answer to *did it ignore something*. It is exact on the case that matters: a file
+the agent never opened. The comparison is **per file**, against the snapshot the batch went
+out with. That is the same commit `since-batch` diffs against, so a file the tally calls
+touched is exactly a file that scope shows you.
 
-The word is *touched*, not *addressed*. The plugin knows the file moved. It does not know
-that anyone read your note, agreed with it, or acted on it, and it will not imply otherwise.
-It is also not **staleness**: that is the same kind of comparison against a different blob,
-it is about entries still in the queue, and it means *this note may now be wrong* rather than
-*something happened here*. The two are never merged, and an archived entry never shows a
-stale flag.
+`CodeReviewTouched` and `CodeReviewUntouched` are the groups. `archived = false`, or `gA`
+while you are reviewing, turns the tally off along with everything else.
 
-Three things are left unjudged rather than guessed at — a file the current scope does not
-cover, a file that was untracked when the batch went (a snapshot does not record those), and
-a **bare note**, which is about no file at all. A file *deleted* since the dispatch counts as
-touched. Nothing judged means no segment at all rather than a zero to misread.
-
-That the scope decides who is judged is why the tally reads `0 untouched` inside
-`since-batch`: that scope shows you exactly the files that moved, so every entry it covers is
-touched by definition, and the ones you are looking for are the ones it is not showing.
-`branch` and `worktree` are where the number earns its keep.
-
-`CodeReviewTouched` and `CodeReviewUntouched` are the groups, and `archived = false` — or
-`gA` while you are reviewing — turns the tally off along with everything else.
+[Why the word is "touched", what is left unjudged, and why the tally reads 0 in since-batch](docs/rationale.md#untouched-files)
 
 ### The payload
 
-Grouped by type, in the configured order, most actionable first, with anything untyped
-last. A diff is inlined where an `@ref` cannot carry the change. A preamble, where one was
-written, sits above the header with a blank line under it; with none the payload starts at
-the header.
+The payload groups annotations by type, in the configured order, most actionable first, with
+anything untyped last. A diff is inlined where an `@ref` cannot carry the change. A preamble
+sits above the header with a blank line under it. With no preamble the payload starts at the
+header.
 
 ````markdown
 the auth rewrite is the part to read — the route moves are mechanical
@@ -615,141 +486,130 @@ was this dropped on purpose?
 worth a look before we ship this
 ````
 
-## Keymaps
+## Reading the diff
 
-### In the diff
+### Unified or split
 
-| Key | Action |
-| --- | --- |
-| `ab` `af` `as` `an` `ai` | Annotate as bug / fix / suggestion / nitpick / issue |
-| `aa` | Annotate, picking the type from a menu or declining one |
-| `x` | Drop the annotation under the cursor |
-| `R` | Toggle reviewed on this file (collapses it) |
-| `za` | Toggle expansion without marking reviewed |
-| `gs` | Cycle scope, re-rendering in place — `since-batch` joins once a batch has gone |
-| `gr` | Re-read the diff from git |
-| `gp` | Show or hide the file tree |
-| `gl` | Switch between the unified and split layouts |
-| `gb` | Read the last dispatched batch back |
-| `gc` | List the commits on the branch, and trim the review to one |
-| `gA` | Show or hide archived entries, for the rest of the session |
-| `<CR>` | Open the real file here, in a new tab |
-| `gd` | Read this file in your own diff tool — only bound with [`open_diff`](#adapters) wired |
-| `Q` | Review the queue |
-| `gy` | Copy the batch to the `+` register, without submitting it |
-| `<C-t>` | Choose the delivery target |
-| `<C-s>` | Submit the batch |
-| `<C-a>` | Submit the batch under a [preamble](#a-batch-can-carry-a-preamble) |
-| `q` | Close |
+`layout = "unified"` is the default. It stacks deleted and added lines in one column.
+`layout = "split"` draws the same diff as two **panes**: the before-image on the left, and
+the after-image on the right. Corresponding code sits on the same screen row.
 
-Annotation keys are prefixed with `a` rather than bound bare, because bare `b`, `f`, `n`
-and `s` would shadow back-word, find-char, next-search and (if you use it) flash.nvim
-inside the buffer. `a` is append, which is dead in a `nomodifiable` buffer, so the prefix
-costs a keystroke and no motion.
+```lua
+opts = { layout = "split" }   -- "unified" (default) or "split". Validated at setup()
+```
 
-### Getting around
+```
+┌─ tree ───────────┐┌─ Before · origin/master ────┐┌─ branch · ✓2/7 ──────────────┐
+│ ▾ apps       1/4 ││     apps/api/src/main.ts    ││ ● ▾ apps/api/src/main.ts +12 │
+│   ▾ api/src  1/2 ││ @@ -19,6 @@                 ││ @@ +19,8 @@ function boot()  │
+│     ● main.ts  3 ││  19 │  const app = express()││  19 │  const app = express() │
+│   ▾ web/src  0/2 ││ ▌20 │ -const cfg = load()   ││ ▌20 │ +const cfg = loadCfg() │
+│     ✓ index.ts   ││                             ││ ▌   │   🐞 why the rename?   │
+│ ○ README.md      ││                             ││ ▌21 │ +cfg.validate()        │
+│ 2/7 reviewed     ││  21 │  app.listen(cfg.port) ││  22 │  app.listen(cfg.port)  │
+└──────────────────┘└─────────────────────────────┘└──────────────────────────────┘
+```
 
-| Key | Action |
-| --- | --- |
-| `]f` `[f` | Next / previous file |
-| `]F` `[F` | Next / previous **unreviewed** file — wraps |
-| `]h` `[h` | Next / previous hunk |
-| `]a` `[a` | Next / previous annotation |
-| `<C-p>` | Jump to a file by name, from a list |
-| `<Tab>` | Move between the diff and the tree |
+The blank rows on the left are **filler**. The addition has no counterpart in the
+before-image, so the left pane holds its place rather than letting the two panes drift apart.
+Annotate from a filler row and the annotation targets the whole file.
 
-`]F` is the one that matters once a review is underway: the point of marking files reviewed
-is to stop looking at them, so the useful motion is "the next thing I have not done", not
-"the next file", which walks back through everything already finished.
+Both panes are syntax-highlighted and they scroll together. Collapsing, reviewed marks,
+capture and navigation all work the same way in each. The pane you are in decides what is
+captured: a deleted line on the left, and the post-image line on the right.
 
-### In the tree
+**`gl` switches layouts** without losing your place, from either pane or from the file tree.
+You can therefore reach for side-by-side on the one reformatted file, without editing your
+configuration. The choice lasts the rest of the session, and it resets when Neovim exits.
 
-| Key | Action |
-| --- | --- |
-| `<CR>` / `o` | Open the file, or fold the directory |
-| `gd` | Read the file under the cursor in your own diff tool — only bound with [`open_diff`](#adapters) wired |
-| `h` / `zc` | Collapse the directory — on a file, collapses its parent |
-| `l` / `zo` | Expand the directory |
-| `za` | Toggle the directory |
-| `zM` / `zR` | Collapse / expand every directory |
-| `]f` `[f` | Next / previous file, skipping directory rows |
-| `R` | Toggle reviewed — **on a directory, the whole subtree** |
-| `<C-p>` | Jump to a file by name |
-| `<Tab>` | Back to the diff |
-| `gp` | Dismiss the tree, landing back in the diff |
-| `gl` | Switch between the unified and split layouts |
-| `gb` | Read the last dispatched batch back |
-| `gc` | List the commits on the branch, and trim the review to one |
-| `gA` | Show or hide archived entries, for the rest of the session |
-| `q` | Close |
+[What `gl` carries across, how the chrome splits, and the one behavior that differs](docs/rationale.md#the-split-layout)
 
-Jumping to a file that was collapsed because it is reviewed expands it: you asked to look
-at it.
+### What changed inside a changed line
 
-### In the queue float
+Rename one identifier in an eighty-column line. A plain diff then shows you two
+eighty-column lines, one red and one green, with nothing pointing at the four characters that
+differ.
 
-Each annotation is a run of rows carrying a bar in its type's colour — its location, the
-code it inlines, and its note, kept as you wrote it and wrapped to the float. The bar runs
-through blank lines *inside* a note and stops between annotations, so you can always see
-where one ends. Every row belongs to the annotation it is drawn under, so `x` drops what is
-under the cursor and not what a heading further up happened to say.
+So the plugin emphasizes the **spans** that actually differ inside the pair. The rest of the
+line keeps its ordinary red or green, and you read the change instead of the line.
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Jump to the annotation under the cursor |
-| `x` | Drop it |
-| `gy` | Copy the batch to the `+` register, without submitting it |
-| `<C-t>` | Choose the delivery target |
-| `<C-s>` | Submit the batch |
-| `<C-a>` | Submit the batch under a [preamble](#a-batch-can-carry-a-preamble) |
-| `q` / `<Esc>` | Close, keeping the queue |
+```
+▌20 │ -const cfg = load()
+▌20 │ +const cfg = loadConfig()
+                       ▔▔▔▔▔▔ emphasized
+```
 
-`gy` leaves the float open, because it takes nothing out of the queue — everything it is
-listing is still there.
+Spans are on by default, in both layouts, and in both panes on the same row.
 
-### In the last-batch float
+```lua
+opts = { spans = false }   -- true by default. Validated at setup()
+```
 
-`gb`, or `:CodeReviewLastBatch` from anywhere, lists an annotation the same way — the
-reserved gutter, the bar in its type's colour, the code it inlined and its note — so the two
-read as one family. A [preamble](#a-batch-can-carry-a-preamble) is drawn above them all, as
-prose rather than as an entry: no gutter and no bar, because it is about the batch and not
-about a place in the code. What is missing is every key that would change something.
+Granularity is characters, not words. An edit inside an identifier is therefore pointed at
+precisely, and a re-indentation is visible rather than mysterious. Where two lines share so
+little that emphasizing the change emphasizes nearly all of both, the plugin leaves them
+plainly colored. That is a replacement, not an edit.
 
-| Key | Action |
-| --- | --- |
-| `q` / `<Esc>` | Close |
-| `x` `<C-s>` | Bound only to say why they do nothing here |
+[Which lines pair, why the threshold is 60%, and when the work happens](docs/rationale.md#spans)
 
-Those two are bound rather than left off so that the queue float's muscle memory gets a
-sentence instead of `E21`. Nothing else is: the batch has gone, and there is nothing left
-to route, drop or send.
+### The file tree
 
-### In the commit list
+The tree collapses single-child directory chains, so you get `apps/api/src` and not three
+nested rows. It sorts directories before files. It carries a reviewed tally on every
+directory, so you can see which packages are done without opening them.
 
-`gc`, in the diff or in the tree, lists the commits on the branch — newest first, one row
-each, with the short sha, the subject and how long ago it was written. Not the author: it is
-your own branch. Not the added and deleted counts: they cost a second pass over the whole
-branch, and the subject is what you recognise.
+The tree follows the diff cursor, and `<Tab>` into it lands on the file you were reading.
 
-The listing is `--first-parent` from the merge base, so a merge is one row and the commits
-that arrived through it are not listed beside your own. There is **no limit on the rows**: a
-long branch keeps its oldest commits on screen, at the bottom of the list.
+`gp` dismisses and summons the tree. `panel.enabled` decides whether a review *opens* with
+one. Collapsed directories belong to the review rather than to the tree, so they are exactly
+as you left them when the tree comes back.
 
-`<CR>` trims the review to the row under the cursor: the review draws again from that commit
-forward, and that commit is **in** the diff. The top row is "All commits" and removes the
-trim; the bottom row means the same thing, because the oldest commit resolves to the merge
-base and not to its own parent. The row your review currently starts at is marked with `▸`,
-and the cursor opens on it — on "All commits" while the whole branch is in the review.
+### Focus and fade
 
-| Key | Action |
-| --- | --- |
-| `<CR>` | Review from this commit forward |
-| `q` / `<Esc>` | Close, changing nothing |
+A review can hold three windows at once: the before pane, the after pane and the tree.
 
-Two cases open nothing and say why in one sentence: `gc` outside a branch review, where
-there is no branch behind the diff to list, and `gc` on a branch whose `HEAD` is the merge
-base, which has no commits of its own. A third opens and works: on a detached `HEAD` the
-list is there and the trim applies, and one message says it is not kept.
+**The pane without focus is muted.** Its colors are pulled toward the background, so where
+you are is on screen instead of something you press a key to find out. The muted pane lights
+the row opposite your cursor, in a group of its own. That is the **counterpart row**.
+
+**Every file except the one you are in is faded.** The colors of its rows are pulled toward
+the background, so the file you are reading has a boundary. Cross into another file and the
+fade follows the cursor. The unit is the file, so moving between hunks changes nothing.
+
+**The file tree is never muted.** It draws in your colorscheme's own colors under every
+focus. Move into it and the panes mute, so you can see that your keys now act on the tree.
+
+The colors come from your own colorscheme, blended. Nothing here has a palette of its own.
+
+```lua
+opts = {
+  muted       = { enabled = true, strength = 0.5 },
+  faded       = { enabled = true, strength = 0.35 },
+  counterpart = { enabled = true, strength = 0.25 },
+}
+```
+
+Set `enabled = false` on any of the three to turn it off. Each `strength` is one number from
+0 to 1, saying how far toward the background a color goes.
+
+[What the counterpart row is for, why the tree is exempt, and how the three differ](docs/rationale.md#focus-and-fade)
+
+### The sticky header
+
+A file's header row scrolls off the top as soon as you read past the first screenful. The
+**sticky header** keeps it on the winbar:
+
+```
+ ○ ▾ src/routes.lua  +12 -3  [2 notes]        branch vs master · ✓2/7 · +40 -9 · ●2 · → janus
+```
+
+It carries the same icon, chevron, path, `+N -M` and annotation count that the in-buffer
+header carries, with the review summary right-aligned beside it. It names the file the
+**cursor** is in, which is the file an annotation attaches to.
+
+It works with the tree dismissed, and with a review opened without one.
+
+[Why glyphs, how the colors work, and what gives way on a narrow pane](docs/rationale.md#the-sticky-header)
 
 ## Configuration
 
@@ -759,13 +619,13 @@ opts = {
   untracked = true,                -- show untracked files in branch/worktree scopes
   syntax = true,                   -- treesitter highlighting
   max_syntax_bytes = 256 * 1024,   -- skip syntax above this size
-  layout = "unified",              -- "unified" or "split"; validated at setup
-  spans = true,                    -- emphasise what changed inside a changed line
+  layout = "unified",              -- "unified" or "split". Validated at setup
+  spans = true,                    -- emphasize what changed inside a changed line
   archived = true,                 -- draw already-dispatched entries on the diff, dimmed,
-                                   -- and tally the untouched ones on the winbar; `gA`
+                                   -- and tally the untouched ones on the winbar. `gA`
                                    -- overrides this for the rest of the session
-  muted = { enabled = true,        -- mute the pane that does not have focus; never the tree
-            strength = 0.5 },      -- how far its colours are pulled toward the background
+  muted = { enabled = true,        -- mute the pane without focus, never the tree
+            strength = 0.5 },      -- how far its colors are pulled toward the background
   faded = { enabled = true,        -- fade every file except the one the cursor is in
             strength = 0.35 },     -- its own number: this covers every file but one
   counterpart = { enabled = true,  -- light the row opposite the cursor in a muted pane
@@ -774,37 +634,25 @@ opts = {
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
             collapsed = "▸", expanded = "▾", change_bar = "▌",
             untouched = "↺" },     -- plain Unicode throughout: no Nerd Font anywhere
-  types = nil,                     -- defaults to the five above; see Typed annotations
+  types = nil,                     -- defaults to the five above. See Annotation types
 }
 ```
 
-Every highlight is a `default = true` link to a group your colorscheme already defines
-(`DiffAdd`, `Added`, `DiagnosticError`, …), so overriding any `CodeReview*` group works
-without the plugin fighting back. The two exceptions are `CodeReviewAddSpan` and
-`CodeReviewDelSpan`, which take `DiffText`'s background and set no foreground — still
-`default = true`, so overriding them works the same way.
-
-Three families of groups are computed rather than linked, and none is yours to set. A
-**muted** pane draws through a twin of each group named `CodeReviewMuted.` plus the group
-it blends — `CodeReviewMuted.CodeReviewAdd`, `CodeReviewMuted.@keyword`. A **faded** file's
-rows are drawn in a twin named `CodeReviewFaded.` plus the same, at `faded.strength` instead
-of `muted.strength`. The **counterpart row** a muted pane lights is one member only,
-`CodeReviewCounterpart.CursorLine`, at `counterpart.strength`. Each holds that group's own
-colours pulled that far toward the background, and each is written again on every colorscheme
-change, so setting one yourself is overwritten. Set the strength, or the group the twin is
-named for. A group your theme gives no colour of its own gets no twin in any of the three,
-and is drawn at full brightness — muted, faded or lit, that is the same rule.
+Every highlight is a `default = true` link to a group your colorscheme already defines, so
+overriding any `CodeReview*` group works. Three families of groups are computed rather than
+linked, and none is yours to set.
+[The full rules](docs/rationale.md#highlight-groups)
 
 ## Adapters
 
 The plugin has no opinion about where a review goes, about which pickers you use, or about
-which diff tool you read a rewrite in. Five optional functions inject that — **none are
+which diff tool you read a rewrite in. Five optional functions inject that. **None are
 required.**
 
 | Adapter | What it supplies | Without it |
 | --- | --- | --- |
 | `send` | Delivers the rendered batch | The payload goes to the `+` register |
-| `pick_target` | Chooses a delivery target | No target; `send` decides what that means |
+| `pick_target` | Chooses a delivery target | No target. `send` decides what that means |
 | `pick_file` | Picks a file for `@` in the composer | `@` stays a literal `@`, and says so |
 | `compose` | Collects note text | The composer the plugin ships |
 | `open_diff` | Reads one file in your own diff tool | `gd` is not bound at all |
@@ -819,10 +667,7 @@ opts = {
 }
 ```
 
-**You cannot annotate in whatever `open_diff` opens.** Nothing there has an anchor map, so
-it is a one-way trip: read the file closely, then come back to the review to say anything
-about it. It is for the rewrite that Neovim's own diff mode reads better than a unified
-diff does — a reformat, a re-indent, a file moved wholesale — not a second review surface.
+[Why a send reports dispatch and not arrival, and why you cannot annotate inside `open_diff`](docs/rationale.md#adapters)
 
 <details>
 <summary>The full contract for each</summary>
@@ -835,54 +680,47 @@ opts = {
   -- A dispatch is the one thing that empties the queue, so a batch that did not go is
   -- still there to retry, and an immediate send that did not go keeps its note as a
   -- draft. A refusal is reported as an error. Without this the payload goes to the +
-  -- register, which is the default implementation of this same contract — it reports a
+  -- register, which is the default implementation of this same contract -- it reports a
   -- non-dispatch (a register is not a consumer), which is why an unwired host keeps its
   -- queue, and it is a warning rather than an error because nothing is broken. `gy` puts
   -- the payload in that register deliberately, whatever is wired here, so what an adapter
   -- receives is readable without submitting to find out.
   send = function(payload, target) return true end,
 
-  -- Choose a delivery target; call back with anything carrying `short` and `cwd`.
+  -- Choose a delivery target. Call back with anything carrying `short` and `cwd`.
   -- `cwd` matters: refs are re-resolved against it at submit time.
   pick_target = function(cb) cb({ short = "agent", cwd = "/path" }) end,
 
   -- Choose a file to reference from `@` inside the composer. The plugin ships no picker,
-  -- so without this `@` stays a literal `@` and says so. `first`/`last` are optional —
+  -- so without this `@` stays a literal `@` and says so. `first`/`last` are optional --
   -- omit them and the reference is to the file rather than to a range in it.
   pick_file = function(cb) cb({ path = "src/main.lua", first = 12, last = 20 }) end,
 
   -- Collect note text. Without it you get the composer the plugin ships, which implements
-  -- this same contract — wiring one replaces that composer rather than upgrading a prompt.
+  -- this same contract -- wiring one replaces that composer rather than upgrading a prompt.
   -- `ctx` describes what is being annotated: `scope`, `label`, `rel_path`, `file_path`,
-  -- and `origin_win` — the window the annotation was started from. Focus goes back there
-  -- once `on_accept` runs; a composer the user can *cancel* never calls it, so that path
+  -- and `origin_win` -- the window the annotation was started from. Focus goes back there
+  -- once `on_accept` runs. A composer the user can *cancel* never calls it, so that path
   -- is the composer's to restore.
   --
-  -- On an immediate send `ctx.routing` is also there — `{ label(), pick(on_done) }` for
+  -- On an immediate send `ctx.routing` is also there -- `{ label(), pick(on_done) }` for
   -- the target *this note* will reach. Name it, and change it with `pick`. It is absent
   -- for a note joining the queue, which the batch routes.
   compose = function(ctx, on_accept, label) on_accept(nil, "text") end,
 
-  -- Read one file in the diff tool you already have — DiffviewOpen, :Gdiffsplit, your own
+  -- Read one file in the diff tool you already have -- DiffviewOpen, :Gdiffsplit, your own
   -- diffthis pair. The plugin ships none of that: it hands over the file and the two refs
   -- its scope is between and stops caring. `path` is absolute and is the post-image path,
   -- so for a rename the pre-image lives elsewhere in `before`. `after` is nil whenever the
-  -- post-image is the working tree — that is most scopes, and it is not an error: nil
+  -- post-image is the working tree -- that is most scopes, and it is not an error: nil
   -- means the file on disk. `line` is nil when the file was named from the file tree,
   -- which knows a file and no position in it.
-  --
-  -- Bound to `gd` only while this is wired, in the diff and in the tree. A key that
-  -- silently did nothing would be worse than no key.
   open_diff = function(spec)
     local rev = spec.after and (spec.before .. ".." .. spec.after) or spec.before
     vim.cmd(("DiffviewOpen %s -- %s"):format(rev, vim.fn.fnameescape(spec.path)))
   end,
 }
 ```
-
-[ADR-0005](docs/adr/0005-a-send-reports-dispatch-not-arrival.md) records why "dispatched"
-is the narrow promise — the adapter most hosts wire is asynchronous, and holding the queue
-until an agent confirmed would keep a sent batch queued for the length of that agent's work.
 
 </details>
 
@@ -900,86 +738,39 @@ opts = {
 ```
 
 `scope = "none"` and `prerendered = true` are both load-bearing, and `pick_target`'s `cwd`
-is what decides whether refs survive. [`docs/herdr.md`](docs/herdr.md) explains why, and
-spells out which queue is which.
+decides whether refs survive. [`docs/herdr.md`](docs/herdr.md) explains why, and spells out
+which queue is which.
 
 </details>
 
 ## Persistence
 
-Reviewed marks, the queue and the batches already dispatched are stored per repository
-under `stdpath("state")/codereview/`, keyed by scope and diff base, and survive a restart.
-Each entry records the git blob it was captured against. On reload:
+The plugin stores reviewed marks, the queue and the batches already dispatched per
+repository, under `stdpath("state")/codereview/`. It keys them by scope and diff base, and
+they survive a restart. Each entry records the git blob it was captured against.
 
-- a **reviewed mark** whose blob moved is silently un-marked — the file changed, so you
-  have not reviewed what is there now;
-- an **annotation** whose blob moved is kept and flagged `⚠ stale`, because the prose is
-  still worth sending and only its line anchor is untrustworthy. A stale entry never
-  travels as an `@ref`; its code is inlined instead.
+On reload:
 
-Two things deliberately do **not** persist: the delivery target, which names a live
-destination a restart would make dead, and the layout `gl` last chose, which is a
-preference rather than review progress. The store is per repository and neither of those
-is; both last for the session and no longer.
+- A **reviewed mark** whose blob moved is silently un-marked. The file changed, so you have
+  not reviewed what is there now.
+- An **annotation** whose blob moved is kept and flagged `⚠ stale`. The prose is still worth
+  sending, and only its line anchor is untrustworthy. A stale entry never travels as an
+  `@ref`, and the plugin inlines its code instead.
 
-<details>
-<summary>Annotations with no repository behind them</summary>
+Two things deliberately do **not** persist: the delivery target, and the layout `gl` last
+chose. Both last for the session and no longer.
 
-A bare note, or a file outside any checkout, has nowhere repository-shaped to live, so it
-goes to a single global store beside the others. Nothing ever reconciles that store against
-a diff, so nothing would ever clear it: entries older than **seven days** are dropped when
-it is read. That bounds its growth but not its staleness, which is the accepted cost of not
-making those annotations second-class.
-
-</details>
-
-<details>
-<summary>What a dispatched batch leaves behind</summary>
-
-A batch that is **dispatched** is kept rather than forgotten: the annotations as they went,
-the **preamble** they went out under where there was one, where they went, when, and a
-**snapshot** of the working tree at that moment — a commit
-object minted with `git stash create`, which moves no ref, leaves the index alone and never
-touches your files. On a clean tree there is nothing to record that `HEAD` does not already
-say, and `HEAD` is what is stored.
-
-A dispatch writes it and nothing else does. An adapter that declined, one that raised, the
-`+` register the default send copies to and the one `gy` copies to deliberately all leave
-it exactly as they leave the queue — a payload sitting in a register is not something an
-agent received. An immediate send is a batch of one and is kept as one. The most recent
-**twenty** batches are kept per store, oldest dropped on write.
-
-`:CodeReviewLastBatch` reads the newest one back. A batch holding both kinds of annotation
-is written to both stores and rejoined by the moment it was dispatched, which is what stops
-a bare note being the one thing missing from what you read back. Both halves carry the same
-preamble, for the reason they carry the same stamp and the same target: it belongs to the
-dispatch and not to either half of it. A record written before batches could carry one
-lacks the field and reads back with none, exactly as one written before the archive existed
-lacks the archive.
-
-</details>
-
-<details>
-<summary>What staleness is judged against</summary>
-
-Each kind is judged against whatever its blob was actually taken from. A review annotation
-is judged against the diff on screen, and a file the current scope does not include is not
-evidence that anything changed — so it is left alone. An annotation captured from a buffer
-has no scope behind it and is judged against the file on disk, at any scope and with no
-review open. That distinction matters in a `staged` review, where the diff shows the index
-and a buffer capture holds the working tree: judging one by the other would flag a note
-about a file nobody has touched.
-
-</details>
+[Where a bare note lives, what a dispatched batch leaves behind, and what staleness is judged against](docs/rationale.md#persistence)
 
 ## Documentation
 
 | Where | What is in it |
 | --- | --- |
 | `:help codereview` | The full reference — every command, mapping, option and Lua API |
-| [`docs/design-notes.md`](docs/design-notes.md) | Every non-obvious constraint that cost real debugging time |
+| [`docs/rationale.md`](docs/rationale.md) | Why the behavior is what it is |
 | [`docs/adr/`](docs/adr/) | The decisions behind the architecture, and why |
 | [`CONTEXT.md`](CONTEXT.md) | The project's vocabulary — *scope*, *pane*, *filler*, *dispatch*, … |
+| [`docs/design-notes.md`](docs/design-notes.md) | Every non-obvious constraint that cost real debugging time |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Setup, tests, the commit convention, PR shape |
 
 ## Development
@@ -990,39 +781,40 @@ make test    # the suite: one Neovim per spec file, ~5s
 make lint    # stylua --check
 ```
 
-Tests are plenary/busted specs under `tests/codereview/`, each building its own throwaway
-git fixture. CI runs them on Neovim stable and nightly with plenary as the only dependency
-— no nvim-treesitter and no compiler, because the fixtures are Lua and Markdown and those
-parsers ship with Neovim. See [`tests/README.md`](tests/README.md) for the layout, what is
-deliberately not covered, and the traps worth knowing before changing a fixture.
+Tests are plenary/busted specs under `tests/codereview/`, and each one builds its own
+throwaway git fixture. CI runs them on Neovim stable and nightly, with plenary as the only
+dependency. There is no nvim-treesitter and no compiler, because the fixtures are Lua and
+Markdown and those parsers ship with Neovim.
+
+See [`tests/README.md`](tests/README.md) for the layout, what is deliberately not covered,
+and the traps worth knowing before you change a fixture.
 
 ## Contributing
 
-Issues and pull requests are welcome. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) —
-setup is `make hooks && make deps && make all`, and it takes about five seconds to know
-whether the suite is green.
+Issues and pull requests are welcome. Start with [`CONTRIBUTING.md`](CONTRIBUTING.md). Setup
+is `make hooks && make deps && make all`, and it takes about five seconds to know whether the
+suite is green.
 
-Open an issue first for anything with a design decision behind it; typo fixes and
+Open an issue first for anything with a design decision behind it. Typo fixes and
 obviously-correct one-liners can go straight to a PR. Participation is under the
-[Code of Conduct](CODE_OF_CONDUCT.md); security reports go through
-[`SECURITY.md`](SECURITY.md), not the issue tracker.
+[Code of Conduct](CODE_OF_CONDUCT.md). Security reports go through
+[`SECURITY.md`](SECURITY.md), and not through the issue tracker.
 
 ### Built with Claude Code
 
-This plugin was written with [Claude Code](https://claude.com/claude-code), and it is set
-up so anyone can keep working on it that way. Said plainly for two reasons: so you know
-what you are reading, and so you know agent-assisted contributions are welcome here rather
-than merely tolerated.
+This plugin was written with [Claude Code](https://claude.com/claude-code), and it is set up
+so that anyone can keep working on it that way. We say this plainly for two reasons. The
+first is so that you know what you are reading. The second is so that you know that
+agent-assisted contributions are welcome here, rather than merely tolerated.
 
-The repo carries what an agent needs to be useful in it rather than merely fast:
-[`CLAUDE.md`](CLAUDE.md) holds the workflow in imperative form, [`docs/agents/`](docs/agents/)
-records where issues live and how they are labelled, and
-[`docs/design-notes.md`](docs/design-notes.md) exists because several obvious-looking
-approaches here are wrong for reasons no amount of reading the code reveals. Point an agent
-at `CLAUDE.md` and it will follow the same branch, commit and PR conventions a human
-contributor does.
+The repo carries what an agent needs to be useful in it rather than merely fast.
+[`CLAUDE.md`](CLAUDE.md) holds the workflow in imperative form. [`docs/agents/`](docs/agents/)
+records where issues live and how they are labeled. [`docs/design-notes.md`](docs/design-notes.md)
+exists because several obvious-looking approaches here are wrong, for reasons that no amount
+of reading the code reveals. Point an agent at `CLAUDE.md` and it follows the same branch,
+commit and PR conventions a human contributor does.
 
-The bar is the same either way — the tests pass, the design notes were read, and you can
+The bar is the same either way: the tests pass, the design notes were read, and you can
 answer questions about the change in review. There is no requirement to disclose tool use,
 and no penalty for it.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Report privately — **do not open a public issue**.
 - Or email **jfelipevalr@gmail.com**
 
 Include what an attacker can do, the repository or configuration shape needed to reach it,
-and a reproduction if you have one. Expect an acknowledgement within a week.
+and a reproduction if you have one. Expect an acknowledgment within a week.
 
 ## What is in scope
 
@@ -29,7 +29,7 @@ Neovim buffer. Things worth reporting:
 
 ## What is out of scope
 
-- The behaviour of any `send`, `pick_target` or `compose` adapter you supply. The plugin
+- The behavior of any `send`, `pick_target` or `compose` adapter you supply. The plugin
   hands the rendered payload to your function and has no opinion about where it goes;
   what that function does with it is yours to secure.
 - The plugin makes no network requests of its own, and reads no credentials.

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -26,7 +26,7 @@ lines, selections, hunks or whole files with a type; the annotations queue up;
 submit them as one batch. See |codereview-layouts|.
 
 Requires Neovim 0.12 or newer and `git`. Treesitter parsers are optional --
-files without one fall back to flat diff colours.
+files without one fall back to flat diff colors.
 
 ==============================================================================
 2. COMMANDS                                            *codereview-commands*
@@ -163,7 +163,7 @@ entry, gy copies the batch, <C-t> routes, <C-s> submits, <C-a> submits under a
 open -- it takes nothing out of the queue, so every row it is listing is
 still true.
 
-A jump closes the float and centres the line the annotation is about,
+A jump closes the float and centers the line the annotation is about,
 expanding the file first if it was collapsed. The queue is shared with the
 capture path and the float opens with or without a review, so some entries
 have nowhere to go: a bare note has no file at all, there may be no review
@@ -175,7 +175,7 @@ In the last-batch float (`gb`, or |:CodeReviewLastBatch| from anywhere): q and
 <Esc> close, and that is the whole of it. `x` and <C-s> are bound only to say why they do nothing,
 so the queue float's muscle memory gets a sentence rather than |E21| against a
 |nomodifiable| buffer. An annotation is drawn there exactly as the queue float
-draws one -- the reserved gutter, the bar in its type's colour, the code it
+draws one -- the reserved gutter, the bar in its type's color, the code it
 inlined and its note -- so the two read as one family; what is missing is
 every key that would change something. A |codereview-preamble| is drawn above
 them all, as prose rather than as an entry: no gutter and no bar, because it
@@ -278,9 +278,9 @@ the opposite pane holding its place so the two stay aligned.
 
 The panes are held together with |scrollbind| and |cursorbind|, which are
 window-local. |scrollopt| is global and is deliberately not touched, so
-vertical movement is synchronised and horizontal scrolling is not.
+vertical movement is synchronized and horizontal scrolling is not.
 
-One behavioural difference, and only one: a visual range cannot span both
+One behavioral difference, and only one: a visual range cannot span both
 images, because the two runs live in different windows and cannot be in one
 selection. Pure-addition and pure-deletion ranges work, and annotating the
 hunk header captures both images inlined -- so what a split range cannot
@@ -298,7 +298,7 @@ Which pane the cursor lands in follows the line's side: a deleted line lands
 in the left pane, an added or context line in the right. Switching back is
 unambiguous, since one anchor has one row. A cursor on filler has no
 counterpart in the unified layout at all, so it falls back to that file's
-header. The landing line is centred, because the row moved structurally and
+header. The landing line is centered, because the row moved structurally and
 an exact scroll offset carried across would mean nothing.
 
 Nothing else changes. Reviewed marks, expanded state, the queue, the current
@@ -338,9 +338,9 @@ ambiguous. All of them come from `icons` (|codereview-config|) and all of them
 are plain Unicode -- no Nerd Font is needed anywhere in this plugin. The bar
 does not name the review itself.
 
-It is coloured, in groups of the plugin's own that are default links into your
+It is colored, in groups of the plugin's own that are default links into your
 colorscheme: added counts green and removed counts red, the note count in the
-colour notes carry on the diff, the target accented, the separators dimmed,
+color notes carry on the diff, the target accented, the separators dimmed,
 and the path left in the bar's own group, which makes it the brightest thing
 on the left. See |codereview-highlights|. A pane without focus mutes its bar
 with everything else in it.
@@ -357,12 +357,12 @@ segment.
 What changed inside a line                                 *codereview-spans*
 
 Where a deletion and an addition are two versions of the same line, the spans
-that actually differ are emphasised inside them. The rest of the line keeps
+that actually differ are emphasized inside them. The rest of the line keeps
 its ordinary deletion or addition background, so the emphasis means something
 by contrast: >
     ▌20 │ -const cfg = load()
     ▌20 │ +const cfg = loadConfig()
-                           ^^^^^^ emphasised
+                           ^^^^^^ emphasized
 <
 On by default; switch it off with `spans = false`, validated at
 |codereview.setup()| like the other settings. With it off no span work is
@@ -379,8 +379,8 @@ them against.
 Granularity is characters, not tokens, so an edit inside an identifier is
 pointed at precisely rather than widened to the whole word, and a
 whitespace-only change is visible rather than mysterious. Where the two lines
-share so little that emphasising the change would emphasise nearly all of both
--- more than 60% of the longer line -- the pair is left plainly coloured: that
+share so little that emphasizing the change would emphasize nearly all of both
+-- more than 60% of the longer line -- the pair is left plainly colored: that
 is a replacement rather than an edit.
 
 Spans are computed when the diff is parsed, not when it is drawn, so a resize,
@@ -396,25 +396,25 @@ See |codereview-highlights| for the two groups it draws with.
 The pane you are not in                                  *codereview-muted*
 
 A review holds up to three windows -- the two panes and the file tree -- and
-the pane that does not have focus is *muted*: its colours pulled toward the
+the pane that does not have focus is *muted*: its colors pulled toward the
 background, so which window your next keystroke acts on is on screen rather
 than something you press a key to find out. Every pane goes on drawing a
 |cursorline|; the muted one draws it in a group of its own
 (|codereview-counterpart|).
 
 The file tree is never muted. It is the map of the review, so it draws in
-your colorscheme's own colours whichever window has focus, and the row for
+your colorscheme's own colors whichever window has focus, and the row for
 the file you are reading stays lit. Moving into the tree still mutes the
 panes -- both of them in the split layout, the one of them in the unified
 layout -- so the rule above holds of the panes and says nothing about the
 tree.
 
 Muting is a window-local highlight namespace holding a variant of every group
-in play, each computed by blending that group's colours toward `Normal`'s
-background. So the colours are your colorscheme's, blended -- never a palette
+in play, each computed by blending that group's colors toward `Normal`'s
+background. So the colors are your colorscheme's, blended -- never a palette
 of the plugin's own -- and a group it cannot know about is left at full
 brightness rather than guessed at: an unfamiliar theme degrades to less
-muting and never to wrong colours. The set is recomputed when you change
+muting and never to wrong colors. The set is recomputed when you change
 colorscheme.
 
 The bright window is the review window focus was last in, not the window with
@@ -429,7 +429,7 @@ review behind them looks exactly as you left it.
 The file you are not in                                  *codereview-faded*
 
 Every file in the review except the one the cursor is in is *faded*: the
-colours of its rows pulled toward the background, so the file you are reading
+colors of its rows pulled toward the background, so the file you are reading
 has a boundary and the file you just left stops competing with it. Crossing
 into another file moves the fade with the cursor. The unit is the file and
 never the hunk, so moving from one hunk to the next inside one file changes
@@ -441,7 +441,7 @@ than to hide the map. Its hunk headers fade with its body.
 
 The fade changes which highlight group each mark carries and nothing else, so
 faded code keeps its syntax structure instead of flattening to one tone, and
-the order things are drawn in is exactly what it was. The colours are the
+the order things are drawn in is exactly what it was. The colors are the
 muting's arithmetic on your own colorscheme, at a strength of its own, and a
 group the plugin cannot know about is left bright -- the same rule as above.
 A cursor in no file fades nothing.
@@ -464,7 +464,7 @@ is a filler (|codereview-layouts|) -- a pure addition -- the lit blank row is
 what says nothing existed there before, which is the case this exists for.
 
 Which row is lit stays Neovim's business, because the panes are cursorbound.
-Only which colour it is lit in is the plugin's: nothing is drawn onto the diff
+Only which color it is lit in is the plugin's: nothing is drawn onto the diff
 and no extmark is added. It follows the muting, so a pane at full brightness
 lights its row at full strength and the file tree is untouched -- the tree is
 not cursorbound, and its lit row names the file you are reading.
@@ -507,13 +507,13 @@ that group in the submitted payload:
 <
     name        required -- what annotate() takes, and what an entry stores
     key         required -- pressed after the `a` prefix, so `q` binds `aq`
-    label       defaults to the name, title-cased and pluralised
+    label       defaults to the name, title-cased and pluralized
     icon        defaults to `icons.annotated`
-    hl          defaults to CodeReview<Name>, linked so it has colour
+    hl          defaults to CodeReview<Name>, linked so it has color
     directive   optional -- the heading is then just "## Questions (3)"
 
 Order is the order groups appear in the payload, most actionable first.
-Pluralisation is naive, so an irregular name wants an explicit `label`.
+Pluralization is naive, so an irregular name wants an explicit `label`.
 
 A list that cannot work is rejected at |codereview.setup()| naming the entry
 that caused it: a missing or duplicated `name` or `key`, a `key` of "a" (which
@@ -548,12 +548,12 @@ the window that asked. For an |codereview-immediate-send| it is that note's own
 target, and rerouting it leaves the batch pointing where it was.
 
 `@` references another file, through |codereview-opt-pick_file|. It is written
-into the note before the picker opens, so cancelling leaves the character you
+into the note before the picker opens, so canceling leaves the character you
 typed -- and it only opens a picker where a word begins, so an email address in
 a note is an email address.
 
 Either way you are left writing where the picker left off: past the reference
-and the space after it, or past the `@` if you cancelled, and back in insert
+and the space after it, or past the `@` if you canceled, and back in insert
 mode. A picker takes focus and insert mode with it, and asking for a reference
 mid-sentence is not asking to stop writing.
 
@@ -971,7 +971,7 @@ Defaults: >
 <
 `max_syntax_bytes` bounds the one operation with a real performance cliff.
 Files above it, files with no parser, and binary files all fall back to flat
-diff colours individually -- never the whole view.
+diff colors individually -- never the whole view.
 
 `spans` switches the intra-line emphasis (|codereview-spans|). It is on by
 default. On a 12,000-line diff it lengthens opening a review by roughly a
@@ -985,14 +985,14 @@ nothing drawn, nothing tallied and no `git` spent judging. `gA` overrides it
 for the rest of the session, in both directions, and writes nothing here.
 
 `muted` mutes the pane that does not have focus (|codereview-muted|); the
-file tree is never muted. `strength` is how far a colour is pulled toward the
+file tree is never muted. `strength` is how far a color is pulled toward the
 background, from 0 to 1. Coarse the same way: off is nothing muted, nothing
 computed and no highlight namespace attached to any window.
 
 `faded` fades every file except the one the cursor is in (|codereview-faded|).
 `strength` is the same number for a different rule, and gentler by default
 because the fade covers every file but one where the muting covers a window.
-Coarse the same way: off is nothing emitted, no colour computed, and the diff
+Coarse the same way: off is nothing emitted, no color computed, and the diff
 drawn exactly as it was before this existed.
 
 `counterpart` lights the row opposite your cursor in a muted pane
@@ -1047,9 +1047,9 @@ Two are not links. The intra-line spans (|codereview-spans|) take `DiffText`'s
 <
 A foreground there would sit beneath the treesitter replay, which is drawn at
 a higher priority -- so it would lose wherever a parser had painted and win
-wherever one had not, which is emphasis that changes colour depending on which
+wherever one had not, which is emphasis that changes color depending on which
 languages you have installed. A background alone composes with the replay, and
-that is what keeps code readable inside an emphasised span. Both are still
+that is what keeps code readable inside an emphasized span. Both are still
 `default = true`, so overriding either works the same way as the rest.
 
 Three more families are computed, and none is yours to set. A **muted**
@@ -1061,10 +1061,10 @@ carries a twin named `CodeReviewFaded.` plus the same, blended at
 (|codereview-counterpart|) is a family of one member: >
     CodeReviewCounterpart.CursorLine
 <
-blended at `counterpart.strength`. Each holds the group's own colours pulled
+blended at `counterpart.strength`. Each holds the group's own colors pulled
 that far toward the background, and each is written again on every colorscheme
 change, so a definition of your own is overwritten. Set the strength, or the
-group the twin is named for, instead. A group the active theme gives no colour
+group the twin is named for, instead. A group the active theme gives no color
 of its own gets no twin in any of the three, and is drawn at full brightness.
 
 ==============================================================================

--- a/docs/adr/0003-the-plugin-ships-the-composer.md
+++ b/docs/adr/0003-the-plugin-ships-the-composer.md
@@ -5,7 +5,7 @@ adapter — handed exactly what a host composer is handed, required to do exactl
 must. A host that injects its own replaces it rather than upgrading from a lesser path.
 
 The obvious alternative was what this replaced: a one-line prompt built in, with anything
-better left to the host. That produced two behaviours to keep in step, and pushed every host
+better left to the host. That produced two behaviors to keep in step, and pushed every host
 into reimplementing a floating buffer with a submit key before it could have drafts or
 references.
 

--- a/docs/agents/HANDOFF.md
+++ b/docs/agents/HANDOFF.md
@@ -65,7 +65,7 @@ Decisions worth not re-litigating, and the four things that changed along the wa
 - **The rename fixture is three lines, not two.** git compares whole lines, so a two-line
   file with one line rewritten lands at 47% similarity — under the 50% default — and the
   rename silently degrades into an add plus a delete.
-- **git config is neutralised** in both the fixture scripts and `minimal_init.lua`
+- **git config is neutralized** in both the fixture scripts and `minimal_init.lua`
   (`GIT_CONFIG_GLOBAL=/dev/null`). Inherited settings change what a fixture *means*:
   `diff.renames = false` breaks the rename case, and `commit.gpgsign` makes building a
   fixture depend on a gpg agent — which no CI runner has.
@@ -119,7 +119,7 @@ post-image). Do not start this alongside anything else.
 - **The gitsigns diff base is gone.** The host's `claude_review.start()` also called
   `gitsigns.change_base(merge_base, true)`, which made `]h`/`[h` walk branch-relative hunks
   in ordinary buffers. The plugin never touched gitsigns, so the cutover removed that with
-  nothing replacing it. Deliberate, but it is the one behaviour the cutover lost — if `]h`
+  nothing replacing it. Deliberate, but it is the one behavior the cutover lost — if `]h`
   feels wrong outside a review, this is why.
 - **The local delivery path still needs claudecode.nvim.** `util.claude.deliver` falls back
   to `deliver_local` when no target is chosen, and that requires `claudecode`. Picking a

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -67,13 +67,13 @@ in `EDITOR_GROUPS`; every group the bar asks for is in `LINKS`, which is what `h
 derives the muted set from, so a bar group added anywhere else is one a muted pane leaves
 bright. `split_spec` reads two cells of one bar for exactly this reason: one inside the path,
 which carries no group of the plugin's own and is where the muting is proven, and one on the
-file's added count, which carries one and is where the colour is.
+file's added count, which carries one and is where the color is.
 
 **The path is the one thing on the bar left in the bar's own group**, and that is what makes
 it the brightest thing on the left rather than any group being brighter: the icon and the
 chevron in front of it are quiet, the separators quieter still, and everything else carries
 the group the surface saying the same thing on the diff carries — the stat, the note count
-and the untouched tally are the diff's own groups, not a second set for the bar. One colour,
+and the untouched tally are the diff's own groups, not a second set for the bar. One color,
 one meaning, wherever a reviewer meets it.
 
 **Every name on the winbar is escaped, per segment, and the bar is padded by hand in display
@@ -83,8 +83,8 @@ The rule is the same one the wholesale escape held: the bar carries a path a rev
 repository chose, and a `%f` in one would be read as a statusline item and expanded into
 something else. What moved is where it is applied, so that a caller cannot pass a path
 unescaped by accident: a segment has to say which kind it is, and the kind that takes a name
-is the kind that escapes it. **Escaping is by kind and colouring is not** — either kind may
-carry a highlight group, because most of what is worth colouring on this bar is a name: the
+is the kind that escapes it. **Escaping is by kind and coloring is not** — either kind may
+carry a highlight group, because most of what is worth coloring on this bar is a name: the
 **target**, the base revision, a count carrying a glyph a host configured. The alternative is
 a caller writing the markers around a name by hand, which is markup arriving from outside the
 one seam that decides what markup is. The statusline's `%=` would now be possible, and would
@@ -97,7 +97,7 @@ a bar padded by `#` lands a dozen columns short of the pane while every ASCII as
 the suite still passes; the renamed file is what catches it. The mirror of that is a
 highlight marker: `%#Group#` is characters in the string and no columns at all on the
 screen, so a bar measured with its markers in drifts the other way, by the width of every
-one of them. That half stopped being hypothetical the moment the bar was coloured: a
+one of them. That half stopped being hypothetical the moment the bar was colored: a
 hundred-column bar is now some two hundred and fifty characters, so a ruler counting the
 string overshoots by more than the pane is wide. Both are why the padding is arithmetic
 rather than `%=` — the fitting rule has to know how many columns the path may keep, which is
@@ -123,9 +123,9 @@ emitted, so the buffer and the anchor map stay small on a large review, and ther
 mechanism instead of two.
 
 **The intra-line span groups set a background and no foreground.** They sit at a priority
-band above the line's own diff colour and below the treesitter replay, so a foreground there
+band above the line's own diff color and below the treesitter replay, so a foreground there
 would lose to the replay wherever a parser had painted and win wherever one had not —
-emphasis that changes colour depending on which languages the reader has installed. A
+emphasis that changes color depending on which languages the reader has installed. A
 background alone composes with the replay, which is what keeps code readable inside a span.
 It is also why the two groups copy `DiffText`'s background instead of linking to it: a link
 would carry the foreground along.
@@ -147,7 +147,7 @@ directly avoids both quirks.
 each line as a sequence of *characters*. The obvious implementation — splitting a Lua string
 with a pattern — splits by byte, passes every ASCII test in the suite, and corrupts the first
 accented, CJK or emoji line it meets: `é` and `è` share their leading byte, so a byte-wise
-diff emphasises a trailing byte alone, which is a boundary inside a character and a
+diff emphasizes a trailing byte alone, which is a boundary inside a character and a
 rendering error rather than a cosmetic one. Correctness costs about 6 ms across 6,000 line
 pairs, so there is no performance argument for the other one. `src/nonl.md` in `mkfixture`
 is the only fixture line that can fail this, and it is there on purpose.
@@ -462,7 +462,7 @@ The `untouched` segment is read off the view rather than computed by the winbar,
 only drops it when the archive has been *written* since the last verdict — which turning the
 switch off is not. So a toggle that merely repaints leaves the number on the bar while
 nothing it counts is on the diff, which is the one state this feature's coarseness exists to
-refuse. `view.toggle_archived` runs the judgement itself, and that is also where the two
+refuse. `view.toggle_archived` runs the judgment itself, and that is also where the two
 `git` invocations behind the number are skipped when the answer is "nothing drawn".
 
 **`git stash create` mints a commit and does nothing else.** No ref moves, the index is not
@@ -552,7 +552,7 @@ almost no highlights of its own — and the tree is never muted now, so there is
 there for it to do.
 
 **That namespace holds links, and the link is what makes the blend reachable.** Each entry
-names the group that holds the blended colour — `CodeReviewMuted.` plus the group it blends,
+names the group that holds the blended color — `CodeReviewMuted.` plus the group it blends,
 so `@keyword` becomes `CodeReviewMuted.@keyword`. A group name with `@` and dots in it is
 legal, and only a name that *starts* with `@` gets the treesitter fallback chain. Three
 facts here were measured, not assumed:
@@ -562,14 +562,14 @@ facts here were measured, not assumed:
 - `:colorscheme` clears every global group, the blended ones with the rest, but it leaves
   the namespace's links alone. So a theme change is the groups' problem and the namespace
   needs no part of it. What the window rule does on `ColorScheme` is one more pass, for a
-  group the new theme gives a colour to at last.
+  group the new theme gives a color to at last.
 - **A link that reaches no definition draws nothing at all.** It does not fall back to the
   global group, which is what a namespace with no entry does. So a group with no blend must
   have *no* entry in the namespace, and a blend the new theme cannot compute keeps its
   group as a link back to the group it blends. Either way that group draws bright. An entry
   that points at a group the theme wiped draws a hole.
 
-**A highlight namespace colours a whole window, so it cannot colour one part of one.** That
+**A highlight namespace colors a whole window, so it cannot color one part of one.** That
 is the whole reason the two quiet states are two mechanisms rather than one. A **muted**
 window's unit *is* the window, so it is a namespace: attach it and every group the window
 draws is answered at once, including the groups the plugin cannot enumerate. A **faded**
@@ -588,16 +588,16 @@ the archive key nor the muting owns it: `muted_spec` presses the key with an arc
 really on the diff, and injecting a namespace reset or a `cursorline` clear onto that path is
 what gives the case its teeth.
 
-**A muted pane still lights a row, and the namespace is what makes it another colour.** The
+**A muted pane still lights a row, and the namespace is what makes it another color.** The
 panes are cursorbound, so Neovim already lights the row opposite the one being read; what was
-missing was a colour of its own for it. `cursorline` therefore stays set in every pane, and
+missing was a color of its own for it. `cursorline` therefore stays set in every pane, and
 the namespace links `CursorLine` to the **counterpart row**'s blend rather than to the
 muting's — a third family, holding that one member, because the alternative is a second copy
 of the blend arithmetic written where the row is lit. Nothing is emitted onto the diff, and a
-namespace could not have done it any other way: it colours a whole window, so *one row,
+namespace could not have done it any other way: it colors a whole window, so *one row,
 differently* has to be a group that window already draws that row in.
 
-**`line_hl_group` wins over `CursorLine`.** Measured, with `CursorLine` set to a colour
+**`line_hl_group` wins over `CursorLine`.** Measured, with `CursorLine` set to a color
 nothing else on screen holds: the cell on the cursor's own row printed the line background
 instead. So a row carrying one of its own — every added and deleted line, every file and hunk
 header — prints it whether or not the cursor is on that row, and a lit row can only be seen on
@@ -605,11 +605,11 @@ a context line, a **pad** or a **filler**. That is as true of the focused pane's
 counterpart row, and it has been since the plugin drew its first diff. It costs the
 counterpart row nothing in the case it exists for, because the row opposite a pure addition is
 a filler and a filler is blank. It is also why the painted cell proving the counterpart row is
-read on a context line: a reading taken on an added row prints the same colour lit or unlit,
+read on a context line: a reading taken on an added row prints the same color lit or unlit,
 and says nothing about either.
 
 **The fade renames a mark. It does not add one, and it does not change the priority order.**
-One grey foreground laid over a faded file at a priority above the syntax replay is the
+One gray foreground laid over a faded file at a priority above the syntax replay is the
 obvious shape and the wrong one: it wins where a parser painted and loses where none did, so
 the result changes with the parsers a reader happens to have installed. This project already
 refused that shape once, for the intra-line **span** emphasis, which is why those groups set

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -1,0 +1,432 @@
+# Rationale
+
+Why the behavior is what it is.
+
+The [README](../README.md) says what the plugin does. This file says why, for the choices
+that are not obvious from the behavior alone. Several of them look arbitrary until you read
+the reason. `:help codereview` is the full reference for every command, mapping and option.
+
+Three other documents cover different ground. [`CONTEXT.md`](../CONTEXT.md) holds the
+vocabulary. [`docs/adr/`](adr/) holds the architectural decisions. [`docs/design-notes.md`](design-notes.md)
+holds the constraints that cost real debugging time, and it is written for contributors.
+
+---
+
+## Trim
+
+**A trim is checked before it is used.** A rebase, an amend or a force-push leaves a trim
+that names a commit the branch no longer holds. The plugin then drops the trim, opens the
+full branch, and says in one sentence that the trim was lost.
+
+**Reviewed marks survive a trim.** A file that the dropped commits never changed keeps its
+mark. A file that moved since you marked it loses the mark, whether you trimmed or not. The
+mark is judged against the git blob, and a trim does not change any blob.
+
+**A detached `HEAD` has no branch name to key the trim under.** The trim works for the
+session, and one message says that the plugin does not keep it.
+
+**A trim is a modifier on the branch scope, not a scope of its own.** A sixth scope must
+answer what it means with no commit picked. `gs` is a key you hold down, and it must
+not get a new stop.
+
+**The word is subtractive**, because that is what the reviewer does. They remove commits
+from a whole that is there by default. "Trimmed to four commits" and "reset the trim" both
+read correctly, and the verb and the noun are one word.
+
+**The commit list is `--first-parent` from the merge base.** A merge is one row, and the
+commits that arrived through it are not listed beside your own. There is no limit on the
+rows, so a long branch keeps its oldest commits at the bottom of the list.
+
+The list does not show the author, because it is your own branch. It does not show the added
+and deleted counts, because they cost a second pass over the whole branch. The subject is
+what you recognize.
+
+**Two cases open nothing, and say why in one sentence.** The first is `gc` outside a branch
+review, where there is no branch behind the diff to list. The second is `gc` on a branch
+whose `HEAD` is the merge base, which has no commits of its own.
+
+A third case opens and works. On a detached `HEAD` the list is there and the trim applies,
+and one message says that the plugin does not keep the trim.
+
+---
+
+## since-batch
+
+`since-batch` is the one scope to reach for while an agent is working. It diffs against the
+snapshot the last batch went out with.
+
+It behaves like every other scope in every other respect. It is highlighted, navigable,
+collapsible and annotatable, and it draws in both layouts.
+
+`gs` reaches it only after a batch has gone from the repository. Before that there is
+nothing to diff against.
+
+---
+
+## The split layout
+
+**Buffer rows mean nothing across layouts.** The same line of the same hunk sits at a
+different row in each layout. What `gl` carries across is the anchor: the same line, of the
+same hunk, of the same file. The plugin finds the row that carries the anchor afterwards.
+
+The cursor lands in the pane its line belongs to, so switching back is unambiguous. A cursor
+on a filler row falls back to that file's header. The plugin centers the landing line,
+because an exact scroll offset across a structural move preserves nothing meaningful.
+
+**Chrome is split too.** A hunk header shows its pre-image range on the left. It shows its
+post-image range plus git's section heading on the right. A renamed file shows its old path
+on the left and its new path on the right. This holds on the winbar as well as in the buffer,
+so the left pane's sticky header names the pre-image path beside the revision it draws.
+
+**Horizontal scrolling is not synchronized.** Synchronizing it means changing `scrollopt`, a
+global option this plugin does not own.
+
+**One behavior differs between the layouts, and only one.** A visual range cannot span both
+images, because the two runs live in different windows and cannot be in one selection.
+Pure-addition and pure-deletion ranges work. Annotating the hunk header captures both images
+inlined, so what a split range cannot express is still one keystroke away.
+
+A layout is a rendering choice and nothing else. Which layout was on screen never reaches the
+receiving agent ([ADR-0002](adr/0002-one-queue-one-entry-shape.md)).
+
+---
+
+## Spans
+
+**Which lines pair.** The i-th deletion of a contiguous run pairs with the i-th addition of
+the run that follows it. This is the pairing the split layout already uses to put a deletion
+and its replacement on one row. Both layouts use it, which is why the same characters are
+emphasized either side of a `gl`.
+
+Where the runs are unequal, the surplus lines carry no emphasis. Neither does a pure
+addition, a pure deletion, or a file that exists on only one side. There is nothing to
+compare them against.
+
+**When it says nothing.** Above 60% of the longer line inside spans, the plugin leaves the
+pair alone. That is a replacement, not an edit.
+
+The figure was read off real diffs rather than derived. At 70%, a quarter of the unrelated
+pairs inside a long run were still emphasized. Every genuine one-line edit above 60% turned
+out to be a replacement wearing an edit's clothes. A re-indentation is nowhere near the
+threshold: every reformatted pair measured came in under 10%.
+
+**When the work happens.** At parse time, once per git read. It never happens during a
+repaint. On a 12,000-line diff the spans cost about as much again as a whole repaint. A
+repaint runs on every resize, expansion, reviewed toggle and scope change. `make perf`
+reports the figure on its own line, so a change that moves the work back into the repaint is
+visible.
+
+**Two highlight groups**, `CodeReviewAddSpan` and `CodeReviewDelSpan`, both take `DiffText`'s
+background and nothing else. A foreground there sits beneath the treesitter replay. It loses
+wherever a parser painted and wins wherever one did not, which is emphasis that changes color
+with the languages you have installed.
+
+The emphasis is a rendering refinement and nothing else. What you capture, what reaches the
+queue and what the payload says are all untouched
+([ADR-0002](adr/0002-one-queue-one-entry-shape.md)).
+
+---
+
+## Focus and fade
+
+Three mechanisms pull colors toward the background. They are separate on purpose, and
+[`CONTEXT.md`](../CONTEXT.md) keeps their names apart.
+
+### Muting
+
+**A muted pane still lights the row its cursor is on.** The muted pane lights a counterpart
+row: the same row, in a group of its own, blended more gently than the muting. It is bright
+enough to find and it never competes with the pane you are in.
+
+The panes are cursorbound, so the counterpart row sits opposite the line you are reading. On
+a pure addition it is the filler. A lit blank row says that nothing was here before. That is
+the fact you wanted, and the one you cannot otherwise get without counting rows.
+
+**The file tree is never muted.** It is the map of the review: the paths, the icons, the
+per-directory tallies and the `+N -M` counts. It draws in your colorscheme's own colors under
+every focus. Move into the tree and the panes mute instead, so you can see that your keys now
+act on the tree.
+
+**A float changes nothing.** The bright window is the review window you were last in, not the
+window that holds the cursor. This covers the composer, the queue float and the last-batch
+float.
+
+### Fading
+
+**The unit is the file, never the hunk.** Move from one hunk to the next inside one file and
+nothing changes on screen.
+
+**A faded file keeps its header row bright**, with its path, its `+N -M` and its annotation
+count. The review then reads as bright headers over quiet bodies, with one file at full
+strength. Its hunk headers fade with its body.
+
+**A faded file keeps its syntax structure** rather than flattening to one tone. What changes
+is which group each mark carries. The order the marks are drawn in never changes.
+
+The fade is drawn by changing which group a mark carries, never by a foreground laid over the
+file. A foreground above the syntax replay wins where a parser painted and loses where none
+did.
+
+`faded.strength` is gentler than `muted.strength` by default, because fading covers every
+file but one.
+
+---
+
+## The sticky header
+
+**It names the file the cursor is in**, not the file at the top of the window. That is the
+file an annotation attaches to, which is what you reach for when you annotate twenty lines
+into a hunk.
+
+**The summary counts in glyphs rather than words** — `✓2/7` reviewed, `●2` annotations, `↺2`
+untouched. Three numbers side by side then cannot be read as one another. Every glyph comes
+from the `icons` table, so you can change any of them. Every glyph is plain Unicode, so
+nothing here needs a Nerd Font.
+
+The bar does not name the review itself. A bar inside a review does not need to.
+
+**It is colored.** Added counts are green and removed counts are red. The annotation count
+takes the color that annotations carry everywhere else. The delivery target is accented. The
+separators are quieter than the facts between them. The path is the brightest thing on the
+left, which is the thing you scrolled there to keep.
+
+The groups are the plugin's own: `CodeReviewBarIcon`, `CodeReviewBarSep`,
+`CodeReviewBarTarget` and `CodeReviewBarRev`, beside the stat and annotation-count groups the
+diff already uses. Every one is a `default = true` link into your colorscheme. A theme you
+have never used supplies the colors, and a theme change mid-review follows.
+
+**In the split layout each pane names its own side**, so a rename reads correctly on the side
+that holds the old name. The unified layout spells it `old → new`, exactly as the file header
+does.
+
+**On a pane too narrow for both halves the summary gives way first**. It starts with what the file
+beside it now says twice. The path keeps its tail.
+
+The before pane's bar names the base revision, and it never gives that up for the path. Half
+a revision is worse than none of a path that the other pane names anyway.
+
+The bar is chrome of the review window it sits on, so it mutes with that window.
+
+---
+
+## The preamble
+
+**A preamble is never queued.** You write it at the moment the batch goes, and the plugin
+forgets it afterwards. The queue holds annotations and nothing else.
+
+**An abandoned composer sends nothing.** The queue is whole and nothing is archived. What you
+wrote is kept as a draft, so the next `<C-a>` offers it back rather than making you write it
+twice.
+
+**That draft is kept per repository**, not per file, because a preamble is about a batch and
+not about a line of code.
+
+**An empty composer still submits** and draws nothing at all. The payload is then exactly
+what `<C-s>` sends.
+
+**`gy` copies no preamble**, because copying is not submitting. An
+[immediate send](../README.md#send-one-annotation-now) carries none either: a batch of one
+has no batch to cover ([ADR-0004](adr/0004-an-immediate-send-is-a-batch-of-one.md)).
+
+**A preamble that went is part of the record.** The plugin keeps it with its batch and reads
+it back with it. A float that listed the findings and not the covering note describes a
+message nobody received.
+
+---
+
+## The last-batch float
+
+**It is read-only, and that is a statement about the record rather than a feature left out.**
+An archived entry says that something happened. A surface that let you drop, edit or resubmit
+one claims that the plugin can revise what an agent already received. To raise a point again,
+annotate again. That is an ordinary capture, and it joins the next batch.
+
+`x` and `<C-s>` are bound only to say why they do nothing here. They are bound rather than
+left off, so that the queue float's muscle memory gets a sentence instead of `E21`. Nothing
+else is bound: the batch has gone, and there is nothing left to route, drop or send.
+
+---
+
+## Archived entries
+
+**They draw in every scope**, not only `since-batch`. Knowing what you already said is worth
+as much wherever you are.
+
+**Consider a reviewer who continues while the agent works.** Without archived entries, that
+reviewer reads a diff with no memory of what it already sent. They report the same finding
+twice.
+
+An anchor that carries both a queued and an archived entry draws both, the queued one first.
+What is still to send outranks what has already gone. `x` there drops the queued entry and
+never the archived one. Nothing on the diff can revise a batch that already went, for the
+same reason the last-batch float is read-only.
+
+**`gA` overrides the configured value instead of writing it**, so your `setup()` call goes on
+saying what you wrote. The override holds for every review you open afterwards, so you press
+the key once and not once per review. It dies with the Neovim process, so a display
+preference never becomes durable state you forgot you set.
+
+Off is off entirely, exactly as the flag is. The `untouched` tally leaves the winbar with the
+entries, and no git is spent judging them.
+
+`CodeReviewArchived` colors the marker and `CodeReviewArchivedNote` colors the prose. Both are
+`default = true` links, so a colorscheme can say how dim "already sent" looks.
+
+---
+
+## Untouched files
+
+**The word is *touched*, not *addressed*.** The plugin knows that the file moved. It does not
+know that anyone read your annotation, agreed with it, or acted on it, and it will not imply
+otherwise.
+
+**Touched is not staleness.** Staleness is the same kind of comparison against a different
+blob. It is about entries still in the queue, and it means *this annotation can now be wrong*
+rather than *something happened here*. The two are never merged, and an archived entry never
+shows a stale flag.
+
+**Three things are left unjudged rather than guessed at:**
+
+- a file the current scope does not cover,
+- a file that was untracked when the batch went, because a snapshot does not record those,
+- a bare note, which is about no file at all.
+
+A file deleted since the dispatch counts as touched. Nothing judged means no segment at all,
+rather than a zero to misread.
+
+**The tally reads `0 untouched` inside `since-batch`.** That scope shows you exactly the files
+that moved, so every entry it covers is touched by definition. The files you are looking for
+are the ones it is not showing. `branch` and `worktree` are where the number earns its keep.
+
+---
+
+## Highlight groups
+
+Every highlight is a `default = true` link to a group your colorscheme already defines, such
+as `DiffAdd`, `Added` or `DiagnosticError`. Overriding any `CodeReview*` group works without
+the plugin fighting back.
+
+`CodeReviewAddSpan` and `CodeReviewDelSpan` are the two exceptions. They take `DiffText`'s
+background and set no foreground. They are still `default = true`, so overriding them works
+the same way.
+
+**Three families of groups are computed rather than linked, and none is yours to set.**
+
+| Family | Name | Strength |
+| --- | --- | --- |
+| Muted pane | `CodeReviewMuted.` plus the group it blends | `muted.strength` |
+| Faded file | `CodeReviewFaded.` plus the group it blends | `faded.strength` |
+| Counterpart row | `CodeReviewCounterpart.CursorLine`, one member only | `counterpart.strength` |
+
+Each holds that group's own colors pulled that far toward the background. Examples are
+`CodeReviewMuted.CodeReviewAdd` and `CodeReviewMuted.@keyword`. The plugin writes each family
+again on every colorscheme change, so a group you set yourself is overwritten. Set the
+strength, or set the group the twin is named for.
+
+**A group your theme gives no color of its own gets no twin in any of the three families.**
+The plugin draws it at full brightness. Muted, faded or lit, that is the same rule. An
+unfamiliar theme therefore degrades to *less muted*, and never to *wrong*.
+
+---
+
+## Persistence
+
+### Annotations with no repository behind them
+
+A bare note, or a file outside any checkout, has nowhere repository-shaped to live. It goes
+to a single global store beside the others.
+
+Nothing ever reconciles that store against a diff, so nothing ever clears it. The plugin
+drops entries older than seven days when it reads the store. That bounds the growth of the
+store but not its staleness, which is the accepted cost of not making those annotations
+second-class.
+
+### What a dispatched batch leaves behind
+
+A dispatched batch is kept rather than forgotten. The plugin records five things:
+
+- the annotations as they went,
+- the preamble they went out under,
+- where they went,
+- when they went,
+- a snapshot of the working tree at that moment.
+
+The snapshot is a commit object minted with `git stash create`. It moves no ref, it leaves the
+index alone, and it never touches your files. On a clean tree there is nothing to record that
+`HEAD` does not already say, so `HEAD` is what the plugin stores.
+
+**A dispatch writes the archive and nothing else does.** Four things leave the archive
+exactly as they leave the queue:
+
+- an adapter that declined,
+- an adapter that raised,
+- the `+` register the default send copies to,
+- the register `gy` copies to.
+
+A payload that sits in a register is not something an agent received.
+
+An immediate send is a batch of one, and the plugin keeps it as one. The most recent twenty
+batches are kept per store, and the oldest is dropped on write.
+
+A batch that holds both kinds of annotation is written to both stores. The plugin rejoins the
+two halves by the moment they were dispatched. That stops a bare note being the one thing
+missing from what you read back.
+
+Both halves carry the same preamble, for the reason they carry the same stamp and the same
+target. A preamble belongs to the dispatch, and not to either half of it. A record written before
+batches carried a preamble lacks the field and reads back with none. A record written
+before the archive existed lacks the archive.
+
+### What staleness is judged against
+
+Each kind of annotation is judged against whatever its blob was taken from.
+
+A review annotation is judged against the diff on screen. A file the current scope does not
+include is not evidence that anything changed, so the plugin leaves it alone.
+
+An annotation captured from a buffer has no scope behind it. The plugin judges it against the
+file on disk, at any scope and with no review open.
+
+That distinction matters in a `staged` review. There the diff shows the index and a buffer
+capture holds the working tree. Judging one by the other flags an annotation about a file
+nobody has touched.
+
+### What does not persist
+
+Two things deliberately do not persist. The delivery target names a live destination that a
+restart makes dead. The layout `gl` last chose is a preference rather than review progress.
+The store is per repository and neither of those is. Both last for the session and no longer.
+
+---
+
+## Adapters
+
+[ADR-0005](adr/0005-a-send-reports-dispatch-not-arrival.md) records why "dispatched" is the
+narrow promise. The adapter most hosts wire is asynchronous. Holding the queue until an agent
+confirmed keeps a sent batch queued for the length of that agent's work.
+
+**You cannot annotate in whatever `open_diff` opens.** Nothing there has an anchor map, so it
+is a one-way trip. Read the file closely, then come back to the review to say anything about
+it.
+
+`open_diff` is for the rewrite that Neovim's own diff mode reads better than a unified diff
+does. Examples are a reformat, a re-indent, and a file moved wholesale. It is not a second
+review surface.
+
+`gd` is bound only while `open_diff` is wired, in the diff and in the tree. A key that
+silently did nothing is worse than no key.
+
+---
+
+## Annotation keys
+
+Annotation keys carry an `a` prefix rather than being bound bare. Bare `b`, `f`, `n` and `s`
+shadow back-word, find-char, next-search and flash.nvim inside the buffer. `a` is append,
+which is dead in a `nomodifiable` buffer, so the prefix costs a keystroke and no motion.
+
+`]F` is the motion that matters once a review is underway. The point of marking files
+reviewed is to stop looking at them. The useful motion is "the next thing I have not done",
+not "the next file", which walks back through everything already finished.
+
+Pluralization of a type's label is naive: the plugin adds `s` unless the name already ends in
+one. A name that English declines irregularly wants an explicit `label`.

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -34,7 +34,7 @@ change there is felt through.
 | `state.lua` | Persisted review progress, the blob comparisons over it — staleness, and touchedness kept in a function of its own — and each branch's **trim**, checked against `HEAD` before it is handed back | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `trim_float.lua` | The float over the branch's commits: the first-parent listing from the base handed in, one row per commit, the row a **trim** starts at, and the pick that applies one | stateful (float) |
-| `types.lua` | Annotation types: defaults, normalisation, labels, and the directive that earns a type its keystroke | pure |
+| `types.lua` | Annotation types: defaults, normalization, labels, and the directive that earns a type its keystroke | pure |
 | `view.lua` | The review view: the `CRView` it owns, the paint, navigation, delivery, opening and closing | stateful (windows) |
 | `view_layout.lua` | Where the review's windows are: the panes, the before pane, the toggle between the unified and split layouts, which of them is muted, and which group each lights its row in | stateful (windows) |
 | `view_panel.lua` | The file tree's stateful half: its window and buffer, the repaint that follows the diff cursor, and the actions its keys run | stateful (windows) |

--- a/lua/codereview/annotate.lua
+++ b/lua/codereview/annotate.lua
@@ -301,7 +301,7 @@ local function collect(ctx, label, cb)
 
   -- The plugin's own composer is the *default implementation of the adapter*, not a lesser
   -- path beside it: a host that injects one replaces it, and both are handed exactly the
-  -- same thing. There is no third behaviour to keep in step.
+  -- same thing. There is no third behavior to keep in step.
   local compose = cfg.compose or require("codereview.composer").open
   compose(ctx, function(_, text)
     done(text)

--- a/lua/codereview/archive.lua
+++ b/lua/codereview/archive.lua
@@ -279,7 +279,7 @@ local function build(entries, opts)
       end
 
       -- The code an entry carried travels inside its bar, exactly as it did in the payload.
-      -- `+`/`-` already say which side a line is, so they keep the diff's own colours.
+      -- `+`/`-` already say which side a line is, so they keep the diff's own colors.
       if entry.inline and entry.lines then
         for _, code in ipairs(entry.lines) do
           local text = indent .. render.truncate(code, body)

--- a/lua/codereview/composer.lua
+++ b/lua/codereview/composer.lua
@@ -112,7 +112,7 @@ function M.open(ctx, on_accept, label)
   vim.keymap.set({ "i", "n" }, "<C-t>", function()
     routing.pick(refresh)
   end, { buffer = buf, desc = "Choose target" })
-  -- The sentinel is written *before* the picker opens, so cancelling leaves the literal
+  -- The sentinel is written *before* the picker opens, so canceling leaves the literal
   -- character that was just pressed. The position is remembered rather than re-derived for
   -- the same reason a host composer has to remember it: the picker takes focus, and the
   -- cursor with it, so by the time it answers the composer's cursor means nothing.
@@ -146,7 +146,7 @@ function M.open(ctx, on_accept, label)
     end
     pick_file(function(chosen)
       -- Empty when the picker was dismissed, which is the whole point of writing the
-      -- sentinel up front: cancelling costs the reviewer the `@` they typed and nothing
+      -- sentinel up front: canceling costs the reviewer the `@` they typed and nothing
       -- else, and everything below still applies to where that leaves them.
       local spliced = ""
       if chosen and chosen.path then

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -21,7 +21,7 @@ M.defaults = {
   ---column; `split` draws the before-image and the after-image as two panes side by side.
   ---Unified is the default, so upgrading the plugin does not change how a review looks.
   layout = "unified", ---@type "unified"|"split"
-  ---Emphasise the characters that differ inside a deletion and its replacement, so the eye
+  ---Emphasize the characters that differ inside a deletion and its replacement, so the eye
   ---lands on the change instead of on the line. On by default: it is a refinement of a
   ---rendering everyone already has rather than a mode to opt into, and it is what every
   ---comparable review tool does. It lengthens opening a large review by roughly a third and
@@ -41,14 +41,14 @@ M.defaults = {
   ---the archive existed. `gA` overrides this while a session lasts, in both directions, and
   ---never writes here -- see `M.archived` below.
   archived = true, ---@type boolean
-  ---Draw every **pane** that does not have focus **muted**: its colours pulled toward the
+  ---Draw every **pane** that does not have focus **muted**: its colors pulled toward the
   ---background, so the pane with focus is the bright one and a reviewer never has to press
   ---a key to find out where they are. Every pane goes on lighting the row its cursor is on;
-  ---which colour a muted one lights it in is `counterpart` below.
+  ---which color a muted one lights it in is `counterpart` below.
   ---
   ---**The file tree is never muted, and its row stays lit.** The tree is the map of the
   ---review, and a muted map is harder to read for nothing in return: a tree looks nothing
-  ---like a diff, so no colour is needed to tell the two apart. Focus landing in the tree
+  ---like a diff, so no color is needed to tell the two apart. Focus landing in the tree
   ---still mutes the panes, so the rule above stays true of them.
   ---
   ---On by default, and coarse the way `archived` is: off is nothing muted, nothing
@@ -56,12 +56,12 @@ M.defaults = {
   ---dimming plugin or own taste should win. There is no keymap beside it; one can be added
   ---if the switch proves too blunt.
   ---
-  ---`strength` is how far toward the background a colour is pulled, from 0 (not at all) to
-  ---1 (all the way). One number rather than a palette, because the colours it works on are
-  ---the active colorscheme's -- an unrecognised theme is muted in its own colours or, for a
+  ---`strength` is how far toward the background a color is pulled, from 0 (not at all) to
+  ---1 (all the way). One number rather than a palette, because the colors it works on are
+  ---the active colorscheme's -- an unrecognized theme is muted in its own colors or, for a
   ---group the plugin cannot know about, left bright rather than replaced.
   muted = { enabled = true, strength = 0.5 }, ---@type { enabled: boolean, strength: number }
-  ---Draw every file except the one the cursor is in **faded**: the colours of its rows
+  ---Draw every file except the one the cursor is in **faded**: the colors of its rows
   ---pulled toward the background, so the file being read has a visible boundary and the
   ---file just left stops competing with it. The unit is the file and never the hunk, so a
   ---cursor moving from one hunk to the next inside one file changes nothing on screen.
@@ -70,15 +70,15 @@ M.defaults = {
   ---header is the one row that names the file, and this exists to help a reviewer find a
   ---place rather than to hide the map.
   ---
-  ---On by default, and coarse the way `muted` is: off is nothing emitted, no colour
+  ---On by default, and coarse the way `muted` is: off is nothing emitted, no color
   ---computed, and the diff drawn exactly as it was before this existed. There is no keymap
   ---beside it.
   ---
   ---`strength` is its own, and deliberately gentler than `muted.strength`: the fade covers
   ---every file but one, where the window rule covers the panes a reviewer is not in, and a
   ---blend that reads as quiet over a pane reads as washed out over a whole review. Both
-  ---numbers pull the active colorscheme's own colours, so an unrecognised theme fades in
-  ---its own colours or, for a group the plugin cannot know about, stays bright.
+  ---numbers pull the active colorscheme's own colors, so an unrecognized theme fades in
+  ---its own colors or, for a group the plugin cannot know about, stays bright.
   faded = { enabled = true, strength = 0.35 }, ---@type { enabled: boolean, strength: number }
   ---Light the row the cursor is on in a **muted** pane as well -- the **counterpart row** --
   ---in a group of its own rather than in the one the pane with focus uses. A reviewer
@@ -89,7 +89,7 @@ M.defaults = {
   ---addition there is no row to count to.
   ---
   ---Which row is lit stays Neovim's business, because the panes are cursorbound. Only which
-  ---colour it is lit in is this. Nothing is emitted onto the diff and no extmark is added.
+  ---color it is lit in is this. Nothing is emitted onto the diff and no extmark is added.
   ---
   ---On by default, and coarse the way `muted` is: off is a lit row in the pane with focus
   ---only -- nothing computed, and no group of its own defined -- which is what a review
@@ -191,7 +191,7 @@ M.options = vim.deepcopy(M.defaults)
 ---@return CRType[]
 local function resolve_types(options)
   local types = require("codereview.types")
-  return types.normalise(options.types or types.defaults, { icon = options.icons.annotated })
+  return types.normalize(options.types or types.defaults, { icon = options.icons.annotated })
 end
 
 ---Reject a layout the render has no rendering for.
@@ -257,7 +257,7 @@ end
 ---
 ---In the same voice as the switches above. A number outside 0..1 is not a stronger effect
 ---but an arithmetic accident: past 1 the blend overshoots the background and comes back out
----the other side, which is a colour nobody asked for rather than a louder version of one.
+---the other side, which is a color nobody asked for rather than a louder version of one.
 ---@param name string
 ---@param value any
 local function validate_strength(name, value)

--- a/lua/codereview/delivery.lua
+++ b/lua/codereview/delivery.lua
@@ -142,7 +142,7 @@ end
 ---whether one is wired.
 ---
 ---It reports a non-dispatch because that is the truth: a register is not a consumer.
----The behaviour a host with no delivery already had -- the payload reachable, the batch
+---The behavior a host with no delivery already had -- the payload reachable, the batch
 ---still queued -- then falls out of the one rule that empties the queue rather than
 ---being written down a second time.
 ---@param payload string

--- a/lua/codereview/diff.lua
+++ b/lua/codereview/diff.lua
@@ -77,12 +77,12 @@ end
 
 --- Spans ----------------------------------------------------------------------
 
----Above this proportion of the longer line inside spans, a pair is left plainly coloured.
+---Above this proportion of the longer line inside spans, a pair is left plainly colored.
 ---
 ---Two lines sharing almost nothing are not an edit, they are a replacement, and
----emphasising nine tenths of both tells a reviewer less than emphasising neither.
+---emphasizing nine tenths of both tells a reviewer less than emphasizing neither.
 ---
----The figure is a judgement read off real diffs rather than derived. Measured over three
+---The figure is a judgment read off real diffs rather than derived. Measured over three
 ---corpora -- this repository's own history, a file put through stylua at a different width
 ---and indent, and two unrelated modules paired line for line, which is what the pairing
 ---rule produces inside a long run:
@@ -93,7 +93,7 @@ end
 ---| a re-indentation | 0% | 0% |
 ---| unrelated lines paired by index | 90.6% | 73.6% |
 ---
----70%, the figure this started at, still emphasises a quarter of the unrelated pairs, and
+---70%, the figure this started at, still emphasizes a quarter of the unrelated pairs, and
 ---reading them confirms they are noise. Every genuine one-for-one edit above 60% in that
 ---history reads as a replacement rather than an edit -- a `nvim_win_set_cursor` call
 ---becoming `place(1)`, a statement becoming a comment -- so 60% loses nothing worth

--- a/lua/codereview/fade.lua
+++ b/lua/codereview/fade.lua
@@ -7,17 +7,17 @@
 ---
 ---**The fade changes which group a mark carries. It does not change the priority order.** A
 ---faded file's rows are emitted in the blended variants of the groups they would carry
----anyway. The alternative is one grey foreground laid over the file above the syntax replay,
+---anyway. The alternative is one gray foreground laid over the file above the syntax replay,
 ---and this project already refused that shape for the intra-line **span** emphasis: a
 ---foreground above the replay wins where a parser painted and loses where none did, so the
 ---result changes with the parsers a reader has installed. Leaving the bands alone is also
 ---what keeps the composition rules in the design notes true.
 ---
----**It is marks, and not a highlight namespace.** A namespace colours a whole window, so it
+---**It is marks, and not a highlight namespace.** A namespace colors a whole window, so it
 ---cannot fade one file inside a **pane**. The **muted** window rule is a namespace because
 ---its unit *is* the window. The two mechanisms answer two different questions, and they
 ---share nothing but the blends in `hl.lua` -- which is what stops them drifting apart in
----colour while each keeps a strength of its own.
+---color while each keeps a strength of its own.
 local config = require("codereview.config")
 local hl = require("codereview.hl")
 
@@ -25,7 +25,7 @@ local M = {}
 
 ---Whether anything fades at all.
 ---
----Off means no mark is renamed and no colour is computed, so the diff is drawn exactly as it
+---Off means no mark is renamed and no color is computed, so the diff is drawn exactly as it
 ---was before this existed.
 ---@return boolean
 function M.enabled()
@@ -34,21 +34,21 @@ end
 
 ---The group a faded row carries in place of `group`.
 ---
----**A group the active theme gives no colour of its own is emitted as itself.** `hl.lua`
+---**A group the active theme gives no color of its own is emitted as itself.** `hl.lua`
 ---hands back nothing for it, and the row is then drawn in the group it would have carried
----anyway -- a file merely not faded rather than one drawn in a colour nobody chose.
+---anyway -- a file merely not faded rather than one drawn in a color nobody chose.
 ---@param group string
 ---@return string
 function M.group(group)
   return hl.blended("faded", group) or group
 end
 
----One mark's options, with the groups that colour its own row faded.
+---One mark's options, with the groups that color its own row faded.
 ---
 ---`hl_group` and `line_hl_group` are what a mark puts on the row it sits on, and they are
 ---what the fade renames. The virtual lines hanging under a row are left as they are: they
 ---are the **queue**'s entries and the **archive**'s, drawn beneath the code rather than on
----it, and their colours are in the chunks of that mark rather than in either field. So a
+---it, and their colors are in the chunks of that mark rather than in either field. So a
 ---queued entry inside a faded file stays bright, and an archived one keeps the dimness it
 ---already has -- which is how *already sent* and *not the file I am in* stay two statements.
 ---The early return below is what says so, and `quiet_spec` is what pins it.

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -357,7 +357,7 @@ function M.diff(scope, root, context)
   return run(args, { cwd = root, timeout = DIFF_TIMEOUT_MS })
 end
 
----Paths git is not tracking, honouring .gitignore.
+---Paths git is not tracking, honoring .gitignore.
 ---@param root string
 ---@return string[]
 function M.untracked_files(root)

--- a/lua/codereview/hl.lua
+++ b/lua/codereview/hl.lua
@@ -14,10 +14,10 @@
 ---update, because the one thing that would go wrong is invisible until someone looks at an
 ---unfocused pane.
 ---
----**The blended colours are groups of this module, not colours in a window.** A group that
+---**The blended colors are groups of this module, not colors in a window.** A group that
 ---a **muted** window draws, that a **faded** file's row carries, or that a muted pane lights
 ---its **counterpart row** in, gets a twin here, named for the group it blends. The window
----that mutes links to that twin instead of holding a colour of its own, and the fade emits it
+---that mutes links to that twin instead of holding a color of its own, and the fade emits it
 ---in place of the group the row would carry, so one piece of arithmetic answers all three.
 ---See `M.blended` below.
 local M = {}
@@ -28,7 +28,7 @@ local LINKS = {
   CodeReviewAdd = "DiffAdd",
   CodeReviewDel = "DiffDelete",
   CodeReviewLineNr = "LineNr",
-  -- `Added`/`Removed`/`Changed` are standard Neovim groups and carry a foreground colour,
+  -- `Added`/`Removed`/`Changed` are standard Neovim groups and carry a foreground color,
   -- which is what a change bar and a `+12 -3` stat need.
   CodeReviewAddBar = "Added",
   CodeReviewDelBar = "Removed",
@@ -54,7 +54,7 @@ local LINKS = {
 
   -- Whether an archived entry's file has moved since its batch went. Deliberately *not*
   -- `CodeReviewStale`'s group: the two answer different questions about different entries,
-  -- and one colour for both is the merge the rule itself refuses. The unremarkable answer
+  -- and one color for both is the merge the rule itself refuses. The unremarkable answer
   -- takes the dimmest group there is -- a file the agent changed is what reading an agent's
   -- work expects -- and the one worth noticing takes the quietest diagnostic rather than a
   -- warning, because a file nothing happened to is not yet a problem.
@@ -67,7 +67,7 @@ local LINKS = {
   -- The **sticky header**'s own chrome. Everything else on that bar draws in a group it
   -- shares with the surface saying the same thing on the diff -- the stat in
   -- `CodeReviewStatAdd` and `CodeReviewStatDel`, the note count in `CodeReviewNoteCount`,
-  -- the untouched tally in `CodeReviewUntouched` -- because one colour has to mean one
+  -- the untouched tally in `CodeReviewUntouched` -- because one color has to mean one
   -- thing wherever a reviewer meets it.
   --
   -- The path is deliberately not here. It draws in the bar's own group, which is the
@@ -109,12 +109,12 @@ local LINKS = {
 -- cannot know how loud a type nobody has heard of should be.
 local TYPE_FALLBACK = "DiagnosticInfo"
 
--- What emphasises the characters that differ inside a changed line. `DiffText` is the
--- group every colorscheme already tunes for exactly that, so it is where the colour comes
+-- What emphasizes the characters that differ inside a changed line. `DiffText` is the
+-- group every colorscheme already tunes for exactly that, so it is where the color comes
 -- from -- but the background is *copied* rather than linked to, which is the one place
 -- this module departs from the pattern. A link would carry DiffText's foreground too, and
 -- the syntax replay sits at a higher priority: that foreground would lose to it wherever
--- treesitter painted and win wherever it did not, which is emphasis that changes colour
+-- treesitter painted and win wherever it did not, which is emphasis that changes color
 -- depending on whether the language has a parser installed. A background alone composes
 -- with the replay instead of fighting it, which is what keeps code readable inside a span.
 --
@@ -160,7 +160,7 @@ function M.groups()
   return out
 end
 
---- The blended colours ----------------------------------------------------------
+--- The blended colors ----------------------------------------------------------
 
 ---@alias CRBlendFamily "muted"|"faded"|"counterpart"
 
@@ -173,11 +173,11 @@ end
 ---defines starts with any of the prefixes, so a twin shadows none of them.
 ---
 ---**Three families, one blend.** A **muted** window, a **faded** file and the **counterpart
----row** a muted pane lights all pull the theme's own colours toward the same background, and
+---row** a muted pane lights all pull the theme's own colors toward the same background, and
 ---each has a strength of its own because each covers a very different amount of the screen:
 ---the window rule answers for the panes a reviewer is not in, the fade for every file but
 ---one, the counterpart row for a single row inside a window the muting already has. A second
----copy of the arithmetic is how any two of them would drift apart in colour, which is what
+---copy of the arithmetic is how any two of them would drift apart in color, which is what
 ---one family with a strength of its own avoids.
 ---
 ---**One member is enough to justify a family.** `counterpart` holds only `CursorLine`. The
@@ -204,7 +204,7 @@ end
 ---@type integer|nil
 local toward = nil
 
----What a blended colour is pulled toward, whichever family asks.
+---What a blended color is pulled toward, whichever family asks.
 ---
 ---A theme that gives `Normal` no background at all has the terminal's behind it. The only
 ---knowable fact about that background is which way the theme leans.
@@ -217,24 +217,24 @@ local function backdrop()
   return toward
 end
 
----Pull one colour toward another, channel by channel.
----@param colour integer 0xRRGGBB
+---Pull one color toward another, channel by channel.
+---@param color integer 0xRRGGBB
 ---@param target integer 0xRRGGBB
----@param strength number 0 keeps the colour. 1 replaces it with `target`.
+---@param strength number 0 keeps the color. 1 replaces it with `target`.
 ---@return integer
-local function blend(colour, target, strength)
+local function blend(color, target, strength)
   local out = 0
   for _, place in ipairs({ 65536, 256, 1 }) do
-    local from = math.floor(colour / place) % 256
+    local from = math.floor(color / place) % 256
     local to = math.floor(target / place) % 256
     out = out + math.floor(from + (to - from) * strength + 0.5) * place
   end
   return out
 end
 
----Write `family`'s twin of `group`, or report that `group` has no colour to blend.
+---Write `family`'s twin of `group`, or report that `group` has no color to blend.
 ---
----Only the true-colour attributes are blended. `ctermfg` and `ctermbg` are indices into a
+---Only the true-color attributes are blended. `ctermfg` and `ctermbg` are indices into a
 ---palette with no channels to pull, so they are copied without a change.
 ---@param family CRBlendFamily
 ---@param group string
@@ -253,9 +253,9 @@ end
 
 ---The group that holds `group` blended at `family`'s strength, computed once.
 ---
----**A group with no colour of its own gets no twin, and that is the feature.** A caller
+---**A group with no color of its own gets no twin, and that is the feature.** A caller
 ---that finds nothing here must draw `group` as it is. That keeps a colorscheme this plugin
----has never seen merely less muted, or merely less faded, instead of wrongly coloured.
+---has never seen merely less muted, or merely less faded, instead of wrongly colored.
 ---Nothing here reaches for a palette when a lookup is empty, and nothing must.
 ---
 ---An empty lookup is not remembered as done. A pass that somehow runs before the theme's
@@ -278,21 +278,21 @@ end
 
 ---Write every twin again, against the colorscheme that is active now.
 ---
----A twin holds colours the theme decides, and `:colorscheme` clears it with every other
+---A twin holds colors the theme decides, and `:colorscheme` clears it with every other
 ---global group. So `apply` writes the twins again wherever it writes the links again. A
----caller that links to a twin needs no part of this: a link holds a name and not a colour,
+---caller that links to a twin needs no part of this: a link holds a name and not a color,
 ---and a link inside a highlight namespace survives `:colorscheme`.
 ---
 ---Every twin is written again rather than dropped. The diff on screen still carries
----extmarks that name the capture groups the old theme resolved, and those colours must be
+---extmarks that name the capture groups the old theme resolved, and those colors must be
 ---right before anything parses again.
 ---
----A group that loses its colour to the new theme keeps its twin, as a link back to itself.
+---A group that loses its color to the new theme keeps its twin, as a link back to itself.
 ---The window then draws that group at full brightness, which is what a group with no twin
 ---gets. A link that reaches no definition draws nothing at all, so every twin a caller
 ---already links to must stay a definition -- and a mark already emitted in a twin's name is
 ---the same case as a namespace linking to one.
-local function recolour_twins()
+local function recolor_twins()
   toward = nil
   for family, known in pairs(twins) do
     for group, twin in pairs(known) do
@@ -310,7 +310,7 @@ function M.apply()
   apply_spans()
 
   -- A configured type names a group this module cannot know about, so without this a
-  -- custom type renders with no colour at all. After LINKS and with `default = true`, so
+  -- custom type renders with no color at all. After LINKS and with `default = true`, so
   -- the built-in types keep their severity mapping and a user's own group is left alone.
   for _, t in ipairs(require("codereview.config").get().types) do
     vim.api.nvim_set_hl(0, t.hl, { link = TYPE_FALLBACK, default = true })
@@ -322,7 +322,7 @@ function M.apply()
   end
   -- Last, because a twin blends what the links above resolve to. With no review open there
   -- are no twins and this costs one empty loop per family.
-  recolour_twins()
+  recolor_twins()
 end
 
 ---Re-link after a colorscheme change, since `nvim_set_hl` definitions are cleared by

--- a/lua/codereview/queue_float.lua
+++ b/lua/codereview/queue_float.lua
@@ -144,7 +144,7 @@ local function build_queue(items, opts)
     end
     lines[#lines + 1] = heading
     -- Painted rather than inherited. The float used to set `filetype=markdown` and take
-    -- whatever the `##` and `>` prefixes happened to attract, which coloured its chrome by
+    -- whatever the `##` and `>` prefixes happened to attract, which colored its chrome by
     -- accident and an entry's annotation type not at all.
     mark(#lines, 0, { end_col = #label, hl_group = "CodeReviewTitle" })
     if #heading > #label then
@@ -189,7 +189,7 @@ local function build_queue(items, opts)
       end
 
       -- The code an entry carries travels inside its bar. `+`/`-` already say which side a
-      -- line is, so they are drawn in the colours the diff gives them.
+      -- line is, so they are drawn in the colors the diff gives them.
       if entry.inline and entry.lines then
         for _, code in ipairs(entry.lines) do
           local text = indent .. render.truncate(code, body)

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -49,7 +49,7 @@ M.LAYOUTS = { "unified", "split" }
 ---default makes the result depend on insertion order, which changes as the view repaints.
 ---
 ---`span` sits above the line's own background, so the emphasis is visible at all, and
----below the syntax replay, so code colouring survives inside an emphasised span.
+---below the syntax replay, so code coloring survives inside an emphasized span.
 M.PRIORITY = { diff = 100, gutter = 110, span = 120, syntax = 150 }
 
 ---Stable identity for an annotatable line, independent of buffer position.
@@ -353,7 +353,7 @@ end
 ---takes a name is the one that escapes it.
 ---
 ---A literal takes a highlight group as chrome does, and for the reason the escape exists:
----most of what is worth colouring on this bar is a name -- the **target**, the base
+---most of what is worth coloring on this bar is a name -- the **target**, the base
 ---revision, a count carrying a configured glyph -- and the alternative is a caller writing
 ---the markers around one by hand, which is markup arriving from outside the one seam that
 ---decides what markup is. The escape is unchanged by it: the name is doubled, and the
@@ -380,8 +380,8 @@ function M.bar(segments)
   local out = {}
   for i, seg in ipairs(segments) do
     local text = seg.text
-    -- Escape by kind, colour whatever asked for it: the two are separate questions, and a
-    -- name that is coloured is still a name.
+    -- Escape by kind, color whatever asked for it: the two are separate questions, and a
+    -- name that is colored is still a name.
     if kind_of(seg) == "literal" then
       text = (text:gsub("%%", "%%%%"))
     end
@@ -493,7 +493,7 @@ function M.build(files, opts)
     local type_def = require("codereview.types").get(opts.types, item.type)
     local icon = type_def and type_def.icon or "•"
     -- An archived entry keeps its type's icon, because what kind of finding it was is still
-    -- worth knowing, and gives up that type's colour: severity is an instruction to act,
+    -- worth knowing, and gives up that type's color: severity is an instruction to act,
     -- and this one has already been acted on.
     local group = archived and "CodeReviewArchived" or (type_def and type_def.hl or "CodeReviewNote")
     local text_group = archived and "CodeReviewArchivedNote" or "CodeReviewNote"
@@ -696,7 +696,7 @@ function M.build(files, opts)
     if before then
       mark(before, row, 0, { line_hl_group = header_hl })
     end
-    -- Colour only the +N/-M inside the stat, not the note count that may follow it.
+    -- Color only the +N/-M inside the stat, not the note count that may follow it.
     local stat_col = #header - #right
     local plus_len = file.binary and 0 or #(("+%d"):format(file.added))
     if not file.binary then

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -8,7 +8,7 @@
 ---
 ---What a row carries is the short sha, the subject and the relative date. Not the author --
 ---you are reading your own branch. Not the added and deleted counts -- they cost a second
----pass over the whole branch to fill, and the subject is what a reviewer recognises.
+---pass over the whole branch to fill, and the subject is what a reviewer recognizes.
 local git = require("codereview.git")
 local render = require("codereview.render")
 
@@ -44,7 +44,7 @@ local ALL = "All commits"
 
 ---Turn the commits into the float's rows.
 ---
----The subject keeps the buffer's own colour, which is the brightest thing this float has,
+---The subject keeps the buffer's own color, which is the brightest thing this float has,
 ---for the reason the **sticky header** leaves the path in the bar's own group: the sha and
 ---the date are what a row is found by, and the subject is what it is read for.
 ---

--- a/lua/codereview/types.lua
+++ b/lua/codereview/types.lua
@@ -2,15 +2,15 @@
 ---
 ---A type is not decoration. `directive` is what earns it a keystroke: it becomes the
 ---instruction attached to that group in the submitted payload, so "bug" and "nitpick"
----produce different behaviour from the receiving agent rather than just different icons.
+---produce different behavior from the receiving agent rather than just different icons.
 local M = {}
 
 ---@class CRType
 ---@field name string       Required. Identifier used by `annotate()` and stored on an entry.
 ---@field key string        Required. Suffix after the `a` annotate prefix.
 ---@field icon string       Defaults to the configured `icons.annotated`.
----@field hl string         Defaults to `CodeReview<Name>`, auto-linked so it has colour.
----@field label string      Group heading in the payload. Defaults to the pluralised name.
+---@field hl string         Defaults to `CodeReview<Name>`, auto-linked so it has color.
+---@field label string      Group heading in the payload. Defaults to the pluralized name.
 ---@field directive string? What the receiving agent should do with this group. Optional:
 ---                         a type without one gets a bare `## Label (n)` heading.
 
@@ -75,7 +75,7 @@ end
 ---@return string
 local function default_label(name)
   local label = table.concat(words(name), " ")
-  -- Naive pluralisation, minus the worst case. A name that is already plural, or one
+  -- Naive pluralization, minus the worst case. A name that is already plural, or one
   -- English declines irregularly, wants an explicit `label`.
   return label:lower():sub(-1) == "s" and label or (label .. "s")
 end
@@ -95,7 +95,7 @@ end
 ---@param list CRType[]
 ---@param opts? { icon?: string }
 ---@return CRType[]
-function M.normalise(list, opts)
+function M.normalize(list, opts)
   opts = opts or {}
 
   if type(list) ~= "table" or vim.tbl_isempty(list) then

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -190,11 +190,11 @@ local function set_winbar(win, segments)
   vim.wo[win].winbar = render.bar(segments)
 end
 
----The `+N -M` a stat is, with its two halves coloured apart.
+---The `+N -M` a stat is, with its two halves colored apart.
 ---
 ---Taken as the string the stat already is rather than as two numbers, so that the file's own
----counts and the review's totals are spelled by one format and coloured by one rule. A
----`binary` file has no counts in it and takes no colour.
+---counts and the review's totals are spelled by one format and colored by one rule. A
+---`binary` file has no counts in it and takes no color.
 ---@param stat string
 ---@return CRBarSegment[]
 local function stat_segments(stat)
@@ -221,7 +221,7 @@ end
 ---and a bar inside a review does not need to say it is one -- which is about thirty columns
 ---handed back to the path.
 ---
----Each entry is already segments, because a count is coloured and the `·` beside it is not,
+---Each entry is already segments, because a count is colored and the `·` beside it is not,
 ---and because the counts carry glyphs a host chose: those are literals for the reason the
 ---file's icon is one. Three counts, three glyphs, so that three numbers side by side cannot
 ---be read as one another.
@@ -321,7 +321,7 @@ end
 ---The path stays a bare string rather than a segment because it is the one part the fitting
 ---rule cuts, and `render.keep_tail` takes text.
 ---
----Coloured as the in-buffer file header colours the same facts, and for the same reason one
+---Colored as the in-buffer file header colors the same facts, and for the same reason one
 ---function names the file for both: the counts apart, the note count in the group the notes
 ---themselves carry, the icon and the chevron quiet. The path takes no group at all, which
 ---leaves it drawing in the bar's own -- the brightest thing on the left, and the thing the
@@ -527,7 +527,7 @@ local function emit_rows(buf, rendered, first, last, faded)
       opts = fade.opts(opts)
     end
     -- An end_col past the end of a line is a hard error; a mis-measured header should
-    -- lose its colour, not abort the whole repaint.
+    -- lose its color, not abort the whole repaint.
     pcall(vim.api.nvim_buf_set_extmark, buf, NS, m.row, m.col, opts)
   end
 end
@@ -1838,9 +1838,9 @@ function M.open(spec)
     end,
   })
 
-  -- A **muted** window's colours are blends of the theme's, so they cannot outlive it.
+  -- A **muted** window's colors are blends of the theme's, so they cannot outlive it.
   -- `hl.lua` writes those blends again from its own `ColorScheme` autocommand; what this
-  -- adds is the pass that links a group the new theme gives a colour to at last. Declared
+  -- adds is the pass that links a group the new theme gives a color to at last. Declared
   -- after `hl.setup()`, which is the first thing this function does: the two fire in the
   -- order they were declared, so every blend this links to exists by the time it links.
   -- Watched from here rather than from `hl.lua`, which would have to reach back up into the
@@ -1848,7 +1848,7 @@ function M.open(spec)
   vim.api.nvim_create_autocmd("ColorScheme", {
     group = V.augroup,
     callback = function()
-      view_layout.recolour()
+      view_layout.recolor()
     end,
   })
 

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -83,7 +83,7 @@ end
 ---either a focus restore or a geometry read, for which the two panes are equivalent.
 ---
 ---Internal. Exported only because target resolution lives in another module, and is
----exercised through that module's behaviour rather than directly.
+---exercised through that module's behavior rather than directly.
 ---@param V CRView
 ---@return integer win, CRRender|nil render
 function M.focused_pane(V)
@@ -107,7 +107,7 @@ end
 ---@param V CRView
 ---@param row integer
 ---@param cmd string|nil A normal-mode view command: `zt` to put the row at the top, `zz`
----       to centre it, nil to leave the window where it is
+---       to center it, nil to leave the window where it is
 function M.place(V, row, cmd)
   local bound = M.has_before(V)
   ---@param on boolean
@@ -220,12 +220,12 @@ end
 
 ---Every window this module has enrolled in the focus rule, as a set.
 ---
----Enrolment goes through `window_opts` below, the one helper every review window already
+---Enrollment goes through `window_opts` below, the one helper every review window already
 ---passes through -- the file tree's included, though it is not a pane -- so a pane the
 ---layout toggle rebuilt and a tree dismissed and summoned again join the set on the same
 ---line that gives them their options, rather than by a caller remembering to say so.
 ---
----Enrolment says two things: which windows `mute` walks, and which windows can move the
+---Enrollment says two things: which windows `mute` walks, and which windows can move the
 ---bright latch. The tree is here for the second. `mute` walks it too, but only to keep it
 ---bright -- see there.
 ---
@@ -237,7 +237,7 @@ end
 local enrolled = {}
 
 ---@param win integer
-local function enrol(win)
+local function enroll(win)
   for w in pairs(enrolled) do
     if not vim.api.nvim_win_is_valid(w) then
       enrolled[w] = nil
@@ -274,14 +274,14 @@ function M.window_opts(win)
   vim.wo[win].signcolumn = "no"
   vim.wo[win].foldcolumn = "0"
   -- What a **pane** opens with rather than what it keeps: with muting on, `mute` owns a
-  -- pane's `cursorline` from here -- it leaves it set and decides which colour the row is lit
+  -- pane's `cursorline` from here -- it leaves it set and decides which color the row is lit
   -- in, or, with the counterpart row off, makes it a function of focus again. The file tree
   -- keeps this one, because `mute` never touches it. With muting off every review window
   -- keeps it, which is what a review looked like before muting existed.
   vim.wo[win].cursorline = true
   vim.wo[win].list = false
   vim.wo[win].spell = false
-  enrol(win)
+  enroll(win)
 end
 
 --- Muting ---------------------------------------------------------------------
@@ -293,10 +293,10 @@ end
 ---muted. Attaching it is what mutes a window; handing the window the global namespace back
 ---is what brightens it.
 ---
----**The namespace holds links, and no colour of its own.** `hl.lua` owns the blended
----groups, so the colours a muted window draws are reachable from outside this namespace --
+---**The namespace holds links, and no color of its own.** `hl.lua` owns the blended
+---groups, so the colors a muted window draws are reachable from outside this namespace --
 ---which is what keeps one set of them behind every rule that wants them. A link also
----survives a colorscheme change, because it holds a name and not a colour.
+---survives a colorscheme change, because it holds a name and not a color.
 local NS_MUTED = vim.api.nvim_create_namespace("codereview_muted")
 
 ---Which family's blend a muted pane draws `group` through.
@@ -328,8 +328,8 @@ local linked = {}
 ---
 ---**A group left without a link stays bright, and that is the feature.** A group the
 ---namespace does not name falls back to its global definition -- measured, not assumed --
----so a colorscheme this plugin has never heard of, or one whose group carries no colour of
----its own to blend, comes out merely less muted instead of wrongly coloured. `hl.lua`
+---so a colorscheme this plugin has never heard of, or one whose group carries no color of
+---its own to blend, comes out merely less muted instead of wrongly colored. `hl.lua`
 ---decides which groups have a twin, and it hands back nothing for the rest.
 ---@param group string
 local function ensure_link(group)
@@ -375,19 +375,19 @@ function M.mute_extend()
   end
 end
 
----Point every muted window at the colours the theme that is active now decides.
+---Point every muted window at the colors the theme that is active now decides.
 ---
 ---Little is left to do here, and that is the point of the links. `hl.lua` writes every twin
 ---again from its own `ColorScheme` autocommand, and a link inside the namespace survives
----`:colorscheme` and reaches the new colour by name -- measured, not assumed. So no colour
+---`:colorscheme` and reaches the new color by name -- measured, not assumed. So no color
 ---is touched from here.
 ---
 ---What is left is one more pass over the groups in play. A group the old theme gave no
----colour to, and the new theme does, gets its link at last.
+---color to, and the new theme does, gets its link at last.
 ---
 ---Driven by the view's `ColorScheme` autocommand, which is declared after the one `hl.lua`
 ---writes its twins from. The two fire in that order, so every twin this links to exists.
-function M.recolour()
+function M.recolor()
   extended_at = -1
   M.mute_extend()
 end
@@ -403,7 +403,7 @@ end
 ---
 ---**The file tree is never muted, and it still moves the latch.** A muted map is harder to
 ---read than a bright one and buys nothing back: a tree looks nothing like a diff, so no
----colour is needed to tell the two apart. The tree keeps the other half of the rule --
+---color is needed to tell the two apart. The tree keeps the other half of the rule --
 ---focus landing in it mutes the panes -- so "the muted window is the one I am not in" stays
 ---true of the panes, and the tree is not part of that statement. It is named from the
 ---`CRView` this is already handed, so no second set of windows is kept and no flag is put
@@ -412,22 +412,22 @@ end
 ---**The tree is set bright rather than passed over.** A window id that carried the
 ---namespace at some earlier moment would otherwise keep it.
 ---
----**Every pane lights the row its cursor is on**, and the namespace decides in which colour.
+---**Every pane lights the row its cursor is on**, and the namespace decides in which color.
 ---A muted pane lights a **counterpart row**: the same `cursorline`, drawn through the
 ---counterpart family instead of at the theme's own strength. The panes are cursorbound, so
 ---that row is the one opposite the row the reviewer is reading -- and where it is a
 ---**filler**, a lit blank row is the only thing that says nothing existed there before.
----Which row is lit stays Neovim's business; only which colour it is lit in is this.
+---Which row is lit stays Neovim's business; only which color it is lit in is this.
 ---
 ---With the counterpart row off, `cursorline` is a function of focus again and a muted pane
----lights nothing -- the behaviour shipped before this existed.
+---lights nothing -- the behavior shipped before this existed.
 ---
 ---**The tree's `cursorline` is left alone**, so it keeps the one `window_opts` gives it. The
 ---tree is not cursorbound, and its lit row follows the diff cursor rather than sitting
 ---opposite it, so a lit row there names the file being read.
 ---
 ---With muting off this returns having done nothing at all: no namespace is attached to
----anything, no colour is computed, and `cursorline` is left as `window_opts` set it.
+---anything, no color is computed, and `cursorline` is left as `window_opts` set it.
 ---@param V CRView|nil
 function M.mute(V)
   if not (V and vim.api.nvim_win_is_valid(V.win) and config.get().muted.enabled) then
@@ -494,7 +494,7 @@ function M.show_before_pane(V, view)
 
   -- Both window-local. `scrollopt`, which decides what a bound window keeps in step, is
   -- global -- a plugin that set it would reach outside its own windows -- so it is left
-  -- alone. Its default gives vertical synchronisation only, and horizontal scrolling
+  -- alone. Its default gives vertical synchronization only, and horizontal scrolling
   -- staying independent per pane is accepted.
   for _, w in ipairs({ V.win, win }) do
     vim.wo[w].scrollbind = true
@@ -592,7 +592,7 @@ end
 ---
 ---What survives the switch is the **anchor** under the cursor, never the row: the same line
 ---of the same hunk sits at a different row in each layout, so a row carried across would
----land on unrelated code. The result is centred, because the row moved structurally and an
+---land on unrelated code. The result is centered, because the row moved structurally and an
 ---exact scroll offset preserved across that would be preserving something meaningless.
 ---@param V CRView|nil
 ---@param view table The review view: the anchor under its cursor, and the repaint this needs.

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 
 | Path | What |
 | --- | --- |
-| `minimal_init.lua` | The only runtimepath is this plugin plus plenary. Also redirects `XDG_STATE_HOME` and neutralises git config. |
+| `minimal_init.lua` | The only runtimepath is this plugin plus plenary. Also redirects `XDG_STATE_HOME` and neutralizes git config. |
 | `helpers.lua` | Fixture builders, notification capture, extmark filters, highlight-group sets, anchor lookups. |
 | `fixtures/*.sh` | Build a fixture repository from scratch at a given path. Take a target path; safe to run by hand. |
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
@@ -37,7 +37,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/drafts_child.lua` | Spawned by `drafts_spec` to abandon a half-written note and exit — deliberately not a spec. |
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `codereview/trim_child.lua` | Spawned twice by `trim_spec` — once to trim two branches and exit, once to report what a later session's branch review holds — deliberately not a spec. |
-| `codereview/winbar_child.lua` | Spawned four times by `split_spec` to read one cell of a pane's winbar — three inside the path for the muting, one on the file's added count for the colour — deliberately not a spec. |
+| `codereview/winbar_child.lua` | Spawned four times by `split_spec` to read one cell of a pane's winbar — three inside the path for the muting, one on the file's added count for the color — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
 
 | Spec | Covers |
@@ -46,8 +46,8 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `diff_spec` | Scope resolution, unified-diff parsing, rename/binary/untracked, blob hashing |
 | `render_spec` | Anchor map, byte columns, navigation, collapse, panel, scope cycling, archived entries on the diff — where they draw, the groups they draw in, what they cost a file they say nothing about, the flag that removes them and the key that overrides that flag in both directions, for a session — how a winbar is assembled from typed segments, with no review, no fixture and no repository behind it, and the unified layout's sticky header: the file under the cursor, the crossing, the rename spelled out, which group every piece of the bar draws in, what a narrow pane sheds and what the glyphs bought the path, the tree dismissed, a name carrying a `%`, and a review with no files |
 | `split_spec` | The split layout: pane parity, anchor totality, filler, per-pane chrome and note mirroring — queued and archived alike — with no windows; then the binding, annotation parity against the unified layout, the two intersections nobody else owns, each pane's winbar naming its own side of a rename, and the painted cells proving that bar mutes with its pane and draws its counts in a group of the plugin's own |
-| `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centring, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
-| `spans_spec` | What is emphasised inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
+| `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centering, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
+| `spans_spec` | What is emphasized inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
 | `bounded_spec` | Emission bounded by the viewport: what a paint writes and what it leaves out, the bound it shares with the harvest, what a scroll adds and what scrolling back does not, both panes at once — on a diff taller than the window, guarded |
 | `repaint_spec` | When a paint runs on a resize and when it must not: either event with nothing resized, in both layouts; a pane that really changed width; one terminal resize, which fires both events, repainting once; an event that arrives before anything moved; a window resized in another tab page; and the file tree summoned and dismissed |
@@ -66,7 +66,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `norepo_spec` | Bare notes and files outside a checkout: the new kind, the global store, the age sweep |
 | `faded_spec` | Every file but the one the cursor is in: what a review draws when it opens, the crossing, the hunk that changes nothing, the header left bright, both panes, a repaint that moves the rows, an empty review, the fade's family of blended groups beside the muting's, the switch — the two traps, `syntax = false` and a scroll past the last paint — and the cells three child processes read |
 | `muted_spec` | The **pane** without focus: which pane is bright, the namespace that follows focus and the group each pane lights its row in, the **counterpart row** a muted pane lights and the family of one it comes from, the file tree never muted — bright with its row lit under every focus, and still muting the panes in both layouts when focus lands in it — a float changing nothing, a rebuilt pane and a re-summoned tree, `gA` repainting through a path that has never heard of the muting, the group left bright on purpose, the colorscheme change, both switches — and the cells eight child processes read |
-| `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colours one token can hold |
+| `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colors one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
 | `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — the picked commit in the diff, the oldest row at the merge base, the identity that does not move with the pre-image, the label — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, and where `gs` goes from it; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
@@ -75,7 +75,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
 | `queue_jump_panel_spec` | That jump with the tree dismissed, summoned, and never there — the one surface neither slice could test alone |
-| `interactive_spec` | The insert-mode leak, and where a completed or cancelled `@` leaves you, in a real pty-backed Neovim |
+| `interactive_spec` | The insert-mode leak, and where a completed or canceled `@` leaves you, in a real pty-backed Neovim |
 | `map_spec` | That `lua/codereview/CLAUDE.md` lists exactly the modules that exist — the only part of the map a machine can check |
 
 ## Fixtures
@@ -317,7 +317,7 @@ so the out-of-core language path is still checked locally without ever failing C
   whose value is `""`, so a child cannot tell "set to empty" from "never set". A flag a
   child branches on has to be absent or carry a real value — `capture_child.lua` declines a
   type when `CAPTURE_TYPE` is absent, not when it is blank.
-- **git config is neutralised.** Both the fixture scripts and `minimal_init.lua` set
+- **git config is neutralized.** Both the fixture scripts and `minimal_init.lua` set
   `GIT_CONFIG_GLOBAL=/dev/null`. Inherited settings quietly change what a fixture means:
   `diff.renames = false` turns the rename case into an unrelated add plus delete, and
   `commit.gpgsign` makes building a fixture depend on a gpg agent.
@@ -450,7 +450,7 @@ so the out-of-core language path is still checked locally without ever failing C
 - **A bounded paint is invisible on a diff that fits on screen.** Only the rows near the
   window are written into a pane's buffer, so every extmark assertion elsewhere in the suite
   runs on a fixture small enough to sit inside that band and passes whether or not anything
-  is bounded — the same trap as "centring is unobservable in a window taller than its
+  is bounded — the same trap as "centering is unobservable in a window taller than its
   buffer". `bounded_spec` builds `mkbig` for it, and its first case guards that the render
   really is taller than one paint can reach — as does the last block of `faded_spec`, which
   needs the same height for the same reason. Two of its cases judge against
@@ -481,9 +481,9 @@ so the out-of-core language path is still checked locally without ever failing C
   bands. Both traps above caught this while it was being written, and neither was written
   for it.
 - **Two quiet states that meet are invisible to the spec of either one.** A queued entry and
-  an archived one inside a faded file keep their own colours because the fade renames
+  an archived one inside a faded file keep their own colors because the fade renames
   `hl_group` and `line_hl_group` and returns early for a mark carrying neither — an entry's
-  colours are in the chunks of its virtual lines. A faded file inside a muted pane is faded
+  colors are in the chunks of its virtual lines. A faded file inside a muted pane is faded
   once because the muted namespace links the groups `hl.groups()` names, and the faded family
   is not among them. Both were true from the day the fade landed and neither was measured:
   making the fade rename an entry's chunks reds seven cases, **all** of them in `quiet_spec`,
@@ -493,11 +493,11 @@ so the out-of-core language path is still checked locally without ever failing C
   does not name falls back to its global definition and draws it; a link that reaches no
   definition draws nothing at all. So "the muted namespace holds no entry for
   `CodeReviewFaded.CodeReviewAdd`" is only half the claim, and the half a cell cannot show:
-  `quiet_spec` reads the global definition beside it and asserts it holds a colour and is not
-  itself a link. `hl.lua` writes a twin that loses its colour back as a link to the group it
+  `quiet_spec` reads the global definition beside it and asserts it holds a color and is not
+  itself a link. `hl.lua` writes a twin that loses its color back as a link to the group it
   blends for the same reason.
 - **Two blends can only be counted apart when the two strengths differ.** A cell says how far
-  a colour was pulled, not how many times it was pulled, so with `muted.strength` equal to
+  a color was pulled, not how many times it was pulled, so with `muted.strength` equal to
   `faded.strength` a file faded once and a file merely muted print the same number — and
   "faded once, not twice" then passes for a fade that never ran. `quiet_spec` and
   `quiet_child.lua` run the window rule at 0.25 and the fade at 0.5, which gives one token
@@ -558,15 +558,15 @@ so the out-of-core language path is still checked locally without ever failing C
   each. A round trip started there passes with the anchor scan replaced by "keep the row",
   which is the bug. `layout_spec` starts in `src/newname.lua` and `src/routes.lua`, both
   below that collapse, and guards every round trip by asserting the row really did change.
-- **Centring is unobservable in a window taller than its buffer.** `split_spec` runs at 45
+- **Centering is unobservable in a window taller than its buffer.** `split_spec` runs at 45
   lines, where the whole fixture diff fits on screen and nothing can scroll, so a `zz`
   assertion there passes with the `zz` deleted. `layout_spec` runs at 24 for that reason,
-  and asserts centring as "a second `zz` here changes nothing" plus a guard that the window
+  and asserts centering as "a second `zz` here changes nothing" plus a guard that the window
   had scrolled at all.
 - **Two bound panes given the same view command land somewhere neither was asked for.**
   `scrollbind` tracks deltas, so running `zz` in the after pane scrolls the before pane
   before the before pane has been placed, and its own `zz` then scrolls the after pane
-  back — nine rows apart, neither centred. `place` lifts both bindings while it works and
+  back — nine rows apart, neither centered. `place` lifts both bindings while it works and
   puts them back, which does not scroll anything. `zt` happens to be self-correcting from
   an aligned start, which is why no file-jump assertion caught this first.
 - **Reviewed marks and expansion are per scope, so setting them before a scope change
@@ -577,7 +577,7 @@ so the out-of-core language path is still checked locally without ever failing C
   over *characters*; the obvious implementation splits a Lua string with a pattern, which
   splits by byte, and it passes every assertion an ASCII line can make. `src/nonl.md`'s
   changed line therefore carries `café 🎉` against `cafè 🎈`: `é`/`è` share a leading byte,
-  as do `🎉`/`🎈`, so a byte-wise diff emphasises a trailing byte alone — a boundary inside
+  as do `🎉`/`🎈`, so a byte-wise diff emphasizes a trailing byte alone — a boundary inside
   a character. Replacing `diff.lua`'s `characters()` with a byte loop must red five cases,
   two of which come through the fixture. It rides on a line that file already changed, so
   no count anywhere moved. This is the same trap as "a filter test needs a fixture only that
@@ -587,7 +587,7 @@ so the out-of-core language path is still checked locally without ever failing C
   50% default, and the rename silently degrades into an add plus a delete. Three cases go
   green-to-red for reasons that have nothing to do with what was being tested. Keep that
   file ASCII.
-- **A "both panes" assertion needs a pair that emphasises both sides.** `src/main.lua`'s
+- **A "both panes" assertion needs a pair that emphasizes both sides.** `src/main.lua`'s
   edit is a pure insertion, so its *deletion* carries no spans at all — asserting emphasis
   in both panes on its row passes with the before pane never drawing anything, because the
   case is then reading the after pane twice. `spans_spec` uses `src/nonl.md`, the fixture's
@@ -625,7 +625,7 @@ so the out-of-core language path is still checked locally without ever failing C
   the claim a reviewer can see, which is that the session after this one opens the full
   branch; that has teeth against the implementation worth fearing, a trim filed under the
   root when there is no branch to file it under. Asserting the document's own shape instead
-  would pin the store rather than the behaviour, which no spec in this suite does.
+  would pin the store rather than the behavior, which no spec in this suite does.
 - **Two entries of different types are separated by a group, not by a row.** The queue
   float's boundary between entries is one blank row carrying no bar, and an assertion about
   it needs two entries of the *same* annotation type — give them different ones and what
@@ -692,16 +692,16 @@ so the out-of-core language path is still checked locally without ever failing C
 ## Deliberately not covered
 
 - **Rendering as pixels.** Assertions are against the buffer, the anchor map and extmark
-  metadata — never a screenshot. Highlight *groups* are checked; the colours a colorscheme
+  metadata — never a screenshot. Highlight *groups* are checked; the colors a colorscheme
   resolves them to are not.
 - **The `git diff` long tail.** Submodules, mode-only changes and combined (merge) diffs
   are not handled by the plugin and are not tested either way. They should degrade to a
-  visible "unsupported entry" row rather than a stack trace; today neither behaviour is
+  visible "unsupported entry" row rather than a stack trace; today neither behavior is
   pinned down.
 - **Real adapters.** `send`, `pick_target` and `compose` are injected stubs throughout.
   That is the point of the seam — the plugin carries no opinion about the transport — but
   it means no test exercises a real agent handoff.
-- **Horizontal scroll synchronisation between panes.** There is nothing to cover: it is
+- **Horizontal scroll synchronization between panes.** There is nothing to cover: it is
   `scrollopt` that decides whether a bound window keeps its horizontal position in step,
   `scrollopt` is global, and the plugin deliberately does not set it. What *is* covered is
   that it stays untouched.

--- a/tests/codereview/archive_float_spec.lua
+++ b/tests/codereview/archive_float_spec.lua
@@ -13,7 +13,7 @@
 -- a loop can otherwise leave a previous batch's bare note in reach of the next one's stamp.
 -- Clearing is what keeps every case below a statement about the batch it dispatched.
 --
--- Rows, window chrome and highlight *groups*, never colours.
+-- Rows, window chrome and highlight *groups*, never colors.
 local h = require("tests.helpers")
 
 h.ui(100, 30)
@@ -359,7 +359,7 @@ describe("how an entry says where it was", function()
     assert.same("deleted", text[row]:sub(tag.col + 1, tag.end_col))
   end)
 
-  it("draws the code it inlined inside the same bar, in the diff's own colours", function()
+  it("draws the code it inlined inside the same bar, in the diff's own colors", function()
     local first, last = extent(buf, 1)
     local rows = {}
     for row = first, last do

--- a/tests/codereview/bounded_spec.lua
+++ b/tests/codereview/bounded_spec.lua
@@ -3,7 +3,7 @@
 --
 -- Every claim here needs a diff genuinely taller than the window and the margin around it.
 -- A bounding assertion made on a diff that fits on screen passes with the bounding deleted,
--- which is the failure `tests/README.md` already records twice -- "centring is unobservable
+-- which is the failure `tests/README.md` already records twice -- "centering is unobservable
 -- in a window taller than its buffer", and "a filter test needs a fixture only that filter
 -- can reject". So this is the one spec that builds `mkbig`, small enough to build in a
 -- fraction of a second and still eight times taller than everything one paint can reach,
@@ -194,7 +194,7 @@ describe("a paint of a diff taller than the window", function()
     assert.is_true(groups.CodeReviewAddBar, "no added line carries the change bar")
     assert.is_true(groups.CodeReviewDelBar, "no deleted line carries the change bar")
     assert.is_true(groups.CodeReviewLineNr, "no row carries its line number")
-    assert.is_true(groups.CodeReviewAddSpan, "nothing inside a changed line is emphasised")
+    assert.is_true(groups.CodeReviewAddSpan, "nothing inside a changed line is emphasized")
   end)
 end)
 

--- a/tests/codereview/capture_spec.lua
+++ b/tests/codereview/capture_spec.lua
@@ -162,8 +162,8 @@ describe("declining a type", function()
 end)
 
 -- Dismissing the picker still abandons the annotation entirely. The two were the same
--- outcome while cancelling was the only way out of the picker without choosing.
-describe("cancelling the picker", function()
+-- outcome while canceling was the only way out of the picker without choosing.
+describe("canceling the picker", function()
   local orig = vim.ui.select
   vim.ui.select = function(_, _, cb)
     cb(nil, nil)
@@ -184,7 +184,7 @@ describe("cancelling the picker", function()
   end)
 end)
 
-describe("an unrecognised type", function()
+describe("an unrecognized type", function()
   queue.clear()
   edit("src/main.lua")
   local msgs, restore = h.capture_notify()
@@ -195,7 +195,7 @@ describe("an unrecognised type", function()
     assert.same(0, queue.count())
   end)
 
-  it("names the type it did not recognise", function()
+  it("names the type it did not recognize", function()
     assert.is_true(h.notified(msgs, "unknown annotation type: nonsense"))
   end)
 end)

--- a/tests/codereview/composer_spec.lua
+++ b/tests/codereview/composer_spec.lua
@@ -486,9 +486,9 @@ describe("a picker that answers with a path outside the tree", function()
   end)
 end)
 
--- The sentinel is written before the picker opens precisely so that this is what cancelling
+-- The sentinel is written before the picker opens precisely so that this is what canceling
 -- costs you: nothing.
-describe("cancelling the file picker", function()
+describe("canceling the file picker", function()
   reset()
   file_answer = nil
   annotate_line()

--- a/tests/codereview/faded_child.lua
+++ b/tests/codereview/faded_child.lua
@@ -7,7 +7,7 @@
 -- is to make exactly one such call, in one arrangement, and print what it saw.
 --
 -- A group name cannot tell a faded row from a bright one, which is why this exists at all:
--- the cell is the only reading that says the colour really moved.
+-- the cell is the only reading that says the color really moved.
 --
 -- The screen is 80x24 because that is the grid a headless Neovim keeps whatever `columns`
 -- and `lines` are set to: a window drawn past column 80 is drawn into cells no assertion can
@@ -24,8 +24,8 @@ vim.o.lines = 24
 local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
 vim.cmd("cd " .. vim.fn.fnameescape(fixture))
 
--- Colours the arithmetic is exact on: every channel is even, so a blend halfway to a black
--- background is a colour with no rounding in it.
+-- Colors the arithmetic is exact on: every channel is even, so a blend halfway to a black
+-- background is a color with no rounding in it.
 vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
 vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
 vim.api.nvim_set_hl(0, "@keyword", { fg = 0xee0000 })
@@ -33,9 +33,9 @@ vim.api.nvim_set_hl(0, "@keyword", { fg = 0xee0000 })
 require("codereview").setup({
   layout = "unified",
   syntax = true,
-  -- The window rule is off, so nothing but the fade can pull a colour toward the background
+  -- The window rule is off, so nothing but the fade can pull a color toward the background
   -- here. Its strength is deliberately not the fade's either: a fade that read the number
-  -- beside it would print a colour this cell can tell apart.
+  -- beside it would print a color this cell can tell apart.
   muted = { enabled = false, strength = 0.25 },
   faded = { enabled = vim.env.FADED ~= "0", strength = 0.5 },
 })

--- a/tests/codereview/faded_spec.lua
+++ b/tests/codereview/faded_spec.lua
@@ -7,12 +7,12 @@
 -- that emits.
 --
 -- Only this plugin's own groups are judged bright or faded. A treesitter capture the active
--- theme gives no colour of its own is emitted as itself by design -- `@spell` is one in this
+-- theme gives no color of its own is emitted as itself by design -- `@spell` is one in this
 -- fixture -- and counting that as "left bright" would be counting the nil contract as a
 -- defect. What the replay does under the fade is asserted on the captures that do have a
--- colour, by name.
+-- color, by name.
 --
--- Two blocks exist for traps rather than for behaviour. One opens a review with
+-- Two blocks exist for traps rather than for behavior. One opens a review with
 -- `syntax = false`, which fails for a fade that took its row spans from the replay's row map:
 -- that map is built only when highlighting is on. One scrolls into rows no paint had reached
 -- at the moment of the crossing, which fails for a fade that renamed the rows it could see
@@ -32,14 +32,14 @@ local view = require("codereview.view")
 h.ui(110, 40)
 local fixture = h.cd_fixture("mkfixture")
 
--- Colours with even channels, so a blend a quarter of the way to a black background has no
+-- Colors with even channels, so a blend a quarter of the way to a black background has no
 -- rounding in it and the numbers below can be read at a glance.
 vim.o.termguicolors = true
 vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
 vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
--- A group with a name and no colour at all: the one thing the blend cannot compute, and the
+-- A group with a name and no color at all: the one thing the blend cannot compute, and the
 -- case it must hand back nothing for. Defined before any review has blended anything.
-vim.api.nvim_set_hl(0, "FadedSpecColourless", {})
+vim.api.nvim_set_hl(0, "FadedSpecColorless", {})
 
 ---What the name of every blended group in the fade's family starts with.
 local FADED = "CodeReviewFaded."
@@ -384,7 +384,7 @@ describe("a review with no files", function()
   view.set_scope("branch")
 end)
 
---- The colours behind it ------------------------------------------------------------
+--- The colors behind it ------------------------------------------------------------
 
 describe("the fade's family of blended groups, beside the muting's", function()
   it("gives the fade a strength of its own", function()
@@ -394,21 +394,21 @@ describe("the fade's family of blended groups, beside the muting's", function()
     local one = vim.api.nvim_get_hl(0, { name = faded, link = false }).bg
     local other = vim.api.nvim_get_hl(0, { name = muted, link = false }).bg
     assert.is_true(one ~= other, ("both families blend a changed line to %s"):format(tostring(one)))
-    -- Both pulled from the same colour toward the same background, and the fade less far:
+    -- Both pulled from the same color toward the same background, and the fade less far:
     -- it covers every file but one, where the window rule covers a pane.
     assert.is_true(one < theme and other < one, ("theme %s, faded %s, muted %s"):format(theme, one, other))
   end)
 
   -- Nobody is to "fix" this by giving the fade a palette of its own. A group with no blend
-  -- emitted as itself is what keeps an unrecognised theme merely less faded instead of
-  -- wrongly coloured, and there is no higher place to say it: the render carries no mark in
-  -- a colourless group, so no reading of the buffer can reach this.
-  it("hands back nothing for a group the theme gives no colour", function()
-    assert.is_nil(hl.blended("faded", "FadedSpecColourless"))
-    assert.same("FadedSpecColourless", fade.group("FadedSpecColourless"))
+  -- emitted as itself is what keeps an unrecognized theme merely less faded instead of
+  -- wrongly colored, and there is no higher place to say it: the render carries no mark in
+  -- a colorless group, so no reading of the buffer can reach this.
+  it("hands back nothing for a group the theme gives no color", function()
+    assert.is_nil(hl.blended("faded", "FadedSpecColorless"))
+    assert.same("FadedSpecColorless", fade.group("FadedSpecColorless"))
   end)
 
-  it("hands back a blend for a group it does colour, beside it", function()
+  it("hands back a blend for a group it does color, beside it", function()
     assert.same(FADED .. "CodeReviewAdd", fade.group("CodeReviewAdd"))
   end)
 end)
@@ -577,7 +577,7 @@ end)
 
 --- A colorscheme the review was not blended against ------------------------------------
 
--- Last of the in-process blocks, because it replaces every colour the ones above read.
+-- Last of the in-process blocks, because it replaces every color the ones above read.
 describe("changing colorscheme", function()
   local function bg(group)
     return vim.api.nvim_get_hl(0, { name = group, link = false }).bg
@@ -593,14 +593,14 @@ describe("changing colorscheme", function()
   local after = bg(FADED .. "CodeReviewAdd")
 
   -- Without this the case below passes on a theme that happens to paint a changed line the
-  -- same colour the last one did, which would prove nothing about recomputing anything.
+  -- same color the last one did, which would prove nothing about recomputing anything.
   it("is a change the theme really made", function()
     assert.is_true(was ~= now, ("both themes give a changed line %s"):format(tostring(now)))
   end)
 
-  it("recomputes the faded colour against the theme that is active now", function()
-    assert.is_true(before ~= after, "the faded colour is the one the old theme was blended into")
-    assert.is_true(after ~= now, "the faded colour is the new theme's, unfaded")
+  it("recomputes the faded color against the theme that is active now", function()
+    assert.is_true(before ~= after, "the faded color is the one the old theme was blended into")
+    assert.is_true(after ~= now, "the faded color is the new theme's, unfaded")
     local theme, back, faded = now, backdrop, after
     for _, place in ipairs({ 65536, 256, 1 }) do
       local one = math.floor(theme / place) % 256

--- a/tests/codereview/interactive_spec.lua
+++ b/tests/codereview/interactive_spec.lua
@@ -208,10 +208,10 @@ describe("referencing a file while typing", function()
   end)
 end)
 
--- Cancelling is the case the sentinel is written up front for. What it costs the reviewer
+-- Canceling is the case the sentinel is written up front for. What it costs the reviewer
 -- should be the `@` they typed and nothing else -- not the sentence they were in the
 -- middle of.
-describe("cancelling the file picker while typing", function()
+describe("canceling the file picker while typing", function()
   local typed = "look at @"
 
   -- A picker that answers with nothing is a picker the reviewer dismissed.

--- a/tests/codereview/layout_spec.lua
+++ b/tests/codereview/layout_spec.lua
@@ -7,7 +7,7 @@
 -- file the collapse of a deletion above it has not shifted, proves nothing: the row would
 -- have survived a toggle that carried it across unchanged, which is the bug.
 --
--- The window is deliberately short enough that the diff does not fit in it. Centring is
+-- The window is deliberately short enough that the diff does not fit in it. Centering is
 -- unobservable in a window taller than its buffer, and the assertion would pass with `zz`
 -- deleted.
 local h = require("tests.helpers")
@@ -394,7 +394,7 @@ describe("a collapsed file's header", function()
 end)
 
 describe("the landing line", function()
-  it("is far enough down that centring is observable at all", function()
+  it("is far enough down that centering is observable at all", function()
     in_layout("unified")
     local V = current()
     local row = side_row(V.render, "src/untracked.lua", "add")
@@ -404,14 +404,14 @@ describe("the landing line", function()
     )
   end)
 
-  it("is centred", function()
+  it("is centered", function()
     in_layout("unified")
     start_on("src/untracked.lua", "add")
     view.toggle_layout()
 
     local win = vim.api.nvim_get_current_win()
     local was = topline(win)
-    -- Centred is exactly "a `zz` here would change nothing".
+    -- Centered is exactly "a `zz` here would change nothing".
     vim.api.nvim_win_call(win, function()
       vim.cmd("normal! zz")
     end)
@@ -431,7 +431,7 @@ describe("the landing line", function()
 end)
 
 -- Putting a row on screen runs the same view command in both panes, and the toggle's
--- centring shares that with every jump. Asserted here rather than in `split_spec`, whose
+-- centering shares that with every jump. Asserted here rather than in `split_spec`, whose
 -- window is taller than the whole diff: nothing scrolls there, so nothing can come apart.
 describe("a jump in a window shorter than the diff", function()
   it("leaves both panes on the same row and the same top line", function()

--- a/tests/codereview/muted_child.lua
+++ b/tests/codereview/muted_child.lua
@@ -22,12 +22,12 @@ vim.o.lines = 24
 local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
 vim.cmd("cd " .. vim.fn.fnameescape(fixture))
 
--- Colours the arithmetic is exact on: every channel is even, so a blend halfway to a black
--- background is a colour with no rounding in it.
+-- Colors the arithmetic is exact on: every channel is even, so a blend halfway to a black
+-- background is a color with no rounding in it.
 vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
 vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
 vim.api.nvim_set_hl(0, "@keyword", { fg = 0xee0000 })
--- The row a **pane** lights. A colour of its own, and its channels divide by four, so the
+-- The row a **pane** lights. A color of its own, and its channels divide by four, so the
 -- muting's half and the counterpart row's quarter are both exact and neither can be mistaken
 -- for the other: 0x004488 comes out 0x002244 muted and 0x003366 as a counterpart row.
 vim.api.nvim_set_hl(0, "CursorLine", { bg = 0x004488 })

--- a/tests/codereview/muted_spec.lua
+++ b/tests/codereview/muted_spec.lua
@@ -16,7 +16,7 @@
 -- One level lower, and only where there is no higher way to say it, the namespace's own
 -- contents are read: that a variant is derived from the theme that is active now, and that a
 -- group this plugin cannot know about has none. The namespace holds a link to the group that
--- holds the colour, so `muted_hl` below reads the colour through it. Read the namespace alone
+-- holds the color, so `muted_hl` below reads the color through it. Read the namespace alone
 -- and you stop at a name, which says nothing about what a cell will show.
 --
 -- Lower still, the cells the reviewer's screen really holds. Those are in `muted_child.lua`,
@@ -36,7 +36,7 @@ local view = require("codereview.view")
 -- already has, so this is a lookup rather than a second namespace.
 local MUTED = vim.api.nvim_create_namespace("codereview_muted")
 
--- Colours with even channels, so a blend halfway to a black background has no rounding in
+-- Colors with even channels, so a blend halfway to a black background has no rounding in
 -- it and the numbers below can be read at a glance.
 vim.o.termguicolors = true
 vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
@@ -78,7 +78,7 @@ end
 ---can carry `CursorLine` all the way down to the muting's own blend -- which is the one
 ---answer a **counterpart row** must never have. So the group is named as well, and naming it
 ---needs the namespace's own contents; there is no higher way to say it. The cells
----`muted_child.lua` reads are what prove those names are colours.
+---`muted_child.lua` reads are what prove those names are colors.
 ---@param win integer
 ---@return string
 local function lit(win)
@@ -111,7 +111,7 @@ end
 
 ---What a muted window really draws `group` in.
 ---
----One hop, because the namespace names a group and that group holds the colour. Reading the
+---One hop, because the namespace names a group and that group holds the color. Reading the
 ---namespace alone stops at the name, which says nothing about what a cell will show.
 ---@param group string
 ---@return table
@@ -185,7 +185,7 @@ describe("a file whose syntax is parsed only after its pane lost focus", functio
     local bright = {}
     for _, group in ipairs(fresh) do
       local def = vim.api.nvim_get_hl(0, { name = group, link = false })
-      -- A group the theme gives no colour of its own is deliberately left without a
+      -- A group the theme gives no color of its own is deliberately left without a
       -- variant; it is the case below, not a miss here.
       if (def.fg or def.bg) and vim.tbl_isempty(vim.api.nvim_get_hl(MUTED, { name = group })) then
         bright[#bright + 1] = group
@@ -493,8 +493,8 @@ describe("archived entries toggled off the diff and back", function()
   end)
 
   -- The one thing the two readings above cannot see. They name a group; a repaint that had
-  -- written the twins again against nothing would leave the name reaching a different colour.
-  it("leaves the colour that group holds alone", function()
+  -- written the twins again against nothing would leave the name reaching a different color.
+  it("leaves the color that group holds alone", function()
     assert.same(twin, muted_hl("CursorLine").bg)
   end)
 
@@ -519,8 +519,8 @@ describe("a group the plugin cannot know about", function()
   end)
 
   -- Nobody is to "fix" the case above by giving the namespace a palette of its own: a group
-  -- with no variant falling back to its global definition is what keeps an unrecognised
-  -- theme merely less muted instead of wrongly coloured. `muted_child.lua` reads the cell.
+  -- with no variant falling back to its global definition is what keeps an unrecognized
+  -- theme merely less muted instead of wrongly colored. `muted_child.lua` reads the cell.
   it("keeps a group the plugin does know about muted beside it", function()
     local add = muted_hl("CodeReviewAdd")
     assert.is_truthy(add.bg, "CodeReviewAdd has no muted variant")
@@ -528,7 +528,7 @@ describe("a group the plugin cannot know about", function()
 end)
 
 -- A family of its own, holding one member. The alternative is a second copy of the blend
--- arithmetic, which is how this one and the muting would drift apart in colour.
+-- arithmetic, which is how this one and the muting would drift apart in color.
 describe("the group a muted pane lights its counterpart row in", function()
   local theme = vim.api.nvim_get_hl(0, { name = "CursorLine", link = false }).bg
   local counterpart = muted_hl("CursorLine").bg
@@ -539,8 +539,8 @@ describe("the group a muted pane lights its counterpart row in", function()
 
   it("is a blend of the lit row this theme draws, and not that row itself", function()
     assert.same(0x004488, theme)
-    assert.is_truthy(counterpart, "a muted pane lights its row in no colour of its own")
-    assert.is_true(counterpart ~= theme, "the counterpart row is the focused pane's colour")
+    assert.is_truthy(counterpart, "a muted pane lights its row in no color of its own")
+    assert.is_true(counterpart ~= theme, "the counterpart row is the focused pane's color")
   end)
 
   -- What the family is for: a row pulled as far as the muting is would be lost inside the
@@ -585,7 +585,7 @@ describe("changing colorscheme", function()
   end
 
   -- Without these two the cases below pass on a theme that happens to paint a changed line,
-  -- or a lit row, the same colour the last one did -- which would prove nothing about
+  -- or a lit row, the same color the last one did -- which would prove nothing about
   -- recomputing anything.
   it("is a change the theme really made", function()
     assert.is_true(was ~= now, ("both themes give a changed line %s"):format(tostring(now)))
@@ -595,14 +595,14 @@ describe("changing colorscheme", function()
     assert.is_true(lit_was ~= lit_now, ("both themes light a row %s"):format(tostring(lit_now)))
   end)
 
-  it("recomputes the muted colour against the theme that is active now", function()
-    assert.is_true(before ~= after, "the muted colour is the one the old theme was blended into")
-    assert.is_true(after ~= now, "the muted colour is the new theme's, unmuted")
+  it("recomputes the muted color against the theme that is active now", function()
+    assert.is_true(before ~= after, "the muted color is the one the old theme was blended into")
+    assert.is_true(after ~= now, "the muted color is the new theme's, unmuted")
     pulled_toward_the_background("muted", after, now)
   end)
 
   it("recomputes the counterpart row against it too", function()
-    assert.is_true(lit_before ~= lit_after, "the counterpart row is the colour the old theme was blended into")
+    assert.is_true(lit_before ~= lit_after, "the counterpart row is the color the old theme was blended into")
     assert.is_true(lit_after ~= lit_now, "the counterpart row is the new theme's lit row, unblended")
     pulled_toward_the_background("counterpart", lit_after, lit_now)
   end)
@@ -739,7 +739,7 @@ describe("the cell under a reviewer's eye", function()
   end)
 
   -- The regression the `winhighlight`/`NormalNC` route would be: it changes a window's
-  -- default colours, and neither of these two comes from those.
+  -- default colors, and neither of these two comes from those.
   it("mutes both of them once its pane loses focus", function()
     assert.same("cell l fg=770000 bg=002200", (muted:gsub(" at %d+,%d+$", "")))
   end)

--- a/tests/codereview/queue_float_spec.lua
+++ b/tests/codereview/queue_float_spec.lua
@@ -6,7 +6,7 @@
 -- decoration -- it is the same fact `x` resolves against, so an entry whose extent is
 -- visible is an entry that cannot be dropped by accident.
 --
--- Rows and highlight *groups*, never colours: what a colorscheme resolves a group to is
+-- Rows and highlight *groups*, never colors: what a colorscheme resolves a group to is
 -- deliberately not covered anywhere in this suite.
 local h = require("tests.helpers")
 
@@ -234,7 +234,7 @@ describe("an entry with an inlined diff block and a multi-line note", function()
   end)
 
   -- The bar glyph is multibyte, and extmark columns are byte offsets. A highlight placed at
-  -- the display column instead lands inside the glyph and paints nothing recognisable --
+  -- the display column instead lands inside the glyph and paints nothing recognizable --
   -- the same trap the diff's change bar records in the design notes.
   it("highlights the bar by byte offset, not by display column", function()
     assert.is_true(#BAR > vim.fn.strdisplaywidth(BAR), "the bar under test is not multibyte")
@@ -495,7 +495,7 @@ describe("submitting from the float", function()
   end)
 
   -- The invariant the float's window handle is recorded for, restated here because this is
-  -- the keystroke that has to honour it: a batch that has gone must not be left on screen.
+  -- the keystroke that has to honor it: a batch that has gone must not be left on screen.
   it("leaves no float listing a batch that has already gone", function()
     assert.is_false(vim.api.nvim_win_is_valid(win))
   end)

--- a/tests/codereview/queue_jump_spec.lua
+++ b/tests/codereview/queue_jump_spec.lua
@@ -6,7 +6,7 @@
 -- scope -- which is why the messages are asserted apart rather than merely counted.
 local h = require("tests.helpers")
 
--- Deliberately short: whether a landing row is *centred* is only observable when the diff
+-- Deliberately short: whether a landing row is *centered* is only observable when the diff
 -- outruns the window and there is somewhere else the cursor could have been put.
 h.ui(100, 20)
 h.cd_fixture("mkfixture")
@@ -128,7 +128,7 @@ describe("jumping to a line annotation", function()
   local landed = vim.api.nvim_win_get_cursor(V.win)[1]
   local winline = vim.api.nvim_win_call(V.win, vim.fn.winline)
 
-  -- Guards the test itself: a target already on screen would pass the centring assertion
+  -- Guards the test itself: a target already on screen would pass the centering assertion
   -- with nothing scrolling it.
   it("is a jump that has to scroll", function()
     assert.is_true(target > height, ("row %d, window height %d"):format(target, height))
@@ -147,7 +147,7 @@ describe("jumping to a line annotation", function()
     assert.same(target, landed)
   end)
 
-  it("centres it", function()
+  it("centers it", function()
     assert.is_true(
       math.abs(winline - math.ceil(height / 2)) <= 1,
       ("cursor on screen row %d of %d"):format(winline, height)

--- a/tests/codereview/quiet_child.lua
+++ b/tests/codereview/quiet_child.lua
@@ -7,7 +7,7 @@
 -- is to make exactly one such call, in one arrangement, and print what it saw.
 --
 -- A group name cannot tell a faded row from a bright one, and it cannot tell one blend from
--- two. The cell is the only reading that says where a colour really ended up.
+-- two. The cell is the only reading that says where a color really ended up.
 --
 -- The screen is 80x24 because that is the grid a headless Neovim keeps whatever `columns`
 -- and `lines` are set to: a window drawn past column 80 is drawn into cells no assertion can
@@ -24,14 +24,14 @@ vim.o.lines = 24
 local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
 vim.cmd("cd " .. vim.fn.fnameescape(fixture))
 
--- Colours the arithmetic is exact on: every channel divides by four, so a blend halfway to a
--- black background and a blend a quarter of the way are both colours with no rounding in
+-- Colors the arithmetic is exact on: every channel divides by four, so a blend halfway to a
+-- black background and a blend a quarter of the way are both colors with no rounding in
 -- them -- and so is one laid over the other.
 vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
 vim.api.nvim_set_hl(0, "DiffAdd", { bg = 0x004400 })
 vim.api.nvim_set_hl(0, "@keyword", { fg = 0xec0000 })
 -- What the marker of a queued entry draws in, through `CodeReviewBug`, and what the marker
--- of an archived one draws in, through `CodeReviewArchived`. Two colours of their own, so a
+-- of an archived one draws in, through `CodeReviewArchived`. Two colors of their own, so a
 -- reading of either says which of the two it read.
 vim.api.nvim_set_hl(0, "DiagnosticError", { fg = 0x00ec00, bg = 0x440044 })
 vim.api.nvim_set_hl(0, "Comment", { fg = 0x0000ec, bg = 0x444400 })
@@ -40,8 +40,8 @@ require("codereview").setup({
   layout = "unified",
   syntax = true,
   -- Two strengths that cannot be mistaken for each other. A cell blended once at either of
-  -- them, and a cell blended at both, are three different colours -- which is what lets one
-  -- reading say how many times a colour was pulled toward the background.
+  -- them, and a cell blended at both, are three different colors -- which is what lets one
+  -- reading say how many times a color was pulled toward the background.
   muted = { enabled = vim.env.MUTED ~= "0", strength = 0.25 },
   faded = { enabled = true, strength = 0.5 },
   -- One type, with an ASCII marker: the cell under test then holds a character this file can

--- a/tests/codereview/quiet_spec.lua
+++ b/tests/codereview/quiet_spec.lua
@@ -6,7 +6,7 @@
 -- meeting already behaves as it should. Each of them holds by construction rather than by
 -- intent, and until this file none of them was asserted anywhere.
 --
--- That is the shape #108 met in the winbar: a behaviour nothing announces the end of. The
+-- That is the shape #108 met in the winbar: a behavior nothing announces the end of. The
 -- fade renames `hl_group` and `line_hl_group` and returns early for a mark that carries
 -- neither, so it never reaches the chunks an entry's virtual lines are drawn from. The muted
 -- namespace links the groups `hl.groups()` names, and the faded family is not among them, so
@@ -16,10 +16,10 @@
 -- Asserted at the cell, in `quiet_child.lua`, one process per reading -- a group name cannot
 -- tell a faded row from a bright one, and it cannot tell one blend from two. The blocks in
 -- this process assert the mechanism each reading rests on, which is the only level that can
--- say *why* a colour stayed where it is.
+-- say *why* a color stayed where it is.
 --
 -- The one thing no cell can show: `CodeReviewFaded.CodeReviewAdd` is absent from the muted
--- namespace and is a definition with a colour in it, not a link reaching nothing. An absent
+-- namespace and is a definition with a color in it, not a link reaching nothing. An absent
 -- entry falls back and draws; a dead link draws nothing at all. The claim rests on that
 -- difference, so both halves are read here.
 local h = require("tests.helpers")
@@ -30,7 +30,7 @@ local view = require("codereview.view")
 h.ui(110, 40)
 local fixture = h.cd_fixture("mkfixture")
 
--- Colours with even channels, so a blend has no rounding in it and the numbers can be read
+-- Colors with even channels, so a blend has no rounding in it and the numbers can be read
 -- at a glance.
 vim.o.termguicolors = true
 vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
@@ -51,7 +51,7 @@ require("codereview").setup({
   layout = "unified",
   syntax = true,
   -- Two strengths that cannot be mistaken for each other, for the reason the child gives:
-  -- one blend, the other blend and both blends are three different colours.
+  -- one blend, the other blend and both blends are three different colors.
   muted = { enabled = true, strength = 0.25 },
   faded = { enabled = true, strength = 0.5 },
   types = { { name = "bug", key = "b", icon = "!", hl = "CodeReviewBug", label = "Bugs" } },
@@ -167,7 +167,7 @@ describe("a queued entry and an archived one inside a faded file", function()
   end)
 
   -- The mechanism the whole claim rests on. An entry hangs *under* the row it is about, and
-  -- its colours are in that mark's chunks. The fade renames `hl_group` and `line_hl_group`,
+  -- its colors are in that mark's chunks. The fade renames `hl_group` and `line_hl_group`,
   -- which is what a mark puts on the row it sits on, and returns early for a mark that
   -- carries neither.
   it("puts no group of its own on the row it hangs under, so the fade has nothing to rename", function()
@@ -213,7 +213,7 @@ end)
 describe("the groups a faded row carries and the namespace a muted pane draws through", function()
   -- The guard every case below needs: with nothing in the namespace at all, "the faded family
   -- is not in it" holds over an empty table.
-  it("links the group that faded row's colour is blended from", function()
+  it("links the group that faded row's color is blended from", function()
     assert.is_truthy(vim.api.nvim_get_hl(MUTED, { name = "CodeReviewAdd" }).link, "the namespace links nothing")
   end)
 
@@ -230,9 +230,9 @@ describe("the groups a faded row carries and the namespace a muted pane draws th
   -- What the case above is worth nothing without, and what no cell reading can show. An
   -- absent entry falls back to the twin's global definition and draws it; a link reaching
   -- nothing draws nothing at all. Nobody is to "fix" the absence by adding a link.
-  it("leaves a definition with a colour in it to fall back to, not a dead link", function()
+  it("leaves a definition with a color in it to fall back to, not a dead link", function()
     local def = vim.api.nvim_get_hl(0, { name = FADED .. "CodeReviewAdd", link = false })
-    assert.is_truthy(def.bg, "the fade's twin of a changed line holds no colour")
+    assert.is_truthy(def.bg, "the fade's twin of a changed line holds no color")
     assert.is_nil(def.link)
   end)
 end)
@@ -245,7 +245,7 @@ end)
 -- cell of it: the marker of either entry, or the first token the replay painted on an added
 -- line of the code around them.
 --
--- The fade pulls a colour half of the way to the background and the window rule a quarter of
+-- The fade pulls a color half of the way to the background and the window rule a quarter of
 -- the way, so the four numbers a changed line's token can hold are all different: `ec0000` on
 -- `004400` bright, `760000` on `002200` faded, `b10000` on `003300` muted, and `590000` on
 -- `001a00` had it been both.
@@ -297,7 +297,7 @@ describe("the cell under a reviewer's eye", function()
     assert.same("cell ! fg=00ec00 bg=440044", note_away)
   end)
 
-  it("gives it exactly the colour it has in a file that is not faded", function()
+  it("gives it exactly the color it has in a file that is not faded", function()
     assert.same(note_inside, note_away)
   end)
 
@@ -307,7 +307,7 @@ describe("the cell under a reviewer's eye", function()
     assert.same("cell ! fg=0000ec bg=444400", gone_away)
   end)
 
-  it("gives that one exactly the colour it has in a file that is not faded too", function()
+  it("gives that one exactly the color it has in a file that is not faded too", function()
     assert.same(gone_inside, gone_away)
   end)
 

--- a/tests/codereview/render_spec.lua
+++ b/tests/codereview/render_spec.lua
@@ -168,7 +168,7 @@ end)
 -- Archived entries on the diff: what has already been reported, drawn beneath the code it
 -- was about so a reviewer who keeps going while an agent works does not report it twice.
 --
--- Everything here is asserted through extmark metadata and highlight *groups*. The colours
+-- Everything here is asserted through extmark metadata and highlight *groups*. The colors
 -- a colorscheme resolves those to are deliberately not tested, and never have been.
 describe("archived entries", function()
   local V = view.current()
@@ -263,8 +263,8 @@ describe("archived entries", function()
 
   -- Every group here is a `default = true` link into whatever colorscheme is active, which
   -- is the rule every other group in `hl.lua` follows and the only reason overriding one
-  -- works. Asserted as a link to a defined group, never as a resolved colour.
-  it("links those groups into the colorscheme rather than defining colours", function()
+  -- works. Asserted as a link to a defined group, never as a resolved color.
+  it("links those groups into the colorscheme rather than defining colors", function()
     for _, group in ipairs({ "CodeReviewArchived", "CodeReviewArchivedNote" }) do
       local def = vim.api.nvim_get_hl(0, { name = group })
       assert.is_truthy(def.link, ("%s is not a link: %s"):format(group, vim.inspect(def)))
@@ -378,7 +378,7 @@ describe("the winbar assembly", function()
     assert.same("%%#CodeReviewAdd#x", render.bar({ render.literal("%#CodeReviewAdd#x") }))
   end)
 
-  -- A name can be coloured too, and the escape is unchanged by it: the bar's coloured
+  -- A name can be colored too, and the escape is unchanged by it: the bar's colored
   -- pieces are largely names -- a **target**'s short name, a base revision, a count carrying
   -- a glyph a host configured -- and the alternative is a caller writing the markers around
   -- one by hand, which is exactly what having a kind per segment refuses.
@@ -460,10 +460,10 @@ describe("the winbar assembly", function()
     assert.is_true(groups.DiffAdd or false, vim.inspect(drawn.highlights))
   end)
 
-  -- The same claim for a coloured *name*, which is the case the bar actually needs: the
+  -- The same claim for a colored *name*, which is the case the bar actually needs: the
   -- escape and the marker have to compose, so that what Neovim draws is the name as it
   -- stands, in the group asked for, and no wider than the ruler said.
-  it("colours a name without letting the escape reach the screen", function()
+  it("colors a name without letting the escape reach the screen", function()
     local segments = { render.literal("src/50% done.lua", "DiffAdd") }
     local drawn = vim.api.nvim_eval_statusline(render.bar(segments), { highlights = true })
     assert.same("src/50% done.lua", drawn.str)
@@ -625,7 +625,7 @@ describe("the sticky header with room for the whole summary", function()
     assert.is_nil(group_of("src/nonl.md"))
   end)
 
-  it("colours the file's own added and removed counts apart", function()
+  it("colors the file's own added and removed counts apart", function()
     local file = V.files[assert(h.file_index(V, "src/nonl.md"))]
     assert.same("CodeReviewStatAdd", group_of(("+%d"):format(file.added)))
     assert.same("CodeReviewStatDel", group_of(("-%d"):format(file.removed)))
@@ -639,8 +639,8 @@ describe("the sticky header with room for the whole summary", function()
   -- Every group here is a `default = true` link into whatever colorscheme is active, which
   -- is what makes a theme change the theme's problem -- and what gives the bar **muted**
   -- twins for free, since `hl.groups()` derives the muted set from the same table. Asserted
-  -- as a link to a defined group, never as a resolved colour.
-  it("links the bar's own groups into the colorscheme rather than defining colours", function()
+  -- as a link to a defined group, never as a resolved color.
+  it("links the bar's own groups into the colorscheme rather than defining colors", function()
     for _, group in ipairs({ "CodeReviewBarIcon", "CodeReviewBarSep", "CodeReviewBarTarget", "CodeReviewBarRev" }) do
       local def = vim.api.nvim_get_hl(0, { name = group })
       assert.is_truthy(def.link, ("%s is not a link: %s"):format(group, vim.inspect(def)))
@@ -650,7 +650,7 @@ describe("the sticky header with room for the whole summary", function()
 
   -- The theme's problem, proven rather than asserted of the links: a colorscheme clears every
   -- global definition, and the bar has to come back linked into the new one.
-  it("comes back in the new theme's colours when the colorscheme changes", function()
+  it("comes back in the new theme's colors when the colorscheme changes", function()
     vim.cmd("colorscheme blue")
     local def = vim.api.nvim_get_hl(0, { name = "CodeReviewBarSep" })
     assert.is_truthy(def.link, vim.inspect(def))
@@ -696,7 +696,7 @@ end)
 
 describe("the sticky header on a pane that has to choose", function()
   local V = view.current()
-  view.toggle_panel() -- back, so the after pane has a neighbour to give columns to
+  view.toggle_panel() -- back, so the after pane has a neighbor to give columns to
 
   local function bar()
     return h.winbar(V.win)

--- a/tests/codereview/since_batch_spec.lua
+++ b/tests/codereview/since_batch_spec.lua
@@ -1,7 +1,7 @@
 -- The since-batch scope inside a review view: the claim that nothing about it is second
 -- class.
 --
--- Every case here asserts a behaviour some *other* spec owns for every other scope --
+-- Every case here asserts a behavior some *other* spec owns for every other scope --
 -- syntax, navigation, collapse, reviewed marks, both layouts, capture -- because the way
 -- this scope fails is not by throwing: it is by being special-cased somewhere in the
 -- render or the view until it renders a little less than the others do.

--- a/tests/codereview/spans_spec.lua
+++ b/tests/codereview/spans_spec.lua
@@ -1,8 +1,8 @@
--- Emphasising what changed inside a changed line.
+-- Emphasizing what changed inside a changed line.
 --
 -- Two seams, both pure, both asserted without a window. The parser decides *what* is
--- emphasised -- the pairing, unequal runs, the suppression threshold, character
--- boundaries -- and hangs spans on the lines it emphasises. The render decides *how* they
+-- emphasized -- the pairing, unequal runs, the suppression threshold, character
+-- boundaries -- and hangs spans on the lines it emphasizes. The render decides *how* they
 -- are drawn: the priority band, background-only groups, byte offsets past the gutter, and
 -- the same row in both panes.
 --
@@ -33,7 +33,7 @@ local git = require("codereview.git")
 local render = require("codereview.render")
 local config = require("codereview.config")
 
---- The parser: what is emphasised ----------------------------------------------
+--- The parser: what is emphasized ----------------------------------------------
 
 ---A one-hunk diff of `body`, each entry already carrying its `+`/`-`/space marker.
 ---@param body string[]
@@ -59,10 +59,10 @@ local function parse(body)
   return diff.parse(text, { spans = true })[1].hunks[1].lines
 end
 
----The text each of a line's spans covers -- what a reviewer actually sees emphasised.
+---The text each of a line's spans covers -- what a reviewer actually sees emphasized.
 ---@param ln CRLine
 ---@return string[]
-local function emphasised(ln)
+local function emphasized(ln)
   local out = {}
   for _, s in ipairs(ln.spans or {}) do
     out[#out + 1] = ln.text:sub(s.col + 1, s.end_col)
@@ -91,22 +91,22 @@ describe("a deletion and its replacement", function()
     "+local cfg = load_config()",
   })
 
-  it("emphasises the characters that differ", function()
-    assert.same({ "_config" }, emphasised(lines[3]))
+  it("emphasizes the characters that differ", function()
+    assert.same({ "_config" }, emphasized(lines[3]))
   end)
 
-  it("emphasises nothing that both lines share", function()
-    assert.same({}, emphasised(lines[2]))
+  it("emphasizes nothing that both lines share", function()
+    assert.same({}, emphasized(lines[2]))
   end)
 
   -- Both sides, so a reviewer sees what an identifier was as well as what it became. The
-  -- trailing `a` the two names happen to share is not emphasised on either: granularity is
+  -- trailing `a` the two names happen to share is not emphasized on either: granularity is
   -- characters, not tokens, and widening a span to the enclosing identifier would be
   -- pointing at something that did not change.
-  it("emphasises what a rename was as well as what it became", function()
+  it("emphasizes what a rename was as well as what it became", function()
     local del, add = unpack(parse({ "-local cfg = alpha()", "+local cfg = omega()" }))
-    assert.same({ "alph" }, emphasised(del))
-    assert.same({ "omeg" }, emphasised(add))
+    assert.same({ "alph" }, emphasized(del))
+    assert.same({ "omeg" }, emphasized(add))
   end)
 
   it("leaves a context line alone", function()
@@ -115,35 +115,35 @@ describe("a deletion and its replacement", function()
 end)
 
 describe("where an edit sits in the line", function()
-  it("emphasises several separate edits", function()
+  it("emphasizes several separate edits", function()
     local del, add = unpack(parse({ "-local a = 1; local b = 2", "+local a = 9; local b = 8" }))
-    assert.same({ "1", "2" }, emphasised(del))
-    assert.same({ "9", "8" }, emphasised(add))
+    assert.same({ "1", "2" }, emphasized(del))
+    assert.same({ "9", "8" }, emphasized(add))
   end)
 
-  it("emphasises an edit at the very start", function()
+  it("emphasizes an edit at the very start", function()
     local del, add = unpack(parse({ "-xfoo(bar)", "+yfoo(bar)" }))
-    assert.same({ "x" }, emphasised(del))
-    assert.same({ "y" }, emphasised(add))
+    assert.same({ "x" }, emphasized(del))
+    assert.same({ "y" }, emphasized(add))
     assert.same(0, add.spans[1].col)
   end)
 
-  it("emphasises an edit at the very end", function()
+  it("emphasizes an edit at the very end", function()
     local _, add = unpack(parse({ "-# no trailing newline", "+# no trailing newline CHANGED" }))
-    assert.same({ " CHANGED" }, emphasised(add))
+    assert.same({ " CHANGED" }, emphasized(add))
     assert.same(#add.text, add.spans[1].end_col)
   end)
 
   -- A re-indentation is otherwise the one change a reviewer cannot see at all.
-  it("emphasises a whitespace-only change", function()
+  it("emphasizes a whitespace-only change", function()
     local _, add = unpack(parse({ "-  return x", "+    return x" }))
-    assert.same({ "  " }, emphasised(add))
+    assert.same({ "  " }, emphasized(add))
   end)
 end)
 
 describe("which lines pair", function()
   -- The i-th deletion of a run with the i-th addition of the run that follows it. Pairing
-  -- them the other way round would emphasise the identifier as well as the number, so this
+  -- them the other way round would emphasize the identifier as well as the number, so this
   -- fails rather than merely looking different if the rule changes.
   local lines = parse({
     "-local alpha = 1",
@@ -154,10 +154,10 @@ describe("which lines pair", function()
 
   it("pairs the i-th deletion with the i-th addition", function()
     assert.same({ { "1" }, { "2" }, { "3" }, { "4" } }, {
-      emphasised(lines[1]),
-      emphasised(lines[2]),
-      emphasised(lines[3]),
-      emphasised(lines[4]),
+      emphasized(lines[1]),
+      emphasized(lines[2]),
+      emphasized(lines[3]),
+      emphasized(lines[4]),
     })
   end)
 
@@ -171,8 +171,8 @@ describe("which lines pair", function()
     -- The lone deletion above the context line has nothing to pair with; the pair below it
     -- is unaffected by it.
     assert.is_nil(after_ctx[1].spans)
-    assert.same({ "2" }, emphasised(after_ctx[3]))
-    assert.same({ "4" }, emphasised(after_ctx[4]))
+    assert.same({ "2" }, emphasized(after_ctx[3]))
+    assert.same({ "4" }, emphasized(after_ctx[4]))
   end)
 
   it("leaves the surplus of a longer addition run unpaired", function()
@@ -183,8 +183,8 @@ describe("which lines pair", function()
       "+local beta = 4",
       "+local gamma = 5",
     })
-    assert.same({ "3" }, emphasised(runs[3]))
-    assert.same({ "4" }, emphasised(runs[4]))
+    assert.same({ "3" }, emphasized(runs[3]))
+    assert.same({ "4" }, emphasized(runs[4]))
     assert.is_nil(runs[5].spans)
   end)
 
@@ -196,29 +196,29 @@ describe("which lines pair", function()
       "+local alpha = 3",
       "+local beta = 4",
     })
-    assert.same({ "1" }, emphasised(runs[1]))
-    assert.same({ "2" }, emphasised(runs[2]))
+    assert.same({ "1" }, emphasized(runs[1]))
+    assert.same({ "2" }, emphasized(runs[2]))
     assert.is_nil(runs[3].spans)
   end)
 end)
 
 describe("suppression", function()
-  -- The threshold is a judgement, recorded in `diff.lua` with the diffs it was read off.
+  -- The threshold is a judgment, recorded in `diff.lua` with the diffs it was read off.
   -- These two cases sit either side of it by construction, so moving it in either
   -- direction reds one of them.
-  it("emphasises a pair that still shares most of its characters", function()
+  it("emphasizes a pair that still shares most of its characters", function()
     local del, add = pair_at(9, 11)
-    assert.same({ ("b"):rep(11) }, emphasised(del))
-    assert.same({ ("c"):rep(11) }, emphasised(add))
+    assert.same({ ("b"):rep(11) }, emphasized(del))
+    assert.same({ ("c"):rep(11) }, emphasized(add))
   end)
 
-  it("leaves a pair sharing almost nothing plainly coloured", function()
+  it("leaves a pair sharing almost nothing plainly colored", function()
     local del, add = pair_at(7, 13)
     assert.is_nil(del.spans)
     assert.is_nil(add.spans)
   end)
 
-  it("leaves a line replaced wholesale plainly coloured", function()
+  it("leaves a line replaced wholesale plainly colored", function()
     local del, add = unpack(parse({
       "-  pcall(vim.api.nvim_win_set_cursor, V.win, { 1, 0 })",
       "+  place(1)",
@@ -228,7 +228,7 @@ describe("suppression", function()
   end)
 
   -- An empty line has nothing to point at, and everything on the other side is new.
-  it("emphasises nothing opposite an empty line", function()
+  it("emphasizes nothing opposite an empty line", function()
     local del, add = unpack(parse({ "-", "+local x = 1" }))
     assert.is_nil(del.spans)
     assert.is_nil(add.spans)
@@ -236,7 +236,7 @@ describe("suppression", function()
 end)
 
 describe("characters, not bytes", function()
-  -- é and è share their first byte, as do 🎉 and 🎈. A diff taken over bytes emphasises
+  -- é and è share their first byte, as do 🎉 and 🎈. A diff taken over bytes emphasizes
   -- the trailing byte alone -- a boundary inside a character, which is a rendering error
   -- rather than a cosmetic one -- and every assertion here is one such a diff fails.
   local del, add = unpack(parse({
@@ -244,12 +244,12 @@ describe("characters, not bytes", function()
     '+local name = "new"  -- cafè 日本語 🎈',
   }))
 
-  it("emphasises whole characters on the deletion", function()
-    assert.same({ "old", "é", "🎉" }, emphasised(del))
+  it("emphasizes whole characters on the deletion", function()
+    assert.same({ "old", "é", "🎉" }, emphasized(del))
   end)
 
-  it("emphasises whole characters on the addition", function()
-    assert.same({ "new", "è", "🎈" }, emphasised(add))
+  it("emphasizes whole characters on the addition", function()
+    assert.same({ "new", "è", "🎈" }, emphasized(add))
   end)
 
   it("never puts a boundary inside a multibyte character", function()
@@ -264,9 +264,9 @@ describe("characters, not bytes", function()
     end
   end)
 
-  it("emphasises an edit adjacent to multibyte text", function()
+  it("emphasizes an edit adjacent to multibyte text", function()
     local _, add_ = unpack(parse({ "-日本語のテキスト", "+日本語のテキスト!" }))
-    assert.same({ "!" }, emphasised(add_))
+    assert.same({ "!" }, emphasized(add_))
     -- Nine characters in, which is 24 bytes in: a byte-wise offset would land inside 卜.
     assert.same(24, add_.spans[1].col)
   end)
@@ -319,9 +319,9 @@ describe("the fixture's own multibyte line", function()
     add = ln.side == "add" and ln or add
   end
 
-  it("emphasises whole characters as git delivered them", function()
-    assert.same({ "é", "🎉" }, emphasised(assert(del)))
-    assert.same({ "CHANGED ", "è", "🎈" }, emphasised(assert(add)))
+  it("emphasizes whole characters as git delivered them", function()
+    assert.same({ "é", "🎉" }, emphasized(assert(del)))
+    assert.same({ "CHANGED ", "è", "🎈" }, emphasized(assert(add)))
   end)
 
   it("lands every boundary on a character", function()
@@ -469,15 +469,15 @@ describe("both panes", function()
 
   -- `src/nonl.md`, not `src/main.lua`: main's edit is a pure insertion, so its deletion
   -- carries no spans at all and this case would be asserting the after pane twice. nonl's
-  -- pair is the fixture's only one that emphasises something on both sides.
+  -- pair is the fixture's only one that emphasizes something on both sides.
   it("shows the emphasis in both panes on the same row", function()
     local row = paired_row("src/nonl.md")
-    assert.is_true(#span_marks(after, row) > 0, "nothing emphasised in the after pane")
-    assert.is_true(#span_marks(before, row) > 0, "nothing emphasised in the before pane")
+    assert.is_true(#span_marks(after, row) > 0, "nothing emphasized in the after pane")
+    assert.is_true(#span_marks(before, row) > 0, "nothing emphasized in the before pane")
   end)
 
   -- One pairing rule, so a layout toggle cannot change which characters are called out.
-  it("emphasises the same characters as the unified layout", function()
+  it("emphasizes the same characters as the unified layout", function()
     ---@param rendered CRRender
     ---@param into table
     local function collect_by_key(rendered, into)
@@ -486,7 +486,7 @@ describe("both panes", function()
           local file = files[a.file]
           local ln = file.hunks[a.hunk].lines[a.line]
           if ln.spans then
-            into[render.line_key(file.path, ln)] = emphasised(ln)
+            into[render.line_key(file.path, ln)] = emphasized(ln)
           end
         end
       end
@@ -513,12 +513,12 @@ describe("the highlight groups", function()
     end)
   end
 
-  it("takes its background from the group colourschemes tune for changed text", function()
+  it("takes its background from the group colorschemes tune for changed text", function()
     local want = vim.api.nvim_get_hl(0, { name = "DiffText", link = false })
     assert.same(want.bg, vim.api.nvim_get_hl(0, { name = "CodeReviewAddSpan", link = false }).bg)
   end)
 
-  it("follows a colourscheme change mid-session", function()
+  it("follows a colorscheme change mid-session", function()
     local before_bg = vim.api.nvim_get_hl(0, { name = "CodeReviewAddSpan", link = false }).bg
     vim.cmd("colorscheme vim")
     local now = vim.api.nvim_get_hl(0, { name = "CodeReviewAddSpan", link = false })
@@ -603,7 +603,7 @@ describe("changing scope", function()
     view.set_scope("staged")
     local V = view.current()
     -- The staged scope is a pure addition, so there is nothing to pair and nothing to
-    -- emphasise -- which is only meaningful because the branch scope did emphasise things.
+    -- emphasize -- which is only meaningful because the branch scope did emphasize things.
     assert.same(
       { "src/routes.lua" },
       vim.tbl_map(function(f)
@@ -621,7 +621,7 @@ describe("what an annotation records", function()
   -- ADR-0002 read one step further: an entry does not record how it was captured, and it
   -- must not record how it was drawn either.
 
-  ---The row holding a file's replacement line -- the emphasised one, not the context row
+  ---The row holding a file's replacement line -- the emphasized one, not the context row
   ---above it, or this would be capturing on a line the feature never touches.
   ---@param V CRView
   ---@return integer
@@ -642,7 +642,7 @@ describe("what an annotation records", function()
     return entry, payload.render(queue.all(), V.root, { types = config.get().types })
   end
 
-  it("captured on a line that is emphasised", function()
+  it("captured on a line that is emphasized", function()
     local V = view.current()
     assert.is_true(#span_marks(V.render, replacement_row(V)) > 0)
   end)

--- a/tests/codereview/split_spec.lua
+++ b/tests/codereview/split_spec.lua
@@ -693,7 +693,7 @@ end)
 
 describe("holding the panes together", function()
   -- `scrollopt` is global. A plugin that set it would reach outside its own windows, so
-  -- what is accepted instead is its default: vertical synchronisation only.
+  -- what is accepted instead is its default: vertical synchronization only.
   it("does not modify the global scroll-options setting", function()
     assert.same(scrollopt_before, vim.go.scrollopt)
   end)
@@ -914,7 +914,7 @@ describe("annotating from either pane", function()
 
   it("binds the diff's keys in the before pane too", function()
     -- Both sides through `vim.keycode`: the API reports a control key in its own notation
-    -- (`<C-P>`, capitalised) rather than the one it was bound with, so comparing the
+    -- (`<C-P>`, capitalized) rather than the one it was bound with, so comparing the
     -- strings as written silently never matches.
     local lhs = {}
     for _, m in ipairs(vim.api.nvim_buf_get_keymap(V.before_buf, "n")) do
@@ -1224,7 +1224,7 @@ describe("the sticky header in the split layout", function()
   -- Both bars have to hold a 40-character revision and a path at once, and a third of a
   -- 120-column terminal is not enough for that -- the pane would truncate its way to a pass
   -- or a fail for reasons that have nothing to do with which side it names. Widening the
-  -- terminal hands every new column to the last window, so the panes are levelled after it,
+  -- terminal hands every new column to the last window, so the panes are leveled after it,
   -- and the repaint is this test's to drive: `WinResized` never lands in a headless spec.
   vim.o.columns = 200
   vim.cmd("wincmd =")
@@ -1271,13 +1271,13 @@ describe("the sticky header in the split layout", function()
   -- place either can be said of *it*: the revision it exists to name is accented, the
   -- separator in front of that is as quiet as the summary's, and the pre-image path is left
   -- in the bar's own group -- the brightest thing on this bar, exactly as on the other one.
-  it("colours the before pane's bar as it colours the after pane's", function()
+  it("colors the before pane's bar as it colors the after pane's", function()
     assert.same("CodeReviewBarRev", h.winbar_group(V.before_win, V.scope.before))
     assert.same("CodeReviewBarSep", h.winbar_group(V.before_win, "·"))
     assert.is_nil(h.winbar_group(V.before_win, "src/oldname.lua"))
   end)
 
-  -- The note count carries the colour notes carry everywhere else, which is the one thing on
+  -- The note count carries the color notes carry everywhere else, which is the one thing on
   -- this bar `render_spec` cannot reach: nothing is queued while its own summary is measured.
   it("draws the queue's note count in the group the notes themselves carry", function()
     assert.same("CodeReviewNoteCount", h.winbar_group(V.win, ("%s1"):format(config.get().icons.annotated)))
@@ -1343,7 +1343,7 @@ describe("the sticky header on a muted pane", function()
   local stat = child({ FOCUS = "after", MUTED = "1", CELL = "stat" })
 
   -- Every reading is of a cell inside the path, so a bar that had stopped naming the file
-  -- would fail here before any colour was compared.
+  -- would fail here before any color was compared.
   it("really read the file segment in all three arrangements", function()
     for _, reading in ipairs({ muted, bright, unmuted_nc }) do
       assert.same("cell s", reading:sub(1, #"cell s"), reading)
@@ -1354,7 +1354,7 @@ describe("the sticky header on a muted pane", function()
     assert.same("cell s fg=eeee00 bg=006600", bright)
   end)
 
-  -- `WinBar`'s colours blended halfway to `Normal`'s background -- the muted namespace's
+  -- `WinBar`'s colors blended halfway to `Normal`'s background -- the muted namespace's
   -- variant, not the group itself.
   it("mutes the file segment with the pane it names the file for", function()
     assert.same("cell s fg=770000 bg=002200", muted)
@@ -1377,6 +1377,6 @@ describe("the sticky header on a muted pane", function()
   -- a `%#Group#` naming a foreground leaves it showing through.
   it("draws the added count in the plugin's own group rather than the bar's foreground", function()
     assert.same("cell + fg=00cc66 bg=006600", stat)
-    assert.are_not.same(bright:sub(#"cell + " + 1), stat:sub(#"cell + " + 1), "the same colour as the path")
+    assert.are_not.same(bright:sub(#"cell + " + 1), stat:sub(#"cell + " + 1), "the same color as the path")
   end)
 end)

--- a/tests/codereview/staleness_spec.lua
+++ b/tests/codereview/staleness_spec.lua
@@ -67,7 +67,7 @@ describe("a whole-file buffer annotation", function()
     assert.is_true(entry.stale)
   end)
 
-  it("stops travelling as a reference", function()
+  it("stops traveling as a reference", function()
     assert.is_nil(render():find("@src/fresh.lua", 1, true), render())
   end)
 end)

--- a/tests/codereview/syntax_spec.lua
+++ b/tests/codereview/syntax_spec.lua
@@ -80,7 +80,7 @@ describe("replaying captures onto the diff", function()
   -- underneath it. What must never appear either way is a name no colorscheme can reach.
   local FADED = "CodeReviewFaded."
 
-  it("uses @-prefixed treesitter groups a colorscheme can colour", function()
+  it("uses @-prefixed treesitter groups a colorscheme can color", function()
     for _, m in ipairs(marks) do
       local group = m[4].hl_group
       local bare = group:sub(1, #FADED) == FADED and group:sub(#FADED + 1) or group

--- a/tests/codereview/touched_spec.lua
+++ b/tests/codereview/touched_spec.lua
@@ -7,7 +7,7 @@
 --
 -- Everything is asserted through what a reviewer can see -- the winbar, the text of a
 -- virtual line, the highlight *group* it is drawn in -- or through what the reconciliation
--- returns. Never a colour, and never the JSON behind the archive.
+-- returns. Never a color, and never the JSON behind the archive.
 local h = require("tests.helpers")
 
 h.ui(110, 40)
@@ -248,11 +248,11 @@ describe("an archived entry on the diff", function()
     local groups = h.virt_groups(V)
     assert.is_true(groups.CodeReviewTouched or false, vim.inspect(vim.tbl_keys(groups)))
     assert.is_true(groups.CodeReviewUntouched or false, vim.inspect(vim.tbl_keys(groups)))
-    -- Never the group staleness draws in: one colour for both is the merge the rule refuses.
+    -- Never the group staleness draws in: one color for both is the merge the rule refuses.
     assert.is_nil(groups.CodeReviewStale, vim.inspect(vim.tbl_keys(groups)))
   end)
 
-  it("links those groups into the colorscheme rather than defining colours", function()
+  it("links those groups into the colorscheme rather than defining colors", function()
     for _, group in ipairs({ "CodeReviewTouched", "CodeReviewUntouched" }) do
       local def = vim.api.nvim_get_hl(0, { name = group })
       assert.is_truthy(def.link, ("%s is not a link: %s"):format(group, vim.inspect(def)))
@@ -264,8 +264,8 @@ describe("an archived entry on the diff", function()
     assert.is_truthy(h.winbar(V.win):find(tally(1), 1, true), h.winbar(V.win))
   end)
 
-  -- The same group the entries themselves are drawn in, two rows below. One colour, one
-  -- meaning: the tally is the count of what is drawn in that colour on the diff.
+  -- The same group the entries themselves are drawn in, two rows below. One color, one
+  -- meaning: the tally is the count of what is drawn in that color on the diff.
   it("draws the tally in the group those entries carry on the diff", function()
     assert.same("CodeReviewUntouched", h.winbar_group(V.win, tally(1)))
   end)

--- a/tests/codereview/trim_float_spec.lua
+++ b/tests/codereview/trim_float_spec.lua
@@ -434,7 +434,7 @@ end)
 -- A revspec rather than one of the working-tree scopes: the fixture is a clean checkout, so
 -- `staged`, `unstaged` and `worktree` have nothing in them to open a review on -- and a
 -- revspec is the scope a reviewer reaches for when they already know which commit they
--- want, which is the neighbouring surface this key exists beside.
+-- want, which is the neighboring surface this key exists beside.
 describe("gc outside a branch review", function()
   codereview.open("HEAD~1")
   local review = assert(view.current(), "no review view opened")

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -73,7 +73,7 @@ end
 ---
 ---By subject rather than by index: which row of the listing a commit sits on moves the
 ---moment anything below adds one, and every claim here is about a commit a reviewer would
----recognise by what it says.
+---recognize by what it says.
 ---@param subject string
 ---@return { sha: string, subject: string } commit, integer kept
 local function commit_named(subject)

--- a/tests/codereview/types_spec.lua
+++ b/tests/codereview/types_spec.lua
@@ -9,9 +9,9 @@ local h = require("tests.helpers")
 local types = require("codereview.types")
 local config = require("codereview.config")
 
-describe("normalising a type list", function()
+describe("normalizing a type list", function()
   it("leaves a fully specified type alone", function()
-    local out = types.normalise({
+    local out = types.normalize({
       { name = "bug", key = "b", icon = "!", hl = "MyBug", label = "Blockers", directive = "fix" },
     })
     assert.same({
@@ -20,48 +20,48 @@ describe("normalising a type list", function()
   end)
 
   it("accepts the shipped defaults unchanged", function()
-    assert.same(types.defaults, types.normalise(types.defaults))
+    assert.same(types.defaults, types.normalize(types.defaults))
   end)
 
   it("does not mutate the list it was given", function()
     local input = { { name = "question", key = "q" } }
-    types.normalise(input)
+    types.normalize(input)
     assert.same({ { name = "question", key = "q" } }, input)
   end)
 
   it("fills label, icon and hl from the name alone", function()
-    local t = types.normalise({ { name = "question", key = "q" } })[1]
+    local t = types.normalize({ { name = "question", key = "q" } })[1]
     assert.same("Questions", t.label)
     assert.same("CodeReviewQuestion", t.hl)
     assert.same("●", t.icon)
   end)
 
   it("takes the default icon from the configured icons", function()
-    local t = types.normalise({ { name = "question", key = "q" } }, { icon = "◆" })[1]
+    local t = types.normalize({ { name = "question", key = "q" } }, { icon = "◆" })[1]
     assert.same("◆", t.icon)
   end)
 
   it("title-cases a multi-word name for the label and the group", function()
-    local t = types.normalise({ { name = "needs-info", key = "N" } })[1]
+    local t = types.normalize({ { name = "needs-info", key = "N" } })[1]
     assert.same("Needs Infos", t.label)
     assert.same("CodeReviewNeedsInfo", t.hl)
   end)
 
-  -- Naive pluralisation, minus the worst case. Anything English declines irregularly
+  -- Naive pluralization, minus the worst case. Anything English declines irregularly
   -- wants an explicit `label`, which is why one is easy to give.
   it("does not double an s on a name that is already plural", function()
-    assert.same("Notes", types.normalise({ { name = "notes", key = "N" } })[1].label)
+    assert.same("Notes", types.normalize({ { name = "notes", key = "N" } })[1].label)
   end)
 
   it("leaves directive unset when it was not given", function()
-    assert.is_nil(types.normalise({ { name = "question", key = "q" } })[1].directive)
+    assert.is_nil(types.normalize({ { name = "question", key = "q" } })[1].directive)
   end)
 end)
 
 describe("rejecting a type list", function()
   local function err(list)
-    local ok, msg = pcall(types.normalise, list)
-    assert.is_false(ok, "expected normalise to reject this list")
+    local ok, msg = pcall(types.normalize, list)
+    assert.is_false(ok, "expected normalize to reject this list")
     return msg
   end
 

--- a/tests/codereview/winbar_child.lua
+++ b/tests/codereview/winbar_child.lua
@@ -10,18 +10,18 @@
 --
 -- `WinBarNC` is what a non-current window's bar draws in whether or not anything is muted,
 -- which is exactly why the control reading matters: with muting off the same cell must come
--- back at `WinBarNC`'s own colour. Muted and unmuted differing is the claim; a bar that
--- ignored the namespace would return the second colour in both runs.
+-- back at `WinBarNC`'s own color. Muted and unmuted differing is the claim; a bar that
+-- ignored the namespace would return the second color in both runs.
 --
 -- The three constraints are `muted_child.lua`'s, for the reasons measured there: exactly one
 -- `nvim__inspect_cell` call per process, because only the first is honest; an 80x24 grid,
--- because that is what a headless Neovim keeps whatever `columns` says; and colours whose
+-- because that is what a headless Neovim keeps whatever `columns` says; and colors whose
 -- channels are all even, so a half-strength blend toward a black background has no rounding
 -- in it.
 --
 -- `CELL` chooses which cell that is: the path, which carries no group of the plugin's own
 -- and is the reading the muting is proven with, or the file's added count, which carries
--- one and is the reading the *colour* is proven with. Neither can stand in for the other:
+-- one and is the reading the *color* is proven with. Neither can stand in for the other:
 -- the path says the bar recedes with its pane, and the count says a group of the plugin's
 -- reaches the screen at all.
 --
@@ -37,11 +37,11 @@ local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
 vim.cmd("cd " .. vim.fn.fnameescape(fixture))
 
 vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
--- The two groups a winbar can draw in, given distinct colours so the reading says which one
+-- The two groups a winbar can draw in, given distinct colors so the reading says which one
 -- it came from as well as how bright it was.
 vim.api.nvim_set_hl(0, "WinBar", { fg = 0xeeee00, bg = 0x006600 })
 vim.api.nvim_set_hl(0, "WinBarNC", { fg = 0xee0000, bg = 0x004400 })
--- What `CodeReviewStatAdd` links into, given a colour of its own that is neither of the
+-- What `CodeReviewStatAdd` links into, given a color of its own that is neither of the
 -- two above -- so a cell drawn in it cannot be confused with a cell that took the bar's own
 -- foreground. A `%#Group#` sets the foreground and leaves the bar's background showing
 -- through, which is why only the foreground here differs from `WinBar`'s.

--- a/tests/fixtures/mkfixture.sh
+++ b/tests/fixtures/mkfixture.sh
@@ -30,7 +30,7 @@ printf 'local name = "old"\nlocal second = 2\nlocal third = 3\n' > src/oldname.l
 # The fixture's only non-ASCII content, and it is deliberate. Everything else here is
 # ASCII, and an ASCII line CANNOT fail the byte-splitting bug -- a span computed over bytes
 # passes every assertion an ASCII fixture can make. é/è share their leading byte, as do
-# 🎉/🎈, so a byte-wise diff emphasises a trailing byte alone: a boundary inside a
+# 🎉/🎈, so a byte-wise diff emphasizes a trailing byte alone: a boundary inside a
 # character, which is a rendering error. It rides on the line this file already changes, so
 # no count anywhere moves and nothing else has to know.
 printf '# no trailing newline café 🎉' > src/nonl.md

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -168,12 +168,12 @@ end
 ---reported as an absence rather than by name because that name is `WinBar` in the pane with
 ---focus and `WinBarNC` in the other one. A case naming it answers differently depending on
 ---where the cursor was, which is a case that reds for a reason that has nothing to do with
----colour. What is read is the group stacked *on top of* the bar's own, which is exactly the
+---color. What is read is the group stacked *on top of* the bar's own, which is exactly the
 ---question every caller is asking.
 ---
 ---Read through the same parser `M.winbar` uses, so a marker that landed one segment out is
 ---visible here. What this cannot say is that the cell on the screen took that group's
----colour. Only a painted cell can, and `split_spec` reads two.
+---color. Only a painted cell can, and `split_spec` reads two.
 ---@param win integer
 ---@param needle string
 ---@return string|nil
@@ -209,7 +209,7 @@ end
 
 ---The highlight groups the virtual lines on a view's diff are drawn in, as a set.
 ---
----What tells a queued annotation from an archived one without reading a colour: an entry
+---What tells a queued annotation from an archived one without reading a color: an entry
 ---drawn out of the queue carries its annotation type's group, and one drawn out of the
 ---archive carries the archive's own.
 ---@param view CRView


### PR DESCRIPTION
The README moved to American spelling for ASD-STE100 rule 1.14, which left it
disagreeing with the rest of the repo. This restructures the README for
first-time readers and closes the spelling gap everywhere else.

No issue behind it — it started as a README readability pass and grew a
second, mechanical half.

## The README

The old order put ~530 lines of feature prose between the quick start and the
keymap tables. A first-time reader met the counterpart-row blend strengths and
the 60% span threshold before ever seeing the key list.

New order: `Install` → `Your first review` (six numbered steps) → `Keymaps` →
`What you can review` → `Annotations` → `The queue and the batch` →
`Reading the diff` → `Configuration` → `Adapters` → `Persistence`.

1031 lines → 823, with 432 lines of reasoning moved to a new
`docs/rationale.md` rather than deleted. `:help codereview` stays the full
reference, which is why the new file is `rationale.md` and not `reference.md`.

The composer keys (`<C-s>`, `<C-t>`, `@`, `<C-d>`, `q`/`<Esc>`) are documented
in the README for the first time. They were in `:help` but nowhere here, so
step 3 of any walkthrough was unanswerable.

## The spelling sweep

413 substitutions across 53 files. Four internal identifiers move with the
prose, so that a comment never spells a name differently from the name itself:

| Before | After |
| --- | --- |
| `types.normalise` | `types.normalize` |
| `M.recolour` | `M.recolor` |
| `recolour_twins` | `recolor_twins` |
| `enrol` | `enroll` |

None appears in `:help`, so no documented API changes. The `emphasised()`
helper in `spans_spec.lua` moves too.

Words identical in both dialects are left alone: `realistic`,
`characteristics`, `emphasis`, `analysis`, `central`, `cancellation`,
`enrolled`. The `-ise` patterns are suffix-anchored for exactly that reason —
an unanchored `realis` would have produced `realiztic` in `git.lua`.
`doc/tags` needs no regeneration, and the vimdoc's column alignment is
unaffected.

`make all` is green: 1546 passing, 0 failed, 0 errors across 36 spec files.
The `Error in command line: the agent pane is gone` line in the log is a
pre-existing send-failure fixture, present on `master` too.
