### PR TITLE
test(fixtures): add a dependent commit to the history fixture

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -102,14 +102,17 @@ interchangeable, and the assertions know which one they are looking at.
   `packages/shared/src` are single-child chains that must compact, `apps` has two children
   so it must not. Used by `panel_spec`, `focus_spec` and `queue_jump_panel_spec`.
 - **`mkcommits.sh`** — repo whose *history* is the point, and the smallest of the four: no
-  file statuses, no binary, no rename. A branch of four commits over the default branch,
-  one of them a merge that brings in a fifth commit from a side branch cut off master's
+  file statuses, no binary, no rename. A branch of five commits over the default branch,
+  one of them a merge that brings in a sixth commit from a side branch cut off master's
   tip. Used by `trim_spec` and `trim_float_spec`. Two rules need exactly that shape and can be seen in
   nothing else: a listing that dropped `--first-parent` draws the commit the merge brought
   in as a row of its own, and the merge base is a different commit from the oldest listed
-  commit's parent, which is what resolving the oldest row has to notice. Its commits are
-  dated days apart, as offsets back from the moment the script runs, so a relative date on
-  a row is a fact a spec can check and never goes stale. `trim_spec` builds a **second copy**
+  commit's parent, which is what resolving the oldest row has to notice. One commit on the
+  branch rewrites the line an earlier one introduced, in the file that earlier one added,
+  so it is the only commit here that cannot leave a review on its own — without it a
+  refusal has nothing to refuse, which is "a filter test needs a fixture only that filter
+  can reject". Its commits are dated days apart, as offsets back from the moment the script
+  runs, so a relative date on a row is a fact a spec can check and never goes stale. `trim_spec` builds a **second copy**
   for the trim a restart brings back, and cuts a `second` branch at `feature`'s tip inside
   it: two branches over one history is what "each branch keeps its own trim" needs, and
   neither branch the script builds can offer it — `lexer` has one commit of its own, so

--- a/tests/codereview/trim_float_spec.lua
+++ b/tests/codereview/trim_float_spec.lua
@@ -10,7 +10,7 @@
 -- is here is the surface: the row a reviewer moves to, the row the float marks, and the key
 -- they press.
 --
--- The fixture is `mkcommits`, whose history is the whole point of it: a branch of four
+-- The fixture is `mkcommits`, whose history is the whole point of it: a branch of five
 -- commits, one of them a merge, over a merge base that is not the oldest commit's parent.
 -- Both rules this file pins are invisible without it -- see the script's own header.
 local h = require("tests.helpers")
@@ -128,12 +128,12 @@ end
 -- corresponding rule observable at all. Without the guards, a listing that dropped
 -- `--first-parent` and a listing that kept it are the same listing.
 describe("the history this spec reads", function()
-  it("puts four commits on the branch's own line of work", function()
-    assert.same(4, #first_parent, vim.inspect(subjects(first_parent)))
+  it("puts five commits on the branch's own line of work", function()
+    assert.same(5, #first_parent, vim.inspect(subjects(first_parent)))
   end)
 
   it("holds one more commit than that in the same range", function()
-    assert.same(5, #everything, vim.inspect(subjects(everything)))
+    assert.same(6, #everything, vim.inspect(subjects(everything)))
   end)
 
   it("brought that one in through the merge, so first-parent listing can be seen at all", function()

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -119,8 +119,8 @@ end
 --- The fixture the resolution rules lean on --------------------------------------
 
 describe("the history this spec reads", function()
-  it("puts four commits on the branch's own line of work", function()
-    assert.same(4, #commits, vim.inspect(commits))
+  it("puts five commits on the branch's own line of work", function()
+    assert.same(5, #commits, vim.inspect(commits))
   end)
 
   -- The reason the fixture's side branch is cut from master's tip: resolving the oldest row
@@ -624,7 +624,7 @@ describe("the other branch over the same commits", function()
   end)
 
   it("counts its own commits on the winbar", function()
-    assert.is_truthy(h.winbar(W.win):find("last 3", 1, true), h.winbar(W.win))
+    assert.is_truthy(h.winbar(W.win):find("last 4", 1, true), h.winbar(W.win))
   end)
 end)
 

--- a/tests/fixtures/mkcommits.sh
+++ b/tests/fixtures/mkcommits.sh
@@ -13,18 +13,29 @@
 #   c2  test: cover the config reader     feature
 #   s1  fix: tighten the lexer            lexer, off B1 -- arrives through the merge
 #   M   Merge branch 'lexer'              feature
-#   c3  docs: write the readme            feature
+#   c3  test: assert the host as well     feature, and it depends on c2
+#   c4  docs: write the readme            feature
 #
-# `--first-parent B1..HEAD` is c3, M, c2, c1. Two rules that are otherwise untestable ride
-# on that:
+# `--first-parent B1..HEAD` is c4, c3, M, c2, c1. Two rules that are otherwise untestable
+# ride on that:
 #
 #   * s1 is in `B1..HEAD` and NOT on the first-parent line, so a listing that forgot
-#     `--first-parent` lists a fifth row. Without a merge the two listings are one listing
+#     `--first-parent` lists a sixth row. Without a merge the two listings are one listing
 #     and nothing can tell them apart.
 #   * The merge base is B1, while the oldest listed commit's parent is B0. The two are
 #     different commits, which is what a trim that resolves the oldest row has to notice.
 #     The lexer branch is cut from master's tip rather than from the branch point for this
 #     reason alone: it is what pulls the merge base forward past B0.
+#
+# c3 is the one commit here that depends on another: it rewrites the line c2 introduced,
+# in the file c2 added. Every other commit on the branch touches a file no other commit
+# touches, so any one of them can leave the review on its own. c3 cannot, while c2 stays:
+# a review that takes c3 out has to apply c3 to a tree that does not hold the file c2
+# added, and that merge conflicts. A refusal that has no such commit to refuse passes
+# while it measures nothing -- the recorded trap that a filter test needs a fixture only
+# that filter can reject. c2 and c3 are on opposite sides of the merge on purpose: they
+# are not next to each other, so taking both out applies the two of them in turn instead
+# of reading a tree that some commit already has.
 #
 # The commits are dated apart from each other, so the relative date on a row is a fact a
 # reader can check rather than "0 seconds ago" five times over. Each date is an offset back
@@ -86,11 +97,17 @@ printf 'local year = 2025\nlocal strict = true\n' > src/lexer.lua
 git add -A
 commit $((2 * DAY)) "fix: tighten the lexer"
 
-# --- the merge, and one commit after it ---
+# --- the merge, and the two commits after it ---
 git checkout -q feature
 MERGED="$((NOW - 20 * HOUR)) +0000"
 GIT_AUTHOR_DATE="$MERGED" GIT_COMMITTER_DATE="$MERGED" \
   git merge -q --no-ff -m "Merge branch 'lexer' into feature" lexer
+
+# The assert line is the one c2 wrote, in the file c2 added: this is the commit that cannot
+# leave the review while c2 stays in it.
+printf 'local cfg = require("config")\nassert(cfg.port and cfg.host)\n' > src/config_spec.lua
+git add -A
+commit $((10 * HOUR)) "test: assert the host as well"
 
 printf '# The project\n' > README.md
 git add -A
@@ -98,7 +115,7 @@ commit $((1 * HOUR)) "docs: write the readme"
 
 BASE="$(git merge-base master HEAD)"
 echo "history fixture: $R"
-echo "  on the first-parent line: $(git log --first-parent --format=%h "$BASE..HEAD" | wc -l | tr -d ' ') (expect 4)"
-echo "  in the range at all:      $(git log --format=%h "$BASE..HEAD" | wc -l | tr -d ' ') (expect 5)"
+echo "  on the first-parent line: $(git log --first-parent --format=%h "$BASE..HEAD" | wc -l | tr -d ' ') (expect 5)"
+echo "  in the range at all:      $(git log --format=%h "$BASE..HEAD" | wc -l | tr -d ' ') (expect 6)"
 echo "  merge base:               $(git rev-parse --short "$BASE") (chore: bump the year)"
 echo "  oldest listed commit:     $(git log --first-parent --format=%h "$BASE..HEAD" | tail -1)"


### PR DESCRIPTION
The history fixture the commit-list specs read cannot produce a conflicting skip: every
commit on its branch touches a file no other commit touches, so no commit depends on
another and nothing in it can ever be refused. A refusal spec written against it would
pass while asserting nothing — the recorded trap that a filter test needs a fixture only
that filter can reject.

## What the fixture gains

One commit, `test: assert the host as well`, between the merge and `docs: write the
readme`. It rewrites the `assert` line that `test: cover the config reader` introduced, in
the file that commit added, so applying it to a tree without that file conflicts:

```
$ git merge-tree --write-tree --name-only --merge-base=<dep>^ <merge-base> <dep>
e7f37cacee9c37ae87515f6475f22bc74d1069ef
src/config_spec.lua

CONFLICT (modify/delete): src/config_spec.lua deleted in <merge-base> and modified in <dep>.
exit=1
```

Applied after the commit it depends on, the same merge is clean (exit 0), and so is every
other commit on the branch taken on its own. The dependency spans the merge on purpose:
the two commits are not adjacent, so taking both out has to apply them in turn rather than
anchoring on a commit that already exists.

## What still holds

Both rules the fixture already exists to pin:

- `fix: tighten the lexer` is in `B1..HEAD` and not on the first-parent line (6 in the
  range, 5 on the line).
- The merge base (`4ec5f08`) is a different commit from the oldest listed commit's parent
  (`abbbb8e`).

The fixture reports `on the first-parent line: 5` and `in the range at all: 6`, and its
header comment — the fixture's specification — now says why the dependent commit is there.

## What moved in the specs

Only the counts the extra commit shifts: `4 → 5` and `5 → 6` in both `describe("the
history this spec reads")` blocks, and `last 3 → last 4` for the trim `trim_child` sets on
the `second` branch. The oldest row and every relative date are unchanged, because the
commit goes above the merge.

Nothing a reviewer sees changes. This exists so the tickets after it can be tested.

Closes #149