### PR TITLE
feat(git): synthesize the pre-image for a trim with a hole in it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,17 +14,18 @@ whatever changed since the last **batch** went out, or any git revspec.
 _Avoid_: mode, filter, range (a range is a span of lines, see **Range**)
 
 **Trim**:
-The commits taken off the start of a **branch** scope. The default is none. The reviewer
-picks the oldest commit they still want to read, and the commits before it leave the review.
-The word is subtractive, which is what the reviewer does: they remove commits from a whole
-that is there by default. "Trimmed to four commits" and "reset the trim" both read
-correctly, and the verb and the noun are one word. A trim has one end, and it is the start —
-so uncommitted and untracked work stay in the review under every trim. Kept per branch, and
-dropped when its commit leaves the branch: a trim belongs to one reading of one branch, and a
-rewritten commit is not that reading. Said of a **branch**
+The commits taken out of a **branch** scope, however many and wherever they sit. The default
+is none, and they do not have to be next to each other: a trim can take one commit out of the
+middle and leave the commits older than it in the review. The word is subtractive, which is
+what the reviewer does: they remove commits from a whole that is there by default. "Trimmed
+to four commits" and "reset the trim" both read correctly, and the verb and the noun are one
+word. Uncommitted and untracked work stay in the review under every trim, because the
+post-image of a branch review is the working tree and no trim of any shape reaches it. Kept
+per branch, and dropped whole when any commit in it leaves the branch: a trim belongs to one
+reading of one branch, and a rewritten commit is not that reading. Said of a **branch**
 scope only: the working-tree scopes have no commits to take. A modifier on that scope and
 never a scope of its own, because a sixth name would have to answer what it means with
-nothing picked, and because `gs` is a key held down and must not get a new stop. Not
+nothing taken out, and because `gs` is a key held down and must not get a new stop. Not
 _filter_ and not _mode_: both are on **Scope**'s avoid list. Not _range_, which is the lines
 an annotation covers, and not _span_, which is the changed characters inside a paired line.
 Not _selection_ either: that is on **Range**'s avoid list, and reusing it invites the

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ That is the whole configuration. Nothing else is required.
 **Requirements:** Neovim 0.12 or later, and `git`. Treesitter parsers are optional. A file
 without a parser falls back to flat diff colors.
 
+Taking a commit out of the **middle** of a branch review needs **git 2.38 or later**, which
+is where `git merge-tree --write-tree` arrives. That is the only thing the floor is for.
+Every other reading works on any git, a trim included: a trim that only takes commits off the
+start of the branch reads from a commit that already exists and merges nothing.
+
 ## Your first review
 
 Six keys get you through a review.
@@ -209,8 +214,8 @@ commits", which gives the whole branch back, and the bottom row does the same.
 The list marks the row your review starts at with `▸`, and the cursor opens on that row. With
 the whole branch in the review, the cursor opens on "All commits".
 
-Uncommitted and untracked work stay in the review under every trim. A trim has one end, and
-it is the start.
+Uncommitted and untracked work stay in the review under every trim. A branch review reads to
+the working tree, and no trim reaches that end of it.
 
 The plugin keeps the trim per branch, so the next session opens where your reading stopped.
 Each branch keeps its own trim.

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -26,7 +26,10 @@ lines, selections, hunks or whole files with a type; the annotations queue up;
 submit them as one batch. See |codereview-layouts|.
 
 Requires Neovim 0.12 or newer and `git`. Treesitter parsers are optional --
-files without one fall back to flat diff colors.
+files without one fall back to flat diff colors. Taking a commit out of the
+middle of a branch review needs git 2.38 or newer, which is where
+`git merge-tree --write-tree` arrives; every other reading, a trim that only
+takes commits off the start of the branch included, works on any git.
 
 ==============================================================================
 2. COMMANDS                                            *codereview-commands*

--- a/docs/adr/0006-a-trim-with-a-hole-synthesizes-its-pre-image.md
+++ b/docs/adr/0006-a-trim-with-a-hole-synthesizes-its-pre-image.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+---
+
+# A trim with a hole in it synthesizes its pre-image
+
+A **trim** is the commits taken out of a branch review, and they no longer have to be the
+ones at the start. A review that keeps a commit and drops an older one reads from a tree that
+never existed as a commit, so the review builds one: it anchors on the newest commit of the
+run the trim takes off the start of the branch, and three-way merges each skipped commit
+above that run onto the accumulation, oldest first, minting a commit object between steps. A
+trim with no hole in it anchors on a real commit and assembles nothing, which is what leaves
+the trim that already shipped reading exactly as it read. A merge that conflicts is
+**refused rather than approximated**, at the moment the reviewer applies the pick and before
+anything is stored.
+
+Two alternatives were considered and rejected.
+
+**Concatenating the skipped commits' patches out of the diff.** The review would run one
+`git diff` per kept commit and paste the results together, which needs no merge and can never
+conflict. It was rejected because the result is not a diff of anything: a file two kept
+commits both touched appears once per commit, and the whole surface downstream is built on
+one entry per file — the file tree, the anchor map an annotation is bound to, and the
+per-file reviewed marks all count a file once. A reviewer would meet the same path twice in
+one review with no way to say which of the two they had read.
+
+**Attributing each diff line to the commit that last touched it, and hiding the skipped
+ones.** There is no assembly, so there is nothing to conflict and no refusal to explain. It
+was rejected for two reasons that compound. The attribution is *last touched* and therefore
+lossy: a line the skipped commit reindented and a kept commit then rewrote is attributed to
+one of them, and the reviewer reads a line the other one is responsible for. And it puts a
+blame pass on a measured hot path — the rendering work that runs on every resize, expansion,
+reviewed toggle and scope change — for a diff whose size is the reviewer's whole branch.
+
+That second one is kept on the record deliberately, because it is what a reader who meets a
+refusal would propose. If refusals turn out to be the norm rather than the exception, it is
+the escape hatch, and it should be reopened as an issue rather than reinvented.
+
+## Consequences
+
+Some picks are refused, and the likeliest case is the one the feature exists for: a formatter
+run touches the same lines every other commit touched. That is intrinsic — the reviewer is
+asking for a tree that never existed — so the refusal is worded as an ordinary answer and not
+as a failure. It names the skipped commit and the files it conflicts in, and no dependency
+commit: which kept commit introduced the conflicting region takes a heuristic pass that can
+name the wrong commit confidently.
+
+The merge is `git merge-tree --write-tree`, which sets a floor of **git 2.38**. Only a trim
+with a hole in it reaches it, so the floor gates the new selections and not the trim that
+already ships, and the README states it that way.
+
+The synthesized commit is **unreachable**: no ref is written, which is the same exposure the
+**snapshot** minted at dispatch already accepts. git's default prune window is two weeks, so
+an automatic collection cannot take a commit minted minutes ago, and an explicit prune costs
+one rebuild.
+
+The scope's `identity` stays the merge base, so a reviewer's progress is read back under the
+same key however they narrow the review. Only `before` moves, and under a hole it moves to a
+commit no ref names.

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -253,8 +253,9 @@ to an agent whose working directory is not this one; anything outside its tree f
 to an absolute path with the code inlined.
 
 **A scope's identity and its pre-image are two refs, and only one of them may be re-derived.**
-A **trim** moves a `branch` scope's `before` up the branch and leaves `identity` at the merge
-base. Anything asking *where does this branch start* — the commit list, the progress key —
+A **trim** moves a `branch` scope's `before` off the merge base — up the branch, or onto a
+commit no ref names at all — and leaves `identity` where it is. Anything asking *where does
+this branch start* — the commit list, the progress key —
 has to read the identity: the pre-image is what a trim narrows, so a commit list built from
 it shortens every time a reviewer trims and takes away the rows they need to widen it again.
 Anything asking *what is this review reading* has to read the pre-image. Neither may be
@@ -281,6 +282,41 @@ would leave the review narrowed by a selection the reviewer never made, and whic
 rewritten history are still the same reading is a claim nothing here can make. It is also what
 keeps the sentence one sentence — a set that survives in part fails again on the next read,
 one commit at a time.
+
+**The one thing memoised is the built tree, and the key is why that is not the trap above.**
+A trim with a hole in it reads from a tree that never existed as a commit, so it is built —
+and without a cache every scope cycle, every reopen and every pick pays the whole accumulation
+again. The memo the note above refuses is a stored *sha* going stale against a rewritten
+`HEAD`: it answers from memory without ever asking `HEAD` again, which is the exact failure
+the ancestry check exists to refuse. A key that *contains* the `HEAD` sha cannot do that —
+either key changing is a new key — so the cache holds the built tree under the whole of what
+built it: the repository, the base, `HEAD` and the set. Nothing else is cached. Not the trim,
+not its ancestry answer, not the resolved scope: each of those is an answer about a history
+that can be rewritten while the review is open, and only the first of them is checked on
+every read.
+
+**The anchor is the whole of the pre-image rule, and removing it looks like a simplification.**
+Building from the merge base and applying every skipped commit — including the ones the trim
+takes off the *start* — is the obvious rule and the one the spec was first written with. It
+refuses two ordinary cases, both measured against a real repository rather than reasoned
+about: a plain prefix trim reaching past a merge, which is the shipped `gc` flow on any
+branch with a merge in it, and taking every commit out. Both collide because a merge's
+first-parent diff *adds* everything the side branch brought while the merge base already
+holds it. Anchoring on the newest commit of the leading run fixes both, and it is also what
+keeps the git 2.38 floor off the trim that already ships: a trim with no hole reaches no
+merge at all. Deleting the anchor reds 29 cases in `trim_spec`, and two of them —
+`a trim reaching past the merge` and `every commit taken out` — are the ones that exist for
+this and nothing else.
+
+**A conflicting merge is decided on the exit status, and never on the word `CONFLICT`.**
+`merge-tree` prints an informational trailer that says `CONFLICT (add/add): …`, and it is
+tempting to search for it: the paths are right there in a sentence. It is a message written
+for a human, it is not guaranteed across the versions above the floor, and a search that
+finds nothing reports a conflicting merge as **clean** — which ships a review built from a
+tree that could not be assembled, silently, in the one direction that matters. The exit code
+is the whole answer, exactly as it is for `all_ancestors` behind a stored trim, and the paths
+come from `--name-only`, which prints the tree object and then one path per line. Making the
+merge ignore its exit status reds six cases in `trim_spec`.
 
 **Keying progress on the pre-image fails silently rather than loudly.** The per-scope progress
 key is `name .. ":" .. identity`. Spelled with `before` it agrees with the plugin for every

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -22,7 +22,7 @@ change there is felt through.
 | `diff.lua` | Unified-diff parsing, and the intra-line spans within a paired line | pure |
 | `drafts.lua` | Note text abandoned in a composer, keyed by absolute path — or by repository, for a **preamble** — in a store of its own | stateful (disk) |
 | `fade.lua` | The **faded** file rule: which rows one file's fade covers, and which group a faded row carries in place of its own | stateful (editor) |
-| `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes | stateful (git) |
+| `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes, and the pre-image a **trim** with a hole in it is built from | stateful (git) |
 | `hl.lua` | The highlight groups: `default = true` links into whatever colorscheme is active, and the three families of blended twins — the **muted** window's, the **faded** file's and the **counterpart row**'s | stateful (editor) |
 | `init.lua` | The public surface a host reaches: `setup`, the user commands, `annotate(type)` | stateful (setup) |
 | `keymaps.lua` | Every key the review view binds — the diff's and the tree's — onto a buffer handed in, driving actions handed in | stateful (editor) |

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -19,6 +19,7 @@ local BINARY_SNIFF_BYTES = 8000
 ---@param opts? { cwd?: string, timeout?: integer, ok_codes?: integer[] }
 ---@return string|nil stdout Raw, untrimmed -- diff output is whitespace-significant
 ---@return string|nil err
+---@return integer|nil code The exit status, for a caller that accepts more than one
 local function run(args, opts)
   opts = opts or {}
   local cmd = { "git" }
@@ -34,9 +35,9 @@ local function run(args, opts)
 
   if not vim.tbl_contains(opts.ok_codes or { 0 }, res.code) then
     local stderr = vim.trim(res.stderr or "")
-    return nil, stderr ~= "" and stderr or ("git exited %d"):format(res.code)
+    return nil, stderr ~= "" and stderr or ("git exited %d"):format(res.code), res.code
   end
-  return res.stdout or "", nil
+  return res.stdout or "", nil, res.code
 end
 
 ---Single-line queries, trimmed. Returns nil for both failure and empty output, since
@@ -196,38 +197,163 @@ function M.cycle(root)
   return names
 end
 
+--- The pre-image a trim reads from -----------------------------------------------
+
+---The subject on a commit object that exists because a review asked for a tree nothing on
+---the branch has. Never reachable from a ref, so this is all there is to read it by.
+local SYNTHESIZED = "codereview: synthesized pre-image"
+
+---The trees already built for a trim with a hole in it, by the whole of what built them.
+---
+---**The recorded trap about memoising a trim does not reach this, and the key is why.** That
+---trap is a stored *sha* going stale against a rewritten `HEAD`: a memo answers from memory
+---without ever asking `HEAD` again, which is the exact failure the ancestry check exists to
+---refuse. This key holds `HEAD` itself, beside the repository, the base and the set -- every
+---input the accumulation reads -- so any of them moving is a new key rather than a stale
+---answer. Nothing else is cached: not the trim, not its ancestry answer, not the resolved
+---scope.
+---
+---Without it, every scope cycle and every reopen pays the whole accumulation again, and a
+---pick pays it twice over: once to find out whether it can be assembled, once to resolve.
+local built = {}
+
+---@param root string
+---@param base string
+---@param skipped string[]
+---@return string|nil key nil when this repository has no `HEAD` to key on
+local function cache_key(root, base, skipped)
+  local head = line({ "rev-parse", "--verify", "--quiet", "HEAD" }, root)
+  if not head then
+    return nil
+  end
+  -- Sorted, because the same set stored in another order is the same set, and a key that
+  -- said otherwise would rebuild what it already holds.
+  local order = vim.deepcopy(skipped)
+  table.sort(order)
+  return table.concat({ root, base, head, table.concat(order, ",") }, "\31")
+end
+
+---Three-way merge one skipped commit onto the accumulation, and print the tree.
+---
+---`merge-tree` is the primitive for exactly this: a real three-way merge that writes a tree
+---and reports conflicts, touching no index, no working tree and no ref -- the stance
+---`snapshot` already takes with `stash create`. It is what sets the git 2.38 floor the
+---README states, and **only a trim with a hole in it ever reaches it**, so the floor gates
+---the new selections rather than the trim that already ships.
+---
+---**The exit status is the whole answer.** `--name-only` prints the tree object on the first
+---line and, when the merge conflicted, the conflicting paths on the lines below it, above
+---the blank line the informational messages sit under. Deciding instead by searching that
+---trailer for the word `CONFLICT` would be a search that reports a conflicting merge as
+---**clean** wherever the wording differs -- and the wording is a message written for a human,
+---not an interface, so it is free to differ across the versions above the floor. A false
+---negative there ships a review built from a tree that could not be assembled. The exit code
+---is what `all_ancestors` already leans on, for the same reason.
+---@param root string
+---@param ours string The accumulation so far, as a commit
+---@param commit string The skipped commit being applied
+---@return string|nil tree nil when the merge conflicted or git refused it
+---@return string[] conflicts The paths it conflicts in; empty when git refused outright
+---@return string|nil err What git said, when it refused outright
+local function merge_tree(root, ours, commit)
+  local out, err, code = run({
+    "merge-tree",
+    "--write-tree",
+    "--name-only",
+    -- The commit's own parent, so what is applied is what that commit did and nothing else.
+    "--merge-base=" .. commit .. "^",
+    ours,
+    commit,
+  }, { cwd = root, timeout = DIFF_TIMEOUT_MS, ok_codes = { 0, 1 } })
+  -- Anything but a clean merge or a conflicting one -- an unknown option on a git below the
+  -- floor, a bad object -- is what git said it was, reported through the same path.
+  if not out then
+    return nil, {}, err
+  end
+
+  local lines = vim.split(out, "\n", { plain = true })
+  if code == 0 then
+    local tree = vim.trim(lines[1] or "")
+    return tree ~= "" and tree or nil, {}, nil
+  end
+
+  local conflicts = {}
+  for i = 2, #lines do
+    if lines[i] == "" then
+      break
+    end
+    conflicts[#conflicts + 1] = lines[i]
+  end
+  return nil, conflicts, nil
+end
+
+---@class CRTrim
+---@field before string  The pre-image the review reads from
+---@field kept integer   How many of the branch's commits the trim leaves in the review
+---@field total integer  How many the branch has
+---@field hole boolean   Whether a commit was taken out with an older one left in
+
+---@param commit CRCommit
+---@param conflicts string[]
+---@param err string|nil
+---@return string
+local function refusal(commit, conflicts, err)
+  -- The skipped commit and the files, and no dependency commit: `merge-tree` reports the
+  -- files, and naming the kept commit that introduced the conflicting region would take a
+  -- heuristic pass of its own that can name the wrong commit confidently.
+  if #conflicts > 0 then
+    return ("Taking out %s %s conflicts in %s — the review is unchanged"):format(
+      commit.sha,
+      commit.subject,
+      table.concat(conflicts, ", ")
+    )
+  end
+  return ("Taking out %s %s could not be assembled — %s"):format(commit.sha, commit.subject, err or "git refused it")
+end
+
 ---What a **trim** leaves a branch review reading from.
 ---
 ---A trim is the commits taken out, so the review has to read from a tree that already holds
----every one of them and none of the commits kept. That tree is found by **anchoring on the
----leading run**: the commits the trim takes off the *start* of the branch, from the oldest
----up, for as far as the set matches the branch. The newest commit of that run is a real
----commit whose own tree is exactly that, so the answer is a commit that already exists and
----nothing is assembled.
+---every one of them and none of the commits kept. It is built in two parts.
 ---
+---It **anchors on the leading run**: the commits the trim takes off the *start* of the
+---branch, from the oldest up, for as far as the set matches the branch. The newest commit of
+---that run is a real commit whose own tree is exactly that, so nothing is assembled for it.
 ---With nothing in the run the anchor is the merge base: a trim that takes no commit out
 ---reads the branch whole. That is the *oldest row* of the commit list, and the anchor is why
 ---it needs no case of its own -- on a branch with a merge in it the oldest commit's parent
 ---is not the merge base, and a review reading from that parent draws a file the merge base
 ---already had as one the branch added.
 ---
+---**The anchor is the whole design and not an optimization.** Accumulating every skipped
+---commit from the merge base instead refuses two ordinary cases, both confirmed against a
+---real repository: a plain prefix trim reaching past a merge -- which is the shipped `gc`
+---flow on any branch with a merge in it -- and taking every commit out. Both collide, because
+---a merge's first-parent diff *adds* what the side branch brought while the merge base
+---already holds it.
+---
+---Above the run each skipped commit is **three-way merged onto the accumulation, oldest
+---first**, and a commit object is minted between steps because `merge-tree` merges commits
+---rather than trees. Only a set with a hole in it gets that far. **No ref is written**: the
+---synthesized commit is unreachable, which is the exposure `snapshot` already accepts, and
+---git's default prune window is two weeks -- an automatic collection cannot take a commit
+---minted minutes ago, and the cache re-mints on the next resolve if an explicit prune does.
+---
 ---The branch's commits are read back through `branch_commits`, which is the listing the
 ---reviewer picked off. One rule for which commits are on the branch, for the reason there is
 ---one rule for where it starts: a trim built from one listing and resolved against another
----is a trim that can stop resolving without either side changing.
----
----**Nothing above the run is applied here.** A pick takes out the commits older than the row
----it lands on, so every trim this version can store is a prefix and the run always covers
----the whole set. A set with a commit above the run is one this version cannot read, and it
----gives the whole branch back rather than a narrower reading than the reviewer asked for.
+---is a trim that can stop resolving without either side changing. A set holding a commit
+---that listing does not name is one this cannot read from, and it gives the whole branch
+---back rather than a narrower reading than the reviewer asked for.
 ---@param root string
 ---@param base string The merge base: where the branch starts
 ---@param skipped string[] The commits the trim takes out
----@return string|nil before nil when the set is not one this version can read from
+---@return CRTrim|nil trim nil when the set cannot be read from or cannot be built
+---@return string|nil refused The sentence a reviewer is told, when a merge conflicted
 local function pre_image(root, base, skipped)
   local commits = M.branch_commits(root, base)
   if not commits then
-    return nil
+    return nil, nil
   end
 
   local taken = {}
@@ -243,7 +369,69 @@ local function pre_image(root, base, skipped)
     end
     anchor, run = commits[i].id, run + 1
   end
-  return run == #skipped and anchor or nil
+
+  -- Derived from the listing rather than remembered, exactly as the `last N` count is: the
+  -- commit a reviewer makes after trimming is in the review, and in both of these numbers,
+  -- the moment it is made.
+  local trim = { kept = #commits - #skipped, total = #commits, hole = run < #skipped }
+  if not trim.hole then
+    trim.before = anchor
+    return trim, nil
+  end
+
+  local key = cache_key(root, base, skipped)
+  if key and built[key] then
+    trim.before = built[key]
+    return trim, nil
+  end
+
+  local acc, applied = anchor, run
+  -- Oldest first, from the row above the run down to the newest.
+  for i = #commits - run, 1, -1 do
+    local commit = commits[i]
+    if taken[commit.id] then
+      local tree, conflicts, err = merge_tree(root, acc, commit.id)
+      if not tree then
+        return nil, refusal(commit, conflicts, err)
+      end
+      acc = line({ "commit-tree", tree, "-p", acc, "-m", SYNTHESIZED }, root)
+      if not acc then
+        return nil, nil
+      end
+      applied = applied + 1
+    end
+  end
+  if applied ~= #skipped then
+    return nil, nil
+  end
+
+  if key then
+    built[key] = acc
+  end
+  trim.before = acc
+  return trim, nil
+end
+
+---Why a set of commits cannot leave this branch's review, or nil when it can.
+---
+---What a pick asks **before anything is stored**, so a refusal reaches the reviewer with the
+---float still open and the store holding what it held. It is not a seam of its own: it
+---answers out of the same builder scope resolution reads, and the tree it builds on the way
+---is the tree that resolve then finds in the cache.
+---
+---A set this cannot read from at all -- one holding a commit the branch does not list -- is
+---not a refusal. That is the shipped answer for a trim nothing can resolve: the whole branch
+---opens, and the reviewer is not told a sentence about a merge that was never attempted.
+---@param root string
+---@param base string The merge base: the review's own scope identity
+---@param skipped string[]|nil
+---@return string|nil refused
+function M.trim_refusal(root, base, skipped)
+  if not skipped then
+    return nil
+  end
+  local _, refused = pre_image(root, base, skipped)
+  return refused
 end
 
 ---Resolve a scope name, or any git revspec, into the refs the rest of the plugin needs.
@@ -335,17 +523,42 @@ function M.resolve_scope(spec, root)
     -- store drops a set holding a commit `HEAD` no longer descends from, and says so, so a
     -- commit this repository cannot read from never reaches the anchor below.
     local skipped = require("codereview.state").trim(root)
-    local anchor = skipped and pre_image(root, base, skipped)
-    -- A count the repository cannot take leaves the whole branch open rather than a review
-    -- narrowed by an answer nothing could work out.
-    local kept = anchor and M.count_commits(anchor, root)
-    local before = kept and anchor or base
+    -- Only the first answer, deliberately. A refusal belongs to the **pick**, which asks
+    -- before it stores anything and still has the reviewer in front of it; here a set that
+    -- cannot be built gives the whole branch back, which is what an unresolvable trim has
+    -- always done rather than a narrower reading than the reviewer asked for.
+    local trim
+    if skipped then
+      trim = pre_image(root, base, skipped)
+    end
+
+    -- Two spellings of one number, for two different questions. While the trim is a prefix
+    -- the review is the last N commits, and how far `HEAD` is from the pre-image is a
+    -- question git answers -- and a count the repository cannot take leaves the whole branch
+    -- open rather than a review narrowed by an answer nothing could work out. Under a hole
+    -- the review is not a run of commits at all, so there is no ref to count from and what
+    -- is left in is the size of the kept set.
+    local kept
+    if trim then
+      kept = trim.hole and trim.kept or M.count_commits(trim.before, root)
+    end
+    local before = kept and trim.before or base
+
+    -- Short, because the winbar is width-constrained and the summary is what a narrow pane
+    -- gives up first. The label is also the only thing that stops a trim from being a trap,
+    -- so it carries two forms: `last N` while the trim is a prefix, and `N of M` once it has
+    -- a hole in it or has taken the whole branch out. Neither of those is the last anything,
+    -- and a label must never claim a shape the reading does not have.
+    local label = ("branch vs %s"):format(branch)
+    if kept and (trim.hole or kept == 0) then
+      label = ("%s · %d of %d"):format(label, kept, trim.total)
+    elseif kept then
+      label = ("%s · last %d"):format(label, kept)
+    end
 
     return {
       name = "branch",
-      -- Short, because the winbar is width-constrained and the summary is what a narrow
-      -- pane gives up first. It is also the only thing that stops a trim from being a trap.
-      label = kept and ("branch vs %s · last %d"):format(branch, kept) or ("branch vs %s"):format(branch),
+      label = label,
       args = { before },
       -- What the commits the trim took out are already in, so the ones it kept are the diff.
       before = before,

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1663,10 +1663,27 @@ end
 ---
 ---Nothing here re-reads the trim to draw anything: resolution does that, so the label and
 ---the diff are answering out of the same store on the same pass.
+---
+---**The build is attempted before anything is stored.** A set with a hole in it needs a tree
+---that never existed, and taking one commit out can need a commit that is staying -- the
+---formatter case is the likeliest of all, because a formatter touches the same lines every
+---other commit touched. Such a set is refused rather than approximated, and refused *here*,
+---so the store still holds what it held, the review on screen is the review that was there,
+---and the reviewer is a keystroke away from a selection that works. A refusal is an ordinary
+---answer to a reviewer asking for a tree that never existed, not a failure.
+---
+---The base handed to the check is the review's own **identity**, for the reason the commit
+---list is drawn from it: a second derivation of where this branch starts is a second chance
+---to answer it differently.
 ---@param skipped string[]|nil The commits to take out; nil removes the trim
 function M.trim_to(skipped)
   local v = M.current()
   if not v then
+    return
+  end
+  local refused = require("codereview.git").trim_refusal(v.root, v.scope.identity, skipped)
+  if refused then
+    info(refused)
     return
   end
   require("codereview.state").set_trim(v.root, skipped)

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,8 @@ make perf                                             # timing report at two siz
 `make test` runs `PlenaryBustedDirectory` over `tests/codereview/`, which starts **one
 Neovim per spec file**. Each process builds its own fixture repository and gets its own
 throwaway state directory, so files neither share state nor need resetting between them.
-The whole suite is about 1,430 cases in ~5 seconds.
+The whole suite is about 1,590 cases in under ten seconds. A little over a second of that is
+one deliberate wait in `trim_spec` — see "a cache is invisible unless the clock moved".
 
 Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *without*
 `-u`, which loads your real config instead of `tests/minimal_init.lua`.
@@ -69,7 +70,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colors one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
-| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — every row of the listing read against git's own answer for the reading that row has always given, the oldest row at the merge base, the identity that does not move with the pre-image, the label, and the commit made afterwards that is in the review without the trim being touched — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, and where `gs` goes from it; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence beside one the branch still holds, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
+| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — every row of the listing read against git's own answer for the reading that row has always given, the oldest row at the merge base, the identity that does not move with the pre-image, the label, and the commit made afterwards that is in the review without the trim being touched; then the sets with a **hole** in them, which read from a pre-image that is built — the commit taken out of the middle, two that are not next to each other, the prefix reaching past the merge that must assemble nothing, the whole branch taken out, the commit no set can be built without, the same one succeeding beside what it depends on, the refs and the working tree the build must not touch, and the second resolve that finds the tree already built — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, where `gs` goes from it, and the pick that is refused — the sentence naming the commit and the file and no dependency, the store still holding the trim that was there, the review still on screen, and the same commit picked again beside the one it depends on; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence beside one the branch still holds, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
 | `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the row that removes the trim, the row a trim is marked on, the cursor's opening row, the keys, `gc` from the diff and from the tree, and the two refusals that open nothing |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
@@ -629,6 +630,35 @@ so the out-of-core language path is still checked locally without ever failing C
   against `git diff --name-status` for exactly this reason, and the oldest row is the row that
   reds when the anchor is wrong. Same trap as "a filter test needs a fixture only that filter
   can reject", arriving through the expectation instead of through the fixture.
+- **A pre-image is asserted by its delta and never by a tree object's identity.** A trim with a
+  hole in it reads from a tree that is built, and the tempting assertion is the tree oid —
+  cheap, exact, and it passes against a tree assembled the wrong way for as long as the
+  expectation was assembled the same wrong way, which is what happens when the expectation is
+  produced by a script that shares the implementation's rule. What a reviewer can see is which
+  files the review draws and how much of each, so that is what `trim_spec` compares. Names
+  alone are not enough either: taking out the commit that *added* `src/config_spec.lua` leaves
+  that path in the review, because a kept commit changed it afterwards — the counts (`+1 -1`
+  rather than the whole file arriving) are where a pre-image that took nothing out shows.
+- **Two cases in the matrix exist because reasoning got the rule wrong twice.** A prefix trim
+  reaching past the merge, and every commit taken out: both are ordinary readings, both are
+  refused outright by the obvious rule of accumulating from the merge base, and a suite without
+  them passes on a rule that breaks the shipped feature. Deleting the anchor in `git.lua`'s
+  `pre_image` — building from the base and applying the leading run as well — reds 29 cases in
+  `trim_spec`, and those two blocks are the ones that exist for it and nothing else. Measured.
+- **A cache is invisible unless the clock moved between the two builds.** The tree a hole
+  builds is cached on the repository, the base, `HEAD` and the set, and the claim is that a
+  second resolve does not build it again. A commit object carries the moment it was minted, so
+  two accumulations inside one second mint the *same* object — and "the second resolve produced
+  the same commit" then holds with nothing cached at all. `trim_spec` waits past a whole second
+  between the two, which is the only reason removing the cache reds that case; measured, it
+  reds that one and nothing else in the suite. Same trap as "a filter test needs a fixture only
+  that filter can reject".
+- **A refusal decided on the word `CONFLICT` cannot be told from one decided on the exit
+  status by any green suite.** Both refuse the fixture's dependent commit, because this git
+  prints that word. What separates them is a git that words it differently, which no CI runner
+  here has — so the case that has teeth is the mutation: making `merge_tree` ignore its exit
+  status and take the first line of the output as a tree reds six cases in `trim_spec`, four of
+  them about the refusal a reviewer reads. Run that mutation rather than trusting the green.
 - **"The whole set was dropped" needs a survivor that would have narrowed the review.** A trim
   is a set, and any commit failing the ancestry check drops all of it — but a store that kept
   the commits that passed opens the full branch anyway whenever the survivors have a hole in

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -99,6 +99,18 @@ local function taken_out_below(subject)
   return skipped
 end
 
+---The commits with these subjects, as the set a trim takes out — wherever they sit.
+---@param ... string
+---@return string[] skipped
+local function taken_out(...)
+  local skipped = {}
+  for _, subject in ipairs({ ... }) do
+    local commit = commit_named(subject)
+    skipped[#skipped + 1] = commit.sha
+  end
+  return skipped
+end
+
 --- Reading a scope back ----------------------------------------------------------
 
 ---Set the trim and resolve the branch scope through it, exactly as opening a review does.
@@ -128,6 +140,23 @@ local function status_of(files, path)
       return f.status
     end
   end
+end
+
+---How much of a file the review draws, in git's own two numbers.
+---
+---A path alone cannot tell the change one kept commit made to a file from the whole of that
+---file arriving with the commit that added it: both are the same name in the same list. The
+---counts are where a pre-image built from the wrong commits shows.
+---@param files CRFile[]
+---@param path string
+---@return string "+N -M", or a sentence when the review does not hold that file
+local function counts_of(files, path)
+  for _, f in ipairs(files) do
+    if f.path == path then
+      return ("+%d -%d"):format(f.added, f.removed)
+    end
+  end
+  return "not in the review at all"
 end
 
 --- The fixture the resolution rules lean on --------------------------------------
@@ -262,6 +291,201 @@ describe("no trim at all", function()
     assert.same({ "README.md", "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }, paths(files))
   end)
 end)
+
+--- A trim with a hole in it -------------------------------------------------------
+
+-- The commits taken out no longer have to be the ones at the start of the branch, so the
+-- review reads from a tree that never existed as a commit and has to be built. What is
+-- asserted here is the **delta** and never a tree object's identity: a comparison of tree
+-- oids passes against a tree assembled the wrong way for as long as the expectation was
+-- assembled the same wrong way. Which files the review draws, and how much of each, is what
+-- a reviewer can see and the only thing that can catch a pre-image built from the wrong
+-- commits.
+--
+-- Every case is set through the store and read back through resolution, which is the seam
+-- the block above already uses. The builder gets no seam of its own.
+
+describe("a commit taken out of the middle", function()
+  -- The commit that added `src/config_spec.lua`, with the commit older than it left in.
+  local files, scope = under_trim(taken_out("test: cover the config reader"))
+
+  it("keeps the commit older than it in the review", function()
+    assert.same("M", status_of(files, "src/config.lua"), vim.inspect(paths(files)))
+  end)
+
+  -- The teeth. The file the skipped commit *added* is still in the review, because a kept
+  -- commit changed it afterwards — but only that change is left. Read from the merge base
+  -- instead and the same path is there as an addition of the whole file, so a comparison of
+  -- names alone passes against a pre-image that took nothing out at all.
+  it("shows the file it added as the one line a kept commit changed in it", function()
+    assert.same("M", status_of(files, "src/config_spec.lua"), vim.inspect(paths(files)))
+    assert.same("+1 -1", counts_of(files, "src/config_spec.lua"))
+  end)
+
+  it("holds nothing else the skipped commit did", function()
+    assert.same({ "README.md", "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }, paths(files))
+  end)
+
+  it("says N of M in its label, which is the shape this reading has", function()
+    assert.is_truthy(scope.label:find(("%d of %d"):format(#commits - 1, #commits), 1, true), scope.label)
+  end)
+
+  it("still names the branch it is a review of", function()
+    assert.is_truthy(scope.label:find("branch vs ", 1, true), scope.label)
+  end)
+
+  -- The field a narrowed review's progress is read back under. It does not move with the
+  -- pre-image, and a synthesized pre-image is the furthest the two have ever been apart.
+  it("keeps the identity at the merge base", function()
+    assert.same(base, scope.identity)
+    assert.are_not.same(scope.before, scope.identity)
+  end)
+end)
+
+describe("two commits taken out that are not next to each other", function()
+  -- The oldest commit and the merge are kept, and they sit between the two taken out.
+  local files, scope = under_trim(taken_out("test: cover the config reader", "docs: write the readme"))
+
+  it("leaves out what both of them did", function()
+    assert.same({ "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }, paths(files))
+  end)
+
+  it("keeps the work of every commit between them", function()
+    assert.same("+1 -0", counts_of(files, "src/config.lua"))
+    assert.same("+2 -1", counts_of(files, "src/lexer.lua"))
+  end)
+
+  it("counts what is left in its label", function()
+    assert.is_truthy(scope.label:find(("%d of %d"):format(#commits - 2, #commits), 1, true), scope.label)
+  end)
+end)
+
+-- The case that caught the first design. Accumulating every skipped commit from the merge
+-- base refuses this one — the merge's own diff adds what the side branch brought while the
+-- base already holds it — and it is the shipped `gc` flow on any branch with a merge in it.
+-- Anchored, it assembles nothing at all and reads what it has always read.
+describe("a trim reaching past the merge", function()
+  local merge = commit_named("Merge branch 'lexer' into feature")
+  local files, scope = under_trim(taken_out_below("test: assert the host as well"))
+
+  it("reads from the merge itself, so nothing was assembled", function()
+    assert.same(merge.sha, scope.before)
+  end)
+
+  it("draws exactly what the shipped trim drew for that reading", function()
+    local expected = h.git_lines(fixture, { "diff", "--name-status", merge.sha })
+    assert.same(
+      expected,
+      vim.tbl_map(function(f)
+        return ("%s\t%s"):format(f.status, f.path)
+      end, files)
+    )
+  end)
+
+  it("says last N, because that is the shape this reading has", function()
+    assert.is_truthy(scope.label:find(("last %d"):format(#commits - 3), 1, true), scope.label)
+  end)
+end)
+
+-- The other case that caught it, and for the same reason: from the merge base this collides
+-- on the merge, and anchored it is the whole branch's newest commit and nothing is built.
+describe("every commit taken out", function()
+  local everything = vim.tbl_map(function(c)
+    return c.sha
+  end, commits)
+  local files, scope = under_trim(everything)
+
+  it("reads from the branch's own tip", function()
+    assert.same(full("HEAD"), scope.before)
+  end)
+
+  it("leaves a review of the reviewer's uncommitted work, which is nothing here", function()
+    assert.same({}, paths(files))
+  end)
+
+  it("says it holds none of them", function()
+    assert.is_truthy(scope.label:find(("0 of %d"):format(#commits), 1, true), scope.label)
+  end)
+end)
+
+-- A skip that cannot be built, at the seam where nothing can be said about it: resolution
+-- has no reviewer in front of it. The refusal a reviewer reads is at the pick, in the view
+-- half of this file.
+describe("a commit whose work a kept commit rewrote", function()
+  local files, scope = under_trim(taken_out("test: assert the host as well"))
+
+  it("gives the whole branch back rather than a reading nothing could assemble", function()
+    assert.same({ "README.md", "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }, paths(files))
+  end)
+
+  it("says nothing about a trim it could not read", function()
+    assert.is_nil(scope.label:find("last", 1, true), scope.label)
+    assert.is_nil(scope.label:find(" of ", 1, true), scope.label)
+  end)
+end)
+
+describe("the commit it depends on taken out beside it", function()
+  local files, scope = under_trim(taken_out("test: cover the config reader", "test: assert the host as well"))
+
+  -- Both commits that ever touched that file are out, so the file is in the pre-image
+  -- exactly as the working tree has it and the review says nothing about it. A pre-image
+  -- that stopped at the first of the two would draw it, which is the whole difference
+  -- between applying the set and reading from one commit in it.
+  it("takes the file both of them touched out of the review", function()
+    assert.same({ "README.md", "src/config.lua", "src/lexer.lua" }, paths(files))
+  end)
+
+  it("counts what is left in its label", function()
+    assert.is_truthy(scope.label:find(("%d of %d"):format(#commits - 2, #commits), 1, true), scope.label)
+  end)
+end)
+
+-- The synthesized commit is unreachable on purpose, which is the exposure the **snapshot**
+-- mechanism already accepts. Nothing about building it may reach the reviewer's repository:
+-- no ref to keep it alive, no index, no working tree.
+describe("what building a pre-image must not touch", function()
+  local refs = h.git_lines(fixture, { "for-each-ref", "--format=%(refname) %(objectname)" })
+  local head = full("HEAD")
+  local _, scope = under_trim(taken_out("test: cover the config reader", "docs: write the readme"))
+
+  it("built a commit this repository really holds", function()
+    assert.same({ "commit" }, h.git_lines(fixture, { "cat-file", "-t", scope.before }))
+  end)
+
+  it("wrote no ref for it", function()
+    assert.same(refs, h.git_lines(fixture, { "for-each-ref", "--format=%(refname) %(objectname)" }))
+    assert.same({}, h.git_lines(fixture, { "branch", "--contains", scope.before }))
+  end)
+
+  it("left the index and the working tree alone", function()
+    assert.same({}, h.git_lines(fixture, { "status", "--porcelain" }))
+  end)
+
+  it("left HEAD where it was", function()
+    assert.same(head, full("HEAD"))
+  end)
+end)
+
+-- Cycling scopes and reopening a review both resolve again, and a reviewer who narrowed a
+-- long branch pays the whole accumulation on each of them without a cache.
+--
+-- **A cache is invisible unless the clock moved between the two builds.** A commit object
+-- carries the moment it was minted, so two accumulations inside one second mint the same
+-- object and this case would hold with nothing cached at all — the trap that a filter test
+-- needs a fixture only that filter can reject. The wait is what gives it teeth: measured,
+-- removing the cache reds it and nothing else in the suite.
+describe("the tree a hole builds, resolved a second time", function()
+  local skipped = taken_out("test: cover the config reader", "docs: write the readme")
+  local _, first = under_trim(skipped)
+  vim.wait(1100)
+  local _, again = under_trim(skipped)
+
+  it("is the commit the first resolve built, not a second one", function()
+    assert.same(first.before, again.before)
+  end)
+end)
+
+state.set_trim(root, nil)
 
 describe("what a trim never moves", function()
   local _, trimmed = under_trim(taken_out_below("Merge branch 'lexer' into feature"))
@@ -615,6 +839,117 @@ describe("work committed after the trim was picked", function()
   end)
 end)
 
+--- A pick that cannot be built ------------------------------------------------------
+
+-- Taking one commit out can need a commit that is staying, and such a pick is refused
+-- rather than approximated — at the moment it is applied, before anything is stored. What
+-- the reviewer can see is the sentence, a store still holding the trim they had, and the
+-- review on screen unchanged.
+--
+-- Applied through `view.trim_to`, which is the one entry point a pick goes through. No key
+-- reaches a set with a hole in it yet: the float still picks a start.
+describe("a commit whose work a kept commit rewrote, picked", function()
+  local W = assert(view.current())
+  local was_paths = paths(W.files)
+  local was_label = W.scope.label
+  local was_trim = vim.deepcopy(assert(state.trim(root), "this review is not trimmed, so nothing can be untouched"))
+
+  local dependent = commit_named("test: assert the host as well")
+  local dependency = commit_named("test: cover the config reader")
+  local short = assert(h.git_lines(fixture, { "rev-parse", "--short", dependent.sha })[1])
+
+  local msgs, restore = h.capture_notify()
+  view.trim_to({ dependent.sha })
+  restore()
+
+  it("names the commit it refused", function()
+    assert.is_true(h.notified(msgs, short), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, dependent.subject), vim.inspect(msgs))
+  end)
+
+  it("names the file it conflicts in", function()
+    assert.is_true(h.notified(msgs, "src/config_spec.lua"), vim.inspect(msgs))
+  end)
+
+  -- Which kept commit introduced the conflicting region takes a heuristic that can name the
+  -- wrong commit confidently, so the message names none. The commit this one really does
+  -- depend on is the one the message must not claim to have found.
+  it("names no commit it might have depended on", function()
+    local short_dependency = assert(h.git_lines(fixture, { "rev-parse", "--short", dependency.sha })[1])
+    assert.is_false(h.notified(msgs, short_dependency), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, dependency.subject), vim.inspect(msgs))
+  end)
+
+  it("leaves the store holding the trim the reviewer already had", function()
+    assert.same(was_trim, state.trim(root))
+  end)
+
+  it("leaves the review that was on screen exactly as it was", function()
+    local X = assert(view.current(), "the review view closed")
+    assert.same(was_paths, paths(X.files))
+    assert.same(was_label, X.scope.label)
+  end)
+end)
+
+describe("the commit it depends on picked beside it", function()
+  local dependent = commit_named("test: assert the host as well")
+  local dependency = commit_named("test: cover the config reader")
+  local listed = assert(git.branch_commits(root, base))
+
+  local msgs, restore = h.capture_notify()
+  view.trim_to({ dependency.sha, dependent.sha })
+  restore()
+  local W = assert(view.current())
+
+  it("refuses nothing", function()
+    assert.is_false(h.notified(msgs, "conflicts"), vim.inspect(msgs))
+  end)
+
+  it("draws the review the two of them are out of", function()
+    assert.same({
+      "README.md",
+      "src/config.lua",
+      "src/config_spec.lua",
+      "src/late.lua",
+      "src/lexer.lua",
+      "src/loose.lua",
+    }, paths(W.files))
+  end)
+
+  it("counts what is left on the winbar", function()
+    local bar = h.winbar(W.win)
+    assert.is_truthy(bar:find(("%d of %d"):format(#listed - 2, #listed), 1, true), bar)
+  end)
+
+  it("stored it, so the next resolve reads the same review", function()
+    assert.same({ dependency.sha, dependent.sha }, state.trim(root))
+  end)
+end)
+
+-- The maximal trim: the review is the work the reviewer has not committed, which is what
+-- the file left uncommitted and untracked several blocks above.
+describe("every commit taken out, in the review", function()
+  local listed = assert(git.branch_commits(root, base))
+  view.trim_to(vim.tbl_map(function(c)
+    return c.id
+  end, listed))
+  local W = assert(view.current())
+
+  it("holds the reviewer's uncommitted and untracked work and nothing else", function()
+    assert.same({ "src/config_spec.lua", "src/loose.lua" }, paths(W.files))
+  end)
+
+  it("still keeps the untracked file as untracked work", function()
+    assert.same("U", status_of(W.files, "src/loose.lua"), vim.inspect(paths(W.files)))
+  end)
+
+  it("says on the winbar that it holds none of the branch's commits", function()
+    local bar = h.winbar(W.win)
+    assert.is_truthy(bar:find(("0 of %d"):format(#listed), 1, true), bar)
+  end)
+end)
+
+state.set_trim(root, nil)
 codereview.close()
 
 --- The trim a session leaves behind -----------------------------------------------


### PR DESCRIPTION
A **trim** could already hold any set of commits, but every set it could resolve was a
prefix: the anchor covered the whole set, and a set with a commit above the run gave the
whole branch back. This is the part above the run — a trim with a **hole** in it, which
reads from a tree that never existed as a commit and therefore has to be built.

## The rule

```
run = how far the skipped set matches the branch from its oldest commit up
T   = (run > 0) ? the newest commit in that run : the merge base
for each skipped commit S above the run, oldest first:
    tree = git merge-tree --write-tree --name-only --merge-base=S^  T  S
    T    = git commit-tree tree -p T -m <synthesized>
before = T
```

**The anchor is not an optimization.** Accumulating every skipped commit from the merge
base instead refuses a plain prefix trim reaching past a merge — the shipped `gc` flow on
any branch with a merge in it — and refuses taking every commit out. Both were measured
against a real repository, and both are ordinary readings. Anchored, a trim with no hole
merges nothing at all, which is also what keeps the git 2.38 floor `merge-tree` sets off
the trim that already ships.

## The case matrix

| Set taken out | What resolves |
| --- | --- |
| nothing | the whole branch, four files |
| the oldest commit | `src/config.lua` out; the rest in |
| a prefix of two | reads from the second commit's own tree |
| **a prefix reaching past the merge** | reads from the merge itself, and draws exactly what `git diff <merge>` draws |
| **every commit** | reads from the branch tip; the review is the reviewer's uncommitted and untracked work |
| a middle commit that only adds a file | the file it added stays in as the one line a kept commit changed in it (`+1 -1`), not as the whole file |
| two that are not next to each other | both are out, everything between them is in |
| the dependent commit alone | **refused**, naming that commit and `src/config_spec.lua` |
| the dependent commit and what it depends on | succeeds; the file both touched leaves the review |

The two emphasised rows are the ones that caught the first design. A suite without them
passes on a rule that breaks the shipped feature.

## Refusal

Decided on the merge's **exit status**, with the paths read from `--name-only`. Searching
the output for the word `CONFLICT` would report a conflicting merge as clean wherever that
wording differs — a false negative in the one direction that ships a review built from a
tree that could not be assembled. The refusal happens at the pick, before anything is
stored, so the store still holds the trim the reviewer had and the review on screen is the
review that was there. It names the skipped commit and the files, and no dependency
commit: which kept commit introduced the conflicting region takes a heuristic that can
name the wrong one confidently.

Taking a merge out of the middle refuses like any other commit here, naming files. The
sentence about merges is #153's.

## The cache

The built tree is cached module-local, keyed on the repository, the base, the `HEAD` sha
and the set. The recorded trap about memoising a trim is a stored sha going stale against a
rewritten `HEAD`; a key that holds `HEAD` cannot do that, because either key moving is a
new key. Nothing else is cached — not the trim, not its ancestry answer, not the resolved
scope. The case that measures it waits past a whole second, because two accumulations
inside one second mint the same object and the assertion would otherwise hold with nothing
cached at all.

## Elsewhere

- `ADR-0006` records the synthesized pre-image and the two rejected alternatives:
  concatenated per-commit patches, and attributing diff lines to commits to hide the
  skipped ones — kept on the record as the escape hatch if refusals prove to be the norm.
- `CONTEXT.md`'s **Trim** entry is rewritten: the commits taken out, wherever they sit,
  with the one-end clause replaced by the reason the working tree survives every trim.
- The README and `:help` state the git 2.38 floor as what taking a commit out of the
  *middle* needs, not what a trim needs.
- `docs/design-notes.md` gains the anchor, the exit-status rule and the one thing that is
  cached, beside the note that refuses memoising a trim.
- No ref is written. The synthesized commit is unreachable, which is the exposure the
  **snapshot** mechanism already accepts.

`make all` passes: 1,591 cases, 0 failures, 0 errors, exit 0. Measured teeth: deleting the
anchor reds 29 cases, ignoring the merge's exit status reds 6, removing the cache reds 1.

Closes #151
