### PR TITLE
feat(git): refuse a merge taken out of the middle of a trim

### DIFF
--- a/docs/adr/0006-a-trim-with-a-hole-synthesizes-its-pre-image.md
+++ b/docs/adr/0006-a-trim-with-a-hole-synthesizes-its-pre-image.md
@@ -45,6 +45,17 @@ as a failure. It names the skipped commit and the files it conflicts in, and no 
 commit: which kept commit introduced the conflicting region takes a heuristic pass that can
 name the wrong commit confidently.
 
+**A merge cannot start a hole.** A merge above the run collides wholesale, for the reason the
+anchor exists at all: its first-parent diff adds everything the side branch brought, and the
+anchor already holds it. That one is refused before any merge is attempted, and the sentence
+is about merges rather than about files — merging the default branch moves the merge base
+forward, so what the merge brought is already outside the review, and the files it would
+collide in are files the reviewer did not write and cannot act on. The same merge taken off
+the *start* of the branch, with every commit older than it taken off too, is inside the run:
+it assembles nothing and reads what a trim past a merge has always read. So the rule is
+dynamic — one row, free or refused by what else the trim takes — and no surface can grey it
+out ahead of time.
+
 The merge is `git merge-tree --write-tree`, which sets a floor of **git 2.38**. Only a trim
 with a hole in it reaches it, so the floor gates the new selections and not the trim that
 already ships, and the README states it that way.

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -318,6 +318,24 @@ is the whole answer, exactly as it is for `all_ancestors` behind a stored trim, 
 come from `--name-only`, which prints the tree object and then one path per line. Making the
 merge ignore its exit status reds six cases in `trim_spec`.
 
+**A merge cannot start a hole, and the rule is about where the merge sits rather than about
+the row.** Taking a merge out with a commit older than it left in always collides, by the
+same arithmetic that made the anchor necessary: the merge's first-parent diff *adds*
+everything the side branch brought, and the anchor already holds it. The collision also means
+nothing to the reviewer — merging the default branch moves the merge base forward, so what
+the merge brought is already outside the review, and the files `merge-tree` would name are
+files they did not write and cannot act on. So such a set is refused **before any merge is
+attempted**, with a sentence about merges and no file in it. Attempting it first and
+rewording what git said is the same answer with better prose.
+The rule is therefore **dynamic**: the same merge taken off the *start* of the branch, with
+every commit older than it taken off too, is inside the leading run — it assembles nothing,
+and it is the shipped `gc` flow on any branch with a merge in it. A skipped merge above the
+run is exactly a merge with a kept commit older than it, which is why no surface can grey the
+row out ahead of time. Measured, in `trim_spec`: asking the question of the whole skipped set
+rather than the part above the run reds the three cases written for a hole above a merge the
+trim takes off the start; asking it before a plain prefix has returned reds 32, the shipped
+prefix trim among them; and not asking it at all reds the two that are the sentence.
+
 **Keying progress on the pre-image fails silently rather than loudly.** The per-scope progress
 key is `name .. ":" .. identity`. Spelled with `before` it agrees with the plugin for every
 scope that carries no trim, so it reads correctly everywhere until a trimmed branch review is

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -311,6 +311,21 @@ local function refusal(commit, conflicts, err)
   return ("Taking out %s %s could not be assembled — %s"):format(commit.sha, commit.subject, err or "git refused it")
 end
 
+---What a reviewer is told when they take a merge out of the middle of a trim.
+---
+---**It names no file**, and that is the whole difference between this sentence and the one
+---above it. The files a merge collides in are every file the side branch brought: the
+---reviewer did not write them, did not ask about them, and can do nothing with a list of
+---them. What they can act on is the reason, and the reason is that the merge is not the
+---thing they think they are taking out: merging the default branch moves the merge base
+---forward, so everything that merge brought is already outside this review.
+---@param commit CRCommit
+---@return string
+local function merge_refusal(commit)
+  local named = ("Taking out the merge %s %s is not needed"):format(commit.sha, commit.subject)
+  return named .. ": a merge brings nothing the review does not already read — the review is unchanged"
+end
+
 ---What a **trim** leaves a branch review reading from.
 ---
 ---A trim is the commits taken out, so the review has to read from a tree that already holds
@@ -334,10 +349,28 @@ end
 ---
 ---Above the run each skipped commit is **three-way merged onto the accumulation, oldest
 ---first**, and a commit object is minted between steps because `merge-tree` merges commits
----rather than trees. Only a set with a hole in it gets that far. **No ref is written**: the
----synthesized commit is unreachable, which is the exposure `snapshot` already accepts, and
----git's default prune window is two weeks -- an automatic collection cannot take a commit
----minted minutes ago, and the cache re-mints on the next resolve if an explicit prune does.
+---rather than trees. Only a set with a hole in it gets that far, and a **merge** above the
+---run never gets that far at all: the rule below refuses it first. **No ref is written**:
+---the synthesized commit is unreachable, which is the exposure `snapshot` already accepts,
+---and git's default prune window is two weeks -- an automatic collection cannot take a
+---commit minted minutes ago, and the cache re-mints on the next resolve if an explicit
+---prune does.
+---
+---**A merge cannot start a hole**, and the refusal comes before any merge is attempted. A
+---merge above the run collides wholesale, for the same reason the anchor exists: its
+---first-parent diff *adds* everything the side branch brought, and the anchor already holds
+---it. Attempting it would answer the reviewer with a list of files they did not touch and
+---cannot act on, so what they are told instead is the reason -- and the reason is that the
+---merge brings this review nothing. Merging the default branch moves the merge base
+---forward, so what the merge brought is already outside the review: taking it out of the
+---middle is unnecessary as well as impossible.
+---
+---The rule is **dynamic**, which is the point of it. The same merge taken off the *start* of
+---the branch, with every commit older than it taken off too, is inside the run: it assembles
+---nothing and reads what a trim past a merge has always read. Only a merge with a kept
+---commit older than it is refused -- which is exactly a skipped merge above the run -- so the
+---same row is free or refused depending on what else the trim takes, and no surface can grey
+---it out ahead of time.
 ---
 ---The branch's commits are read back through `branch_commits`, which is the listing the
 ---reviewer picked off. One rule for which commits are on the branch, for the reason there is
@@ -349,7 +382,7 @@ end
 ---@param base string The merge base: where the branch starts
 ---@param skipped string[] The commits the trim takes out
 ---@return CRTrim|nil trim nil when the set cannot be read from or cannot be built
----@return string|nil refused The sentence a reviewer is told, when a merge conflicted
+---@return string|nil refused The sentence a reviewer is told, when the set is refused
 local function pre_image(root, base, skipped)
   local commits = M.branch_commits(root, base)
   if not commits then
@@ -377,6 +410,17 @@ local function pre_image(root, base, skipped)
   if not trim.hole then
     trim.before = anchor
     return trim, nil
+  end
+
+  -- A merge cannot start a hole, refused here rather than attempted -- see the header. The
+  -- walk is the accumulation's own: from the row above the run up to the newest, so the merge
+  -- named is the one the build would have met first. A merge *inside* the run is never
+  -- reached, which is what leaves a trim past a merge free while this one is refused.
+  for i = #commits - run, 1, -1 do
+    local commit = commits[i]
+    if taken[commit.id] and commit.merge then
+      return nil, merge_refusal(commit)
+    end
   end
 
   local key = cache_key(root, base, skipped)
@@ -421,7 +465,7 @@ end
 ---
 ---A set this cannot read from at all -- one holding a commit the branch does not list -- is
 ---not a refusal. That is the shipped answer for a trim nothing can resolve: the whole branch
----opens, and the reviewer is not told a sentence about a merge that was never attempted.
+---opens, and the reviewer is not told a sentence about a build that was never begun.
 ---@param root string
 ---@param base string The merge base: the review's own scope identity
 ---@param skipped string[]|nil
@@ -844,6 +888,7 @@ end
 ---@field id string       Full sha: what a **trim** that takes this commit out is stored as
 ---@field when string     How long ago it was authored, in git's own words
 ---@field subject string  The commit's first line
+---@field merge boolean   Whether it has a second parent: a **trim** cannot start a hole here
 
 ---Every commit the branch carries, newest first.
 ---
@@ -865,6 +910,11 @@ end
 ---by; the full sha is what a **trim** taking that commit out is stored as, because git
 ---abbreviates to whatever the repository needs at the moment it is asked, a repository
 ---grows, and a trim outlives the length it was picked at.
+---
+---Each one also says whether it is a **merge**, read off the parents this same listing
+---already knows: a merge cannot start a hole in a trim, and the rule that refuses one is a
+---rule about a row of *this* listing. Asked for separately it would be a second walk of the
+---branch and a second answer to which commits are on it.
 ---@param root string
 ---@param base string Where the branch starts: the scope's identity
 ---@return CRCommit[]|nil commits, string|nil err
@@ -876,7 +926,10 @@ function M.branch_commits(root, base)
   local out, err = run({
     "log",
     "--first-parent",
-    "--format=%h%x1f%H%x1f%ar%x1f%s",
+    -- `%P` is every parent, space-separated, so a second one is what says *merge*. It goes
+    -- after the two sha fields, which are matched as one word each and a parent list is not
+    -- one word, and before the subject, which is still the one field nothing is parsed after.
+    "--format=%h%x1f%H%x1f%P%x1f%ar%x1f%s",
     base .. "..HEAD",
     -- A long branch's log is closer to a diff than to a metadata query.
   }, { cwd = root, timeout = DIFF_TIMEOUT_MS })
@@ -886,9 +939,15 @@ function M.branch_commits(root, base)
 
   local commits = {}
   for _, entry in ipairs(vim.split(out, "\n", { trimempty = true })) do
-    local sha, id, when, subject = entry:match("^(%S+)\31(%S+)\31(.-)\31(.*)$")
+    local sha, id, parents, when, subject = entry:match("^(%S+)\31(%S+)\31(.-)\31(.-)\31(.*)$")
     if sha then
-      commits[#commits + 1] = { sha = sha, id = id, when = when, subject = subject }
+      commits[#commits + 1] = {
+        sha = sha,
+        id = id,
+        when = when,
+        subject = subject,
+        merge = parents:find(" ", 1, true) ~= nil,
+      }
     end
   end
   return commits, nil

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,7 +70,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `quiet_spec` | Where **faded**, **dimmed** and **muted** meet: a queued entry and an archived one inside a faded file, the mark that draws them carrying no group of its own, the namespace a muted pane draws through holding no entry for the fade's family and a definition to fall back to — and the cells eight child processes read, at four colors one token can hold |
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
-| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — every row of the listing read against git's own answer for the reading that row has always given, the oldest row at the merge base, the identity that does not move with the pre-image, the label, and the commit made afterwards that is in the review without the trim being touched; then the sets with a **hole** in them, which read from a pre-image that is built — the commit taken out of the middle, two that are not next to each other, the prefix reaching past the merge that must assemble nothing, the whole branch taken out, the commit no set can be built without, the same one succeeding beside what it depends on, the refs and the working tree the build must not touch, and the second resolve that finds the tree already built — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, where `gs` goes from it, and the pick that is refused — the sentence naming the commit and the file and no dependency, the store still holding the trim that was there, the review still on screen, and the same commit picked again beside the one it depends on; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence beside one the branch still holds, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
+| `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — every row of the listing read against git's own answer for the reading that row has always given, the oldest row at the merge base, the identity that does not move with the pre-image, the label, and the commit made afterwards that is in the review without the trim being touched; then the sets with a **hole** in them, which read from a pre-image that is built — the commit taken out of the middle, two that are not next to each other, the prefix reaching past the merge that must assemble nothing, the whole branch taken out, the commit no set can be built without, the same one succeeding beside what it depends on, the refs and the working tree the build must not touch, and the second resolve that finds the tree already built; then the **merge** on both sides of the rule that refuses it — taken out with an older commit left in, taken off the start of the branch with a hole above it, and a hole on a branch of its own with no merge on its first-parent line at all — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, where `gs` goes from it, and the pick that is refused — the sentence naming the commit and the file and no dependency, the store still holding the trim that was there, the review still on screen, and the same commit picked again beside the one it depends on; the merge picked out of the middle, whose sentence names no file at all, and the same merge picked off the start of the branch, which draws what the shipped trim drew; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence beside one the branch still holds, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
 | `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the row that removes the trim, the row a trim is marked on, the cursor's opening row, the keys, `gc` from the diff and from the tree, and the two refusals that open nothing |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
@@ -113,11 +113,18 @@ interchangeable, and the assertions know which one they are looking at.
   so it is the only commit here that cannot leave a review on its own — without it a
   refusal has nothing to refuse, which is "a filter test needs a fixture only that filter
   can reject". Its commits are dated days apart, as offsets back from the moment the script
-  runs, so a relative date on a row is a fact a spec can check and never goes stale. `trim_spec` builds a **second copy**
+  runs, so a relative date on a row is a fact a spec can check and never goes stale. The merge
+  is a third rule of its own: it is free on the row that takes it off the start of the branch
+  and refused with a commit older than it left in, and one history holding one merge is what
+  lets a spec make both claims about one row. `trim_spec` builds a **second copy**
   for the trim a restart brings back, and cuts a `second` branch at `feature`'s tip inside
   it: two branches over one history is what "each branch keeps its own trim" needs, and
   neither branch the script builds can offer it — `lexer` has one commit of its own, so
-  every trim on it resolves to the merge base, which is the review it already was.
+  every trim on it resolves to the merge base, which is the review it already was. It builds
+  a **third copy** for the opposite shape, and cuts a `flat` branch of three ordinary commits
+  off master's tip inside it: a first-parent line with no merge on it, which is what "a branch
+  with no merge in it is untouched by the merge rule" needs and which no branch over this
+  history has.
 - **`mkbig.sh`** — files of a given size, half of every file rewritten. It takes counts as
   well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and 200), so a caller
   asks for the height it needs rather than for a second script. `perf.lua` builds a 60-file,
@@ -645,6 +652,18 @@ so the out-of-core language path is still checked locally without ever failing C
   them passes on a rule that breaks the shipped feature. Deleting the anchor in `git.lua`'s
   `pre_image` — building from the base and applying the leading run as well — reds 29 cases in
   `trim_spec`, and those two blocks are the ones that exist for it and nothing else. Measured.
+- **The merge rule needs both of its answers, and one row can only give one of them.** A merge
+  taken out with an older commit left in is refused; the same merge taken off the *start* of
+  the branch is free, assembles nothing, and is the shipped `gc` flow on any branch with a
+  merge in it. A block that asserts only the refusal is satisfied by a rule that refuses every
+  set holding a merge, which breaks the trim that already ships — so `trim_spec` makes both
+  claims about the one merge the fixture has, and adds a third selection where the merge is
+  taken off the start *and* a commit above it is taken out, which is the only case that can
+  tell "where the merge sits" from "the set holds a merge". Measured: that mutation reds those
+  three cases and nothing else; asking the same question before a plain prefix has returned
+  reds 32; not asking it at all reds the two that are the sentence. And "a branch with no merge
+  in it is unaffected" is a claim no branch over this history can make, so it is made over a
+  `flat` branch built for it.
 - **A cache is invisible unless the clock moved between the two builds.** The tree a hole
   builds is cached on the repository, the base, `HEAD` and the set, and the claim is that a
   second resolve does not build it again. A commit object carries the moment it was minted, so

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -408,6 +408,124 @@ describe("every commit taken out", function()
   end)
 end)
 
+--- A merge, on either side of the rule ---------------------------------------------
+
+-- One merge, on one branch, in three selections -- because no one selection can state this
+-- rule. Taken off the *start* of the branch it is inside the leading run: it assembles nothing
+-- and reads what a trim past a merge has always read, which is the block two above this one
+-- and the shipped `gc` flow on any branch with a merge in it. Taken out with a commit older
+-- than it left in, it is refused before any merge is attempted: its first-parent diff adds
+-- everything the side branch brought while the anchor already holds it, and what it brought is
+-- outside the review in the first place. Taken off the start with a commit above it taken out
+-- as well, it is inside the run *and* the trim has a hole, which is the only selection that
+-- can tell "where the merge sits" from "the set holds a merge".
+--
+-- What resolution can show of a refusal is only that it did not narrow the review. The
+-- sentence a reviewer reads is at the pick, in the view half of this file.
+describe("the merge taken out of the middle", function()
+  -- Resolution has no reviewer in front of it, so a refused set does here what every set that
+  -- cannot be built does: it gives the whole branch back.
+  local files, scope = under_trim(taken_out("Merge branch 'lexer' into feature"))
+
+  it("gives the whole branch back rather than a reading it refused to build", function()
+    assert.same({ "README.md", "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }, paths(files))
+  end)
+
+  it("says nothing about a trim it refused", function()
+    assert.is_nil(scope.label:find("last", 1, true), scope.label)
+    assert.is_nil(scope.label:find(" of ", 1, true), scope.label)
+  end)
+end)
+
+-- The rule is about where the merge sits and never about the set holding one, and this is the
+-- case that can tell those two apart. The merge is inside the run, so it merges nothing --
+-- and a commit above the run is taken out beside it, so a tree really is assembled. A rule
+-- written as "refuse a set with a merge in it" passes every other block in this file and reds
+-- this one.
+describe("a hole above a merge the trim takes off the start", function()
+  local merge = commit_named("Merge branch 'lexer' into feature")
+  -- Everything up to and including the merge, and the newest commit as well. What is left in
+  -- the review is the one commit between them.
+  local skipped = taken_out_below("test: assert the host as well")
+  vim.list_extend(skipped, taken_out("docs: write the readme"))
+  local files, scope = under_trim(skipped)
+
+  it("refuses nothing, and holds only the commit it kept", function()
+    assert.same({ "src/config_spec.lua" }, paths(files))
+    assert.same("+1 -1", counts_of(files, "src/config_spec.lua"))
+  end)
+
+  -- The teeth against an anchor that stopped at the merge and applied nothing above it: the
+  -- readme the newest commit wrote is out of this review, and only a built tree takes it out.
+  it("built a tree, so the pre-image is no commit on this branch", function()
+    assert.are_not.same(merge.sha, scope.before)
+    assert.same({ "commit" }, h.git_lines(fixture, { "cat-file", "-t", scope.before }))
+    assert.same({}, h.git_lines(fixture, { "branch", "--contains", scope.before }))
+  end)
+
+  it("counts the one commit it kept", function()
+    assert.is_truthy(scope.label:find(("1 of %d"):format(#commits), 1, true), scope.label)
+  end)
+end)
+
+-- **A branch with no merge on its first-parent line is untouched by the rule**, and the
+-- history this spec reads cannot say so on its own: every listing of it holds the merge. So a
+-- second copy of the fixture, and a branch cut off master's tip with three ordinary commits
+-- on it -- a first-parent line the rule has nothing to fire on. A hole in the middle of it is
+-- built and drawn exactly as it was before the rule existed.
+--
+-- Its own repository throughout, so nothing here can be answered out of what the blocks above
+-- did to the fixture they share, and nothing here reaches them.
+describe("a hole on a branch with no merge in it", function()
+  local flat = h.fixture("mkcommits")
+  local flat_root = assert(vim.uv.fs_realpath(flat))
+  h.git_lines(flat, { "checkout", "-q", "-b", "flat", "master" })
+
+  ---@param name string
+  ---@param body string[]
+  ---@param subject string
+  local function commit(name, body, subject)
+    vim.fn.writefile(body, vim.fs.joinpath(flat, name))
+    h.git_lines(flat, { "add", "-A" })
+    h.git_lines(flat, { "commit", "-q", "-m", subject })
+  end
+
+  commit("src/flat_one.lua", { "local one = 1" }, "feat: write the first file")
+  commit("src/flat_two.lua", { "local two = 2" }, "feat: write the second file")
+  commit("src/flat_one.lua", { "local one = 1", "local three = 3" }, "feat: write the first file again")
+
+  local flat_base = assert(h.git_lines(flat, { "merge-base", "master", "HEAD" })[1], "no merge base")
+  local listed = assert(git.branch_commits(flat_root, flat_base))
+  -- The middle row: the only hole a three-commit branch has.
+  local middle = listed[2]
+
+  it("lists a first-parent line with no merge on it", function()
+    assert.same(3, #listed, vim.inspect(listed))
+    for _, c in ipairs(listed) do
+      assert.is_false(c.merge, c.subject)
+    end
+  end)
+
+  state.set_trim(flat_root, { middle.id })
+  local scope = assert(git.resolve_scope("branch", flat_root))
+  local files = assert(git.collect(scope, flat_root, {}))
+
+  it("refuses nothing", function()
+    assert.is_nil(git.trim_refusal(flat_root, flat_base, { middle.id }))
+  end)
+
+  it("draws the two commits it kept and not the one it took out", function()
+    assert.same({ "src/flat_one.lua" }, paths(files))
+    assert.same("+2 -0", counts_of(files, "src/flat_one.lua"))
+  end)
+
+  it("counts what is left in its label", function()
+    assert.is_truthy(scope.label:find("2 of 3", 1, true), scope.label)
+  end)
+
+  state.set_trim(flat_root, nil)
+end)
+
 -- A skip that cannot be built, at the seam where nothing can be said about it: resolution
 -- has no reviewer in front of it. The refusal a reviewer reads is at the pick, in the view
 -- half of this file.
@@ -923,6 +1041,94 @@ describe("the commit it depends on picked beside it", function()
 
   it("stored it, so the next resolve reads the same review", function()
     assert.same({ dependency.sha, dependent.sha }, state.trim(root))
+  end)
+end)
+
+-- The merge picked out of the middle, which is the one refusal that is not about files. What
+-- the reviewer is told is that the merge brings this review nothing: merging the default
+-- branch moves the merge base forward, so what it brought is already outside the reading.
+-- Naming the files it would have collided in would answer a question they did not ask with a
+-- list they did not write and cannot act on.
+describe("the merge picked out of the middle", function()
+  local W = assert(view.current())
+  local was_paths = paths(W.files)
+  local was_label = W.scope.label
+  local was_trim = vim.deepcopy(assert(state.trim(root), "this review is not trimmed, so nothing can be untouched"))
+
+  local merge = commit_named("Merge branch 'lexer' into feature")
+  local short = assert(h.git_lines(fixture, { "rev-parse", "--short", merge.sha })[1])
+
+  local msgs, restore = h.capture_notify()
+  view.trim_to({ merge.sha })
+  restore()
+
+  it("says a merge brings nothing the review does not already read", function()
+    assert.is_true(h.notified(msgs, "brings nothing the review does not already read"), vim.inspect(msgs))
+  end)
+
+  it("names the merge it refused", function()
+    assert.is_true(h.notified(msgs, short), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, merge.subject), vim.inspect(msgs))
+  end)
+
+  -- The teeth against a rule that attempts the merge and rewords what `merge-tree` said: that
+  -- is the same answer with better prose, and it names every file the side branch brought.
+  it("names no file it would have collided in", function()
+    for _, path in ipairs({ "README.md", "src/config.lua", "src/config_spec.lua", "src/lexer.lua" }) do
+      assert.is_false(h.notified(msgs, path), vim.inspect(msgs))
+    end
+    assert.is_false(h.notified(msgs, "conflicts in"), vim.inspect(msgs))
+  end)
+
+  it("leaves the store holding the trim the reviewer already had", function()
+    assert.same(was_trim, state.trim(root))
+  end)
+
+  it("leaves the review that was on screen exactly as it was", function()
+    local X = assert(view.current(), "the review view closed")
+    assert.same(was_paths, paths(X.files))
+    assert.same(was_label, X.scope.label)
+  end)
+end)
+
+-- The same row, taken off the start of the branch: every commit older than the merge goes out
+-- with it, so it is inside the leading run and merges nothing. This is the shipped `gc` flow
+-- on any branch with a merge in it, and it is the half of the rule a reviewer meets most.
+describe("the same merge picked off the start of the branch", function()
+  local merge = commit_named("Merge branch 'lexer' into feature")
+  local listed = assert(git.branch_commits(root, base))
+
+  local msgs, restore = h.capture_notify()
+  view.trim_to(taken_out_below("test: assert the host as well"))
+  restore()
+  local W = assert(view.current())
+
+  it("refuses nothing", function()
+    assert.is_false(h.notified(msgs, "is not needed"), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "conflicts in"), vim.inspect(msgs))
+  end)
+
+  it("reads from the merge itself, so nothing was assembled", function()
+    assert.same(merge.sha, W.scope.before)
+  end)
+
+  -- Against `git diff` alone, so the comparison is with the reading this trim gave before any
+  -- of this existed. The untracked file left in the tree further up this file is in the review
+  -- and in no `git diff`, so it is held out of the comparison rather than dropped from the
+  -- claim -- that it survives every trim is asserted where it is written and again below.
+  it("draws exactly what the shipped trim drew for that reading", function()
+    local tracked = {}
+    for _, f in ipairs(W.files) do
+      if f.status ~= "U" then
+        tracked[#tracked + 1] = ("%s\t%s"):format(f.status, f.path)
+      end
+    end
+    assert.same(h.git_lines(fixture, { "diff", "--name-status", merge.sha }), tracked)
+  end)
+
+  it("says last N on the winbar, because that is the shape this reading has", function()
+    local bar = h.winbar(W.win)
+    assert.is_truthy(bar:find(("last %d"):format(#listed - 3), 1, true), bar)
   end)
 end)
 


### PR DESCRIPTION
Taking a merge out of a trim with a commit older than it left in always failed, and the failure a reviewer read was a file collision: every file the side branch brought, named as a conflict they did not cause and could do nothing about.

The collision is real — a merge's first-parent diff adds what the side branch brought while the anchor already holds it — but it is not the answer. Merging the default branch moves the merge base forward, so what the merge brought is already outside the review. Taking such a merge out of the middle is unnecessary as well as impossible, and the reviewer is now told the first part:

```
Taking out the merge acf5bef Merge branch 'lexer' into feature is not needed: a merge
brings nothing the review does not already read — the review is unchanged
```

It names no file, because the files are not why the set was refused. And it is decided **before any merge is attempted** — attempting it first and rewording what `merge-tree` said is the same answer with better prose.

## The rule is dynamic

It reads where the merge sits and never what the set holds. The same merge taken off the *start* of the branch, with every commit older than it taken off too, is inside the leading run: it assembles nothing and reads what a trim past a merge has always read — the shipped `gc` flow on any branch with a merge in it. Only a merge with a kept commit older than it is refused, which is exactly a skipped merge above the run. So the same row is free or refused by what else the trim takes, and no surface can grey it out ahead of time.

Which commits are merges comes off the listing that already answers which commits are on the branch, through one more field in its format.

## What the specs pin, and what they were measured against

`trim_spec` makes all three claims about the one merge the fixture has, and one more on a branch built with no merge on it at all:

- the merge taken out of the middle — refused, and the sentence names no file
- the same merge taken off the start of the branch — refuses nothing, reads from the merge itself, and draws exactly what `git diff --name-status <merge>` draws
- the merge inside the run with a commit above it taken out as well — a hole that really is assembled, over an anchor that is the merge
- a `flat` branch of three ordinary commits, whose middle commit comes out and is built

Measured mutations: asking the question of the whole skipped set rather than the part above the run reds the three cases written for a hole above a merge; asking it before a plain prefix has returned reds 32, the shipped prefix trim among them; not asking it at all reds the two that are the sentence, and prints the file collision this replaces.

`make all` exits 0.

## Not in this slice

The float keeps the row and closes before it applies, so a refusal from the float leaves it closed. Keeping it open with the cursor on the row is a change to `trim_float.lua`, which #152 owns.

Closes #153