### PR TITLE
refactor(state): keep a trim as the set of commits it takes out

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -265,13 +265,22 @@ using. That is why `git.branch_commits` takes the base and no longer resolves on
 **A stored trim is checked on every read, and dropping it is what keeps the sentence to one.**
 The two tempting shortcuts are one shortcut: memoise the branch's trim for the session, and
 latch the sentence beside it. The memo is wrong because a reviewer can rebase in another
-window with the review open — the trim then names a commit that was rewritten, and resolution
+window with the review open — the trim then holds a commit that was rewritten, and resolution
 reads it from memory without ever asking `HEAD` about it again, which is the exact failure the
 check exists to refuse. The latch is unnecessary once the failing trim is removed from the
 document as well as from the answer: the next read finds nothing to fail, so the sentence
 cannot repeat, and there is no key to invalidate when the reviewer moves to another branch.
-What it costs is a `symbolic-ref` and a document read per branch resolve, which is what
-`state.restore` already spends on every scope change.
+What it costs is a `symbolic-ref`, a document read and one `rev-list` per branch resolve — one
+process for the whole set and not one per commit, which is what keeps the check affordable on
+a trim that took a long branch's worth of commits out. `state.restore` already spends the
+document read on every scope change.
+
+**Any commit failing that check drops the whole set.** A trim is the commits taken out, and a
+rebase rewrote the reading rather than one row of it: keeping the commits that still resolve
+would leave the review narrowed by a selection the reviewer never made, and which parts of a
+rewritten history are still the same reading is a claim nothing here can make. It is also what
+keeps the sentence one sentence — a set that survives in part fails again on the next read,
+one commit at a time.
 
 **Keying progress on the pre-image fails silently rather than loudly.** The per-scope progress
 key is `name .. ":" .. identity`. Spelled with `before` it agrees with the plugin for every

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -95,30 +95,44 @@ function M.merge_base(a, b, root)
   return line({ "merge-base", a, b }, root)
 end
 
----Whether `HEAD` still descends from `commit`.
+---Whether `HEAD` still descends from every one of them.
 ---
 ---What a stored **trim** is checked with before a review reads from it. A rebase, an amend
----and a force-push all end in the same place: the commit the trim was picked off is not in
----this branch any more, and a diff against one of those is a diff nobody asked for.
+---and a force-push all end in the same place: a commit the trim took out is not in this
+---branch any more, and a review resolved from one of those is a review nobody asked for.
 ---
----One answer out of two failures, deliberately. `merge-base --is-ancestor` exits 1 when the
----commit is real and off this line of work, and 128 when the repository has nothing under
----that name at all -- which is what a `git gc` after a rebase leaves a stored trim naming.
----Both mean *not a commit this review can read from*, and the reviewer has one thing to be
----told either way. The exit code is the whole answer, so an empty stdout is a yes here and
----only `nil` is a no.
----@param commit string
+---**One process for the whole set**, because a trim holds as many commits as the reviewer
+---took out and this runs on every read. `rev-list` walks the commits it is given and
+---excludes everything `HEAD` reaches, so a count of nothing left over is the one answer that
+---means *all of them* -- and asking per commit would spend a process per row of a listing
+---the reviewer is free to take the whole of.
+---
+---One answer out of two failures, deliberately. A commit that is real and off this line of
+---work is counted, and a commit this repository has nothing under at all -- which is what a
+---`git gc` after a rebase leaves a stored trim naming -- makes `rev-list` exit non-zero
+---instead. Both mean *not commits this review can read from*, and the reviewer has one thing
+---to be told either way.
+---
+---An empty set asks nothing: a trim that takes no commit out has no commit that can fail.
+---@param commits string[]
 ---@param root string
 ---@return boolean
-function M.is_ancestor(commit, root)
-  return run({ "merge-base", "--is-ancestor", commit, "HEAD" }, { cwd = root }) ~= nil
+function M.all_ancestors(commits, root)
+  if #commits == 0 then
+    return true
+  end
+  local args = { "rev-list", "--count" }
+  vim.list_extend(args, commits)
+  vim.list_extend(args, { "--not", "HEAD" })
+  return line(args, root) == "0"
 end
 
 ---How many commits `from` is behind `HEAD` on the branch's own line of work.
 ---
----What the scope label reports as `last N`, derived rather than remembered: a reviewer who
----commits again after trimming has one more commit in their review than they picked, and a
----number stored at pick time would keep saying the old one.
+---What the scope label reports as `last N`, counted from what a **trim** leaves the review
+---reading from. Derived rather than remembered: a reviewer who commits again after trimming
+---has one more commit in their review than they picked, and a number stored at pick time
+---would keep saying the old one.
 ---
 ---`--first-parent` for the reason the listing is: a merge is one commit, and counting what
 ---arrived through it would report a number no row of the commit list adds up to.
@@ -180,6 +194,56 @@ function M.cycle(root)
     end
   end
   return names
+end
+
+---What a **trim** leaves a branch review reading from.
+---
+---A trim is the commits taken out, so the review has to read from a tree that already holds
+---every one of them and none of the commits kept. That tree is found by **anchoring on the
+---leading run**: the commits the trim takes off the *start* of the branch, from the oldest
+---up, for as far as the set matches the branch. The newest commit of that run is a real
+---commit whose own tree is exactly that, so the answer is a commit that already exists and
+---nothing is assembled.
+---
+---With nothing in the run the anchor is the merge base: a trim that takes no commit out
+---reads the branch whole. That is the *oldest row* of the commit list, and the anchor is why
+---it needs no case of its own -- on a branch with a merge in it the oldest commit's parent
+---is not the merge base, and a review reading from that parent draws a file the merge base
+---already had as one the branch added.
+---
+---The branch's commits are read back through `branch_commits`, which is the listing the
+---reviewer picked off. One rule for which commits are on the branch, for the reason there is
+---one rule for where it starts: a trim built from one listing and resolved against another
+---is a trim that can stop resolving without either side changing.
+---
+---**Nothing above the run is applied here.** A pick takes out the commits older than the row
+---it lands on, so every trim this version can store is a prefix and the run always covers
+---the whole set. A set with a commit above the run is one this version cannot read, and it
+---gives the whole branch back rather than a narrower reading than the reviewer asked for.
+---@param root string
+---@param base string The merge base: where the branch starts
+---@param skipped string[] The commits the trim takes out
+---@return string|nil before nil when the set is not one this version can read from
+local function pre_image(root, base, skipped)
+  local commits = M.branch_commits(root, base)
+  if not commits then
+    return nil
+  end
+
+  local taken = {}
+  for _, sha in ipairs(skipped) do
+    taken[sha] = true
+  end
+
+  -- Up from the oldest commit, which is the end of a listing drawn newest first.
+  local anchor, run = base, 0
+  for i = #commits, 1, -1 do
+    if not taken[commits[i].id] then
+      break
+    end
+    anchor, run = commits[i].id, run + 1
+  end
+  return run == #skipped and anchor or nil
 end
 
 ---Resolve a scope name, or any git revspec, into the refs the rest of the plugin needs.
@@ -268,21 +332,26 @@ function M.resolve_scope(spec, root)
     -- already has, and for the reason recorded for it: handing the value in would put the
     -- one scope that needs it into every caller of scope resolution, and scope resolution
     -- is exactly what has to stay one function. What comes back is already checked: the
-    -- store drops a trim `HEAD` no longer descends from and says so, so a commit this
-    -- repository cannot read from never reaches the arithmetic below.
-    local trim = require("codereview.state").trim(root)
-    local kept = trim and M.count_commits(trim, root)
+    -- store drops a set holding a commit `HEAD` no longer descends from, and says so, so a
+    -- commit this repository cannot read from never reaches the anchor below.
+    local skipped = require("codereview.state").trim(root)
+    local anchor = skipped and pre_image(root, base, skipped)
+    -- A count the repository cannot take leaves the whole branch open rather than a review
+    -- narrowed by an answer nothing could work out.
+    local kept = anchor and M.count_commits(anchor, root)
+    local before = kept and anchor or base
 
     return {
       name = "branch",
       -- Short, because the winbar is width-constrained and the summary is what a narrow
       -- pane gives up first. It is also the only thing that stops a trim from being a trap.
       label = kept and ("branch vs %s · last %d"):format(branch, kept) or ("branch vs %s"):format(branch),
-      args = { kept and trim or base },
-      -- The parent of the oldest commit still being read, so that commit is in the diff.
-      before = kept and trim or base,
-      -- Both of these follow from a trim having one end, and it is the start: the work in
-      -- the tree is on the other side of the review and no trim reaches it.
+      args = { before },
+      -- What the commits the trim took out are already in, so the ones it kept are the diff.
+      before = before,
+      -- Both of these follow from how far a trim reaches: it takes commits out, and the
+      -- post-image is the working tree, so the work in the tree is on the other side of the
+      -- review and no trim of any shape reaches it.
       after = nil,
       untracked = true,
       -- The merge base, which is what says *this branch*, and it does not move when the
@@ -559,9 +628,9 @@ end
 
 ---@class CRCommit
 ---@field sha string      Short sha, abbreviated by git to whatever this repository needs
+---@field id string       Full sha: what a **trim** that takes this commit out is stored as
 ---@field when string     How long ago it was authored, in git's own words
 ---@field subject string  The commit's first line
----@field before string   What a review **trimmed** to this commit reads from
 
 ---Every commit the branch carries, newest first.
 ---
@@ -579,9 +648,10 @@ end
 ---scope's pre-image, which is exactly what a trim narrows -- reading that would shorten the
 ---list every time a reviewer trimmed, and take the rows they need to widen it again away.
 ---
----Each commit carries what a trim starting at it reads from: its own parent, so the commit
----is in the diff -- except the oldest, which reads from the base. On a branch with merges
----those are different commits, and only the base means *all of it*.
+---Each commit carries both spellings of its name. The abbreviation is what a row is read
+---by; the full sha is what a **trim** taking that commit out is stored as, because git
+---abbreviates to whatever the repository needs at the moment it is asked, a repository
+---grows, and a trim outlives the length it was picked at.
 ---@param root string
 ---@param base string Where the branch starts: the scope's identity
 ---@return CRCommit[]|nil commits, string|nil err
@@ -593,7 +663,7 @@ function M.branch_commits(root, base)
   local out, err = run({
     "log",
     "--first-parent",
-    "--format=%h%x1f%p%x1f%ar%x1f%s",
+    "--format=%h%x1f%H%x1f%ar%x1f%s",
     base .. "..HEAD",
     -- A long branch's log is closer to a diff than to a metadata query.
   }, { cwd = root, timeout = DIFF_TIMEOUT_MS })
@@ -603,23 +673,10 @@ function M.branch_commits(root, base)
 
   local commits = {}
   for _, entry in ipairs(vim.split(out, "\n", { trimempty = true })) do
-    local sha, parents, when, subject = entry:match("^(%S+)\31(.-)\31(.-)\31(.*)$")
+    local sha, id, when, subject = entry:match("^(%S+)\31(%S+)\31(.-)\31(.*)$")
     if sha then
-      commits[#commits + 1] = {
-        sha = sha,
-        -- The *first* parent, which is the one the listing walks. A merge names two, and
-        -- the second one is the branch that arrived rather than the branch being read.
-        before = parents:match("^%S+") or base,
-        when = when,
-        subject = subject,
-      }
+      commits[#commits + 1] = { sha = sha, id = id, when = when, subject = subject }
     end
-  end
-  -- The oldest listed commit's parent is off the end of the range, and on a branch with
-  -- merges it is not the merge base. Picking the last row means the whole branch, so what
-  -- it reads from is the base itself.
-  if #commits > 0 then
-    commits[#commits].before = base
   end
   return commits, nil
 end

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -237,13 +237,22 @@ end
 
 --- The trim ---------------------------------------------------------------------
 
----The **trim** on a branch's review: the ref the review reads from, which is the parent of
----the oldest commit the reviewer still wants to read.
+---The **trim** on a branch's review: the commits it takes out, by full sha.
 ---
----A ref rather than a count or a commit, because that is what a scope needs: `before` has to
----be something the diff, the blob hashing and the highlighter's whole-file fetch can all
----read content out of, and none of them can read a marker. It is the *parent* of the picked
----commit, so the commit picked is in the diff and the ref needs no arithmetic at open time.
+---The commits **taken out** and never the commits kept, so a commit made after a trim is in
+---the review the moment it is made. That is the same reason the `last N` count is derived
+---rather than remembered: anything about the review recorded at pick time keeps describing
+---the branch as it was then.
+---
+---A set and not the ref the review reads from, which is what this held before it was a set.
+---What a trim leaves a review reading is worked out from the set when the **scope** is
+---resolved, because the two answer different questions -- one is what the reviewer chose,
+---the other is where that lands on this branch today -- and a second copy of the second one
+---in the document is a second thing that has to stay true through every commit, rebase and
+---checkout.
+---
+---Full shas, because an abbreviation is not an identity: git picks its length from the size
+---of the repository, and a trim outlives the size it was stored at.
 ---
 ---**Kept in the state document, keyed by branch name**, beside the reviewed marks it is a
 ---review of. A review spans days, so a reviewer who trimmed on Monday opens the same branch
@@ -275,27 +284,32 @@ local said_detached = {}
 
 ---@param root string
 ---@param branch string
----@param before string|nil nil removes it
-local function store_trim(root, branch, before)
+---@param skipped string[]|nil nil removes it
+local function store_trim(root, branch, skipped)
   local data = M.load(root)
   data.trims = data.trims or {}
-  data.trims[branch] = before
+  data.trims[branch] = skipped
   M.save(root, data)
 end
 
 ---The branch's trim, checked before it is handed back.
 ---
----**The check is the point of storing it at all.** The commit has to still be one `HEAD`
----descends from; a rebase, an amend or a force-push leaves it naming a commit that was
----rewritten, and a review that quietly resolves against one of those is worse than no trim.
----A trim that fails is dropped from the document as well as from this answer, which is what
----makes the sentence a reviewer reads a single sentence rather than one per resolve: there
----is nothing left to fail the next time.
+---**The check is the point of storing it at all.** Every commit in the set has to still be
+---one `HEAD` descends from; a rebase, an amend or a force-push leaves the set holding a
+---commit that was rewritten, and a review that quietly resolves around one of those is worse
+---than no trim.
+---
+---**Any commit failing it drops the whole set.** A rebase rewrote the reading, not one row
+---of it: keeping the commits that survived would leave the review narrowed by a selection
+---the reviewer never made, and which parts of a rewritten history are still the same reading
+---is a claim nothing here can make. A trim that fails is dropped from the document as well
+---as from this answer, which is what makes the sentence a reviewer reads a single sentence
+---rather than one per resolve: there is nothing left to fail the next time.
 ---
 ---Checked on every read rather than once per session, because the history can be rewritten
 ---while a review is open -- a reviewer rebases in another window and comes back to the diff.
 ---@param root string
----@return string|nil before nil when the whole branch is in the review
+---@return string[]|nil skipped nil when the whole branch is in the review
 function M.trim(root)
   local git = require("codereview.git")
   local branch = git.current_branch(root)
@@ -304,27 +318,27 @@ function M.trim(root)
   end
 
   local stored = (M.load(root).trims or {})[branch]
-  if not stored or git.is_ancestor(stored, root) then
+  if not stored or git.all_ancestors(stored, root) then
     return stored
   end
   store_trim(root, branch, nil)
-  info("The trim was lost — its commit is not in this branch any more, so the full branch is open")
+  info("The trim was lost — a commit it took out is not in this branch any more, so the full branch is open")
   return nil
 end
 
 ---@param root string
----@param before string|nil nil removes the trim
-function M.set_trim(root, before)
+---@param skipped string[]|nil The commits to take out; nil removes the trim
+function M.set_trim(root, skipped)
   local branch = require("codereview.git").current_branch(root)
   if not branch then
-    session_trims[root] = before
-    if before and not said_detached[root] then
+    session_trims[root] = skipped
+    if skipped and not said_detached[root] then
       said_detached[root] = true
       info("HEAD is detached — this trim is not kept for the next session")
     end
     return
   end
-  store_trim(root, branch, before)
+  store_trim(root, branch, skipped)
 end
 
 --- The archive ------------------------------------------------------------------

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -122,16 +122,24 @@ function M.open(view, root, base)
     return
   end
 
-  -- Which row the review starts at, read back out of the stored trim rather than off the
-  -- scope's pre-image. The two agree, but only the stored trim tells a review trimmed to the
-  -- oldest commit from a review that was never trimmed at all -- one review, two rows, and
-  -- the cursor belongs on a different one in each.
-  local trim = require("codereview.state").trim(root)
+  -- Which row the review starts at: the oldest commit the trim did not take out, read back
+  -- out of the stored trim rather than off the scope's pre-image. The two agree, but only
+  -- the stored trim tells a review trimmed to the oldest commit from a review that was never
+  -- trimmed at all -- one review, two rows, and the cursor belongs on a different one in
+  -- each.
+  local skipped = require("codereview.state").trim(root)
   local at = 0
-  for i, commit in ipairs(commits) do
-    if trim and commit.before == trim then
-      at = i
-      break
+  if skipped then
+    local taken = {}
+    for _, sha in ipairs(skipped) do
+      taken[sha] = true
+    end
+    -- From the oldest row up, which is the end of a listing drawn newest first.
+    for i = #commits, 1, -1 do
+      if not taken[commits[i].id] then
+        at = i
+        break
+      end
     end
   end
 
@@ -179,13 +187,25 @@ function M.open(view, root, base)
 
   ---Apply the row under the cursor and close.
   ---
+  ---What a pick applies is the commits it takes **out**: everything older than the row it
+  ---lands on, which on `ALL` is nothing at all. The commits kept are never spelled out, so a
+  ---commit made after this pick is in the review without the reviewer coming back here.
+  ---
   ---Closed first, and then the trim: applying it repaints the review and puts the cursor
   ---back in it, and a float still on screen would take that focus straight back off it.
   local function pick()
-    local row = vim.api.nvim_win_get_cursor(win)[1]
-    local commit = commits[row - 1]
+    -- The listing starts one row below `ALL`, so the cursor's row is the commit's place in
+    -- it plus one -- and row one is `ALL`, which is no commit and takes nothing out.
+    local starts_at = vim.api.nvim_win_get_cursor(win)[1] - 1
+    local skipped
+    if commits[starts_at] then
+      skipped = {}
+      for i = starts_at + 1, #commits do
+        skipped[#skipped + 1] = commits[i].id
+      end
+    end
     close()
-    view.trim_to(commit and commit.before or nil)
+    view.trim_to(skipped)
   end
 
   vim.keymap.set("n", "<CR>", pick, { buffer = buf, desc = "Review from this commit forward" })

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1653,7 +1653,8 @@ function M.commit_list()
   trim_float.open(M, v.root, v.scope.identity)
 end
 
----Read the branch review from `before` forward, or from the merge base with nothing passed.
+---Read the branch review with `skipped` taken out of it, or the whole branch with nothing
+---passed.
 ---
 ---Set and then applied through `set_scope`, which is the same entry point a **scope** change
 ---goes through, because that path already re-reads the diff, invalidates the syntax caches
@@ -1662,13 +1663,13 @@ end
 ---
 ---Nothing here re-reads the trim to draw anything: resolution does that, so the label and
 ---the diff are answering out of the same store on the same pass.
----@param before string|nil nil removes the trim
-function M.trim_to(before)
+---@param skipped string[]|nil The commits to take out; nil removes the trim
+function M.trim_to(skipped)
   local v = M.current()
   if not v then
     return
   end
-  require("codereview.state").set_trim(v.root, before)
+  require("codereview.state").set_trim(v.root, skipped)
   M.set_scope("branch")
 end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -69,7 +69,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colors one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
-| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — the picked commit in the diff, the oldest row at the merge base, the identity that does not move with the pre-image, the label — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, and where `gs` goes from it; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
+| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — every row of the listing read against git's own answer for the reading that row has always given, the oldest row at the merge base, the identity that does not move with the pre-image, the label, and the commit made afterwards that is in the review without the trim being touched — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, and where `gs` goes from it; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence beside one the branch still holds, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
 | `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the row that removes the trim, the row a trim is marked on, the cursor's opening row, the keys, `gc` from the diff and from the tree, and the two refusals that open nothing |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
@@ -613,14 +613,29 @@ so the out-of-core language path is still checked locally without ever failing C
   Eight other call sites resolve `branch` with nothing set, and each spec process gets a state
   directory and a fixture of its own, so they stay correct — but a `branch` scope behaving
   oddly should send the reader to the stored trim before anywhere else.
-- **"The full branch opened" cannot red on its own for a trim naming a commit that is gone.**
+- **"The full branch opened" cannot red on its own for a trim holding a commit that is gone.**
   The store drops such a trim and says so, but `resolve_scope` also refuses a count it cannot
-  take — the guard #140 left — so the whole branch opens whether or not anything checked the
-  trim. `trim_spec` keeps that case because it is the claim a reviewer can see; the teeth are
+  take — the guard #140 left — and a set it cannot anchor on, so the whole branch opens
+  whether or not anything checked the trim. `trim_spec` keeps that case because it is the claim a reviewer can see; the teeth are
   in the sentence beside it, which reds the moment the check goes. Measured: deleting the
   check reds the sentence alone, and deleting the check *and* the count guard reds both. Same
   shape as "the commit list's opening row can only be measured from a row that is not the
   top".
+- **A pre-image asserted by file name cannot tell the merge base from the oldest commit's
+  parent.** Both hold `src/lexer.lua`, so a review reading from either one draws the same four
+  paths — and `git diff --name-only` for the two is one list. What separates them is the
+  *status*: against the merge base the branch **modified** that file, and against the oldest
+  commit's parent it **added** it. `trim_spec`'s every-pick block compares `status<TAB>path`
+  against `git diff --name-status` for exactly this reason, and the oldest row is the row that
+  reds when the anchor is wrong. Same trap as "a filter test needs a fixture only that filter
+  can reject", arriving through the expectation instead of through the fixture.
+- **"The whole set was dropped" needs a survivor that would have narrowed the review.** A trim
+  is a set, and any commit failing the ancestry check drops all of it — but a store that kept
+  the commits that passed opens the full branch anyway whenever the survivors have a hole in
+  them, because a set that is not a prefix resolves to nothing. So the surviving commit in
+  `trim_spec`'s case is the *oldest* commit on the branch, which narrows the review on its own,
+  and the case above it sets that commit alone and asserts the review really is narrower.
+  Without that guard the block passes against per-commit survival.
 - **"The trim was not written" cannot be read off a detached `HEAD` alone.** A trim set while
   `HEAD` is detached is kept in memory and never filed, and it is also never *read* from the
   document — so a later process opening the same detached checkout finds the whole branch

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -1,16 +1,17 @@
--- The **trim**: the commits taken off the start of a branch review.
+-- The **trim**: the commits taken out of a branch review.
 --
 -- Two halves, and the seams are the two that already exist. The first is scope resolution,
--- where the ref arithmetic lives and where an error is invisible in a rendered diff -- the
--- picked commit is in, the oldest row means the merge base and not a parent, and removing
--- the trim gives the review back. The second is the review view, where everything a
--- reviewer can see is: which files the diff draws, what the label says, which reviewed
--- marks survived, what the queue still lists.
+-- where the pre-image is worked out and where an error is invisible in a rendered diff --
+-- every pick reads what that pick has always read, the oldest row means the merge base and
+-- not a parent, and removing the trim gives the review back. The second is the review view,
+-- where everything a reviewer can see is: which files the diff draws, what the label says,
+-- which reviewed marks survived, what the queue still lists.
 --
 -- What is asserted is what a reviewer can observe. Never the shape of a git invocation, and
 -- never the shape of what the trim is stored in: a trim is set through the state module and
 -- read back through resolution, which is the same round trip `since-batch` makes through
--- the archive.
+-- the archive. A set of commits goes in because that is what a trim *is*, and what comes
+-- back is compared against git's own answer for the same reading.
 --
 -- The fixture is `mkcommits`, whose history is the point: its merge base is a different
 -- commit from its oldest listed commit's parent, so the oldest-row rule is observable at
@@ -85,13 +86,26 @@ local function commit_named(subject)
   error("no commit on this branch says " .. subject)
 end
 
+---The commits a reviewer takes out by starting their reading at that commit: every commit
+---older than it, which is what the row they land on picks.
+---@param subject string
+---@return string[] skipped
+local function taken_out_below(subject)
+  local _, kept = commit_named(subject)
+  local skipped = {}
+  for i = kept + 1, #commits do
+    skipped[#skipped + 1] = commits[i].sha
+  end
+  return skipped
+end
+
 --- Reading a scope back ----------------------------------------------------------
 
 ---Set the trim and resolve the branch scope through it, exactly as opening a review does.
----@param before string|nil nil is no trim
+---@param skipped string[]|nil nil is no trim; an empty set is a trim that takes nothing out
 ---@return CRFile[] files, CRScope scope
-local function under_trim(before)
-  state.set_trim(root, before)
+local function under_trim(skipped)
+  state.set_trim(root, skipped)
   local scope = assert(git.resolve_scope("branch", root))
   local files = assert(git.collect(scope, root, {}))
   return files, scope
@@ -129,37 +143,62 @@ describe("the history this spec reads", function()
   it("keeps the merge base and the oldest commit's parent as different commits", function()
     assert.are_not.same(base, parent_of(commits[#commits].sha))
   end)
+
+  -- What the block below compares against is `git diff` alone, so anything in the tree that
+  -- git diff does not name would be a file the review holds and the expectation lacks.
+  it("is a clean checkout at this point in the file", function()
+    assert.same({}, h.git_lines(fixture, { "status", "--porcelain" }))
+  end)
 end)
 
---- Where a trim can start ---------------------------------------------------------
+--- What every pick resolves to ----------------------------------------------------
 
-describe("the commits a trim can start at", function()
+-- The claim the representation rests on: a reviewer presses the same key, picks the same
+-- row, and reads the same diff. What each row is compared against is git's own answer for
+-- the reading that row has always given -- the picked commit's own parent, and the merge
+-- base on the oldest row -- so what is asserted is the reading and never the arithmetic
+-- that produced it.
+--
+-- Every row rather than a chosen one, because the rows differ in kind: the merge row is
+-- where a trim reaches past a merge, and the oldest row is where the merge base and the
+-- oldest commit's parent are two different commits.
+--
+-- Statuses and not only paths. `src/lexer.lua` is in the review either way, and it is a
+-- file the branch *modified* against the merge base and a file it *added* against the
+-- oldest commit's parent -- so a comparison of names alone passes against the wrong ref.
+describe("every commit a reviewer can pick", function()
   local listed = assert(git.branch_commits(root, base))
 
-  it("offers one per commit on the branch's own line of work", function()
+  it("offers one row per commit on the branch's own line of work", function()
     assert.same(#commits, #listed)
   end)
 
-  -- The stored value is the *parent* of the picked commit, so the commit a reviewer picked
-  -- is in the diff and nothing has to be done to the ref at open time.
-  it("starts every commit but the oldest at that commit's own parent", function()
-    for i = 1, #listed - 1 do
-      assert.same(parent_of(listed[i].sha), full(listed[i].before), listed[i].subject)
-    end
-  end)
+  ---@param files CRFile[]
+  ---@return string[] One `status<TAB>path` per file, in git's own spelling
+  local function as_git_says(files)
+    return vim.tbl_map(function(f)
+      return ("%s\t%s"):format(f.status, f.path)
+    end, files)
+  end
 
-  it("starts the oldest at the merge base, and not at its parent", function()
-    local oldest = listed[#listed]
-    assert.same(base, full(oldest.before))
-    assert.are_not.same(parent_of(oldest.sha), full(oldest.before))
-  end)
+  for at, commit in ipairs(commits) do
+    it(("reads what a review starting at %q has always read"):format(commit.subject), function()
+      -- The ref a trim starting at this commit was stored as before a trim was a set.
+      local shipped = at < #commits and parent_of(commit.sha) or base
+      local files = under_trim(taken_out_below(commit.subject))
+      assert.same(h.git_lines(fixture, { "diff", "--name-status", shipped }), as_git_says(files))
+    end)
+  end
+
+  state.set_trim(root, nil)
 end)
 
 --- What a trim resolves to --------------------------------------------------------
 
 describe("a trim starting at a commit part-way up the branch", function()
-  local picked, kept = commit_named("test: cover the config reader")
-  local files, scope = under_trim(parent_of(picked.sha))
+  local subject = "test: cover the config reader"
+  local _, kept = commit_named(subject)
+  local files, scope = under_trim(taken_out_below(subject))
 
   -- The commit picked added `src/config_spec.lua`; the one before it added the host line to
   -- `src/config.lua`. So the two files say which side of the pick each commit landed on.
@@ -180,12 +219,19 @@ describe("a trim starting at a commit part-way up the branch", function()
   end)
 end)
 
+-- The oldest row takes nothing out: there is no commit older than it to take. That is a
+-- trim all the same -- the label counts the whole branch and the list marks the row -- and
+-- it is the one pick whose set is empty, so it is also what says the store keeps an empty
+-- set rather than losing it on the way to the disk and back.
 describe("a trim starting at the oldest commit", function()
-  local listed = assert(git.branch_commits(root, base))
-  local files, scope = under_trim(listed[#listed].before)
+  local files, scope = under_trim({})
 
   it("reads from the merge base", function()
     assert.same(base, scope.before)
+  end)
+
+  it("is still a trim, and says so in its label", function()
+    assert.is_truthy(scope.label:find(("last %d"):format(#commits), 1, true), scope.label)
   end)
 
   -- `src/lexer.lua` exists at the merge base and does not exist at the oldest commit's
@@ -218,8 +264,7 @@ describe("no trim at all", function()
 end)
 
 describe("what a trim never moves", function()
-  local picked = commit_named("Merge branch 'lexer' into feature")
-  local _, trimmed = under_trim(parent_of(picked.sha))
+  local _, trimmed = under_trim(taken_out_below("Merge branch 'lexer' into feature"))
   local _, whole = under_trim(nil)
 
   -- The one field the whole feature rests on. The pre-image moves under a trim and the
@@ -250,7 +295,7 @@ describe("the scopes gs moves through", function()
   it("is the same cycle under a trim as without one", function()
     state.set_trim(root, nil)
     local without = git.cycle(root)
-    state.set_trim(root, parent_of(commits[1].sha))
+    state.set_trim(root, taken_out_below(commits[1].subject))
     assert.same(without, git.cycle(root))
     state.set_trim(root, nil)
   end)
@@ -540,6 +585,36 @@ describe("cycling scope from a trimmed review", function()
   end)
 end)
 
+-- A commit made after a trim is in the review the moment it is made, because a trim is the
+-- commits it takes *out* and nobody took this one out. A trim that recorded the commits it
+-- kept would leave the new one outside a review the reviewer never narrowed past it, and a
+-- count remembered at pick time would keep saying the number it said then.
+--
+-- Last of this half, because it puts a sixth commit on the branch every block above counts.
+describe("work committed after the trim was picked", function()
+  vim.fn.writefile({ "local late = true" }, vim.fs.joinpath(fixture, "src/late.lua"))
+  -- That file alone: the tree also holds work two blocks above left uncommitted, and this
+  -- claim is about a commit rather than about what else is in the review beside it.
+  h.git_lines(fixture, { "add", "src/late.lua" })
+  h.git_lines(fixture, { "commit", "-q", "-m", "feat: commit after trimming" })
+  -- The entry point `gs` back onto the branch and every open already go through, so the
+  -- trim is read again and nothing about it was touched.
+  view.set_scope("branch")
+  local W = assert(view.current())
+
+  it("holds the new commit's work", function()
+    assert.is_number(h.file_index(W, "src/late.lua"), vim.inspect(paths(W.files)))
+  end)
+
+  it("still holds the commit the trim was picked at", function()
+    assert.is_number(h.file_index(W, "src/lexer.lua"), vim.inspect(paths(W.files)))
+  end)
+
+  it("counts it, so the label grew by one", function()
+    assert.is_truthy(W.scope.label:find("last 2", 1, true), W.scope.label)
+  end)
+end)
+
 codereview.close()
 
 --- The trim a session leaves behind -----------------------------------------------
@@ -683,13 +758,27 @@ end)
 -- What a `git gc` after a rebase leaves behind, and the one case no session can reach on its
 -- own: the commit was there when the trim was picked and this repository has nothing under
 -- that name now. One fact for the reviewer, so one sentence -- the same one.
-describe("a stored trim naming a commit this repository does not have", function()
+--
+-- Set beside a commit the branch still holds, because a trim is a set and the rule is that
+-- **any** failure takes all of it. A store that dropped the commit that failed and kept the
+-- rest would leave the review narrowed by a selection the reviewer never made -- so the
+-- surviving commit is one that narrows the review on its own, and the case above it is what
+-- says so rather than assuming it.
+describe("a stored trim holding a commit this repository does not have", function()
+  local oldest = assert(h.git_lines(kept, { "rev-list", "--first-parent", "--reverse", kept_base .. "..HEAD" })[1])
+
+  it("would narrow the review on its own, for the commit that survives the check", function()
+    state.set_trim(kept_root, { oldest })
+    view.set_scope("branch")
+    assert.are_not.same(WHOLE, paths(assert(view.current()).files))
+  end)
+
   local msgs, restore = h.capture_notify()
-  state.set_trim(kept_root, ("0"):rep(40))
+  state.set_trim(kept_root, { oldest, ("0"):rep(40) })
   view.set_scope("branch")
   restore()
 
-  it("opens the full branch", function()
+  it("opens the full branch, so nothing of the set survived", function()
     assert.same(WHOLE, paths(assert(view.current()).files))
   end)
 


### PR DESCRIPTION
A **trim** was stored as one ref: the commit a branch review reads from. #148 redefines a
trim as *the commits taken out of a branch scope*, which is a set. This changes the
representation and nothing else.

A reviewer sees no difference. They press the same key, pick the same row, and get the same
diff. The store holds the commits taken out, and scope resolution derives the pre-image by
**anchoring on the leading run** — the newest commit the trim takes off the start of the
branch, whose own tree is what a trim reads from today. Every trim this version can store is
a prefix, so the run always covers the whole set: nothing is merged and nothing is
synthesized. A set with a commit above its run is one this version cannot read, and it gives
the whole branch back rather than a narrower reading than the reviewer asked for — which is
the seam #151 fills in.

**The commits taken out, not the commits kept.** A commit made after a trim is in the review
the moment it is made, for the same reason the `last N` count is derived rather than
remembered.

**Any commit failing the ancestry check drops the whole set**, under the sentence that
already existed. The check is now one `rev-list` for the set rather than one process per
commit, because it runs on every read.

The commit listing no longer carries the ref a trim starting at each row would read from.
The oldest row needed a case of its own for that value — the merge base and not the commit's
own parent — and the anchor answers it structurally: the oldest row takes nothing out, so
there is no run and the anchor is the merge base.

## How the reading was proved unchanged

Every pick was driven through the keys — `gc`, a cursor row, `<CR>` — on the shipped code and
on this branch, over one copy of the history fixture, and the two transcripts were compared:
label, pre-image, identity, post-image, `untracked`, the file list with statuses and the
sha256 of the `git diff` output itself. Identical for all six picks on a branch with a merge
in it, and for all four on a branch without one.

`trim_spec` now carries that comparison: one case per row of the listing, each asserting the
review's `status<TAB>path` list against `git diff --name-status` for the ref that row's trim
was stored as before it was a set. Statuses and not paths alone — `src/lexer.lua` is in the
review against both the merge base and the oldest commit's parent, and only its status tells
the two apart.

New cases: an empty set is still a trim and still labels `last N`; a commit made under a trim
is in the review with the trim untouched and the count grown; and a stored set holding one
commit the repository does not have drops the whole set, guarded by the case above it that
proves the surviving commit would have narrowed the review on its own.

`make all` passes; judged on its exit code.

Closes #150