### PR TITLE
feat(view): show each commit's size in the branch list

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,13 @@ alone, labelled `0 of 5`.
 The cursor opens on the reading you already have: the oldest commit still in your review, or
 "All commits" while the whole branch is in it.
 
+Every row also says how big its commit is: `3f +212 -48` is three files, two hundred and
+twelve lines added and forty-eight deleted. That is what separates a formatter run from a
+one-line fix before you decide to read it. The counts cost a pass over the whole branch, so
+the list does not wait for them — it opens on the commits and fills the columns in as git
+answers. A merge row carries its first-parent diff, which is the change the review reads for
+it, and no row carries the author: you are reading your own branch.
+
 Some sets cannot be read. Taking a commit out can need a commit you are keeping — a formatter
 run is the likeliest case of all, because it touched the same lines every other commit
 touched. The plugin says so, names the commit and the files it collides in, and leaves the

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -182,6 +182,13 @@ branch back in the review, unchecked it takes every commit out, which leaves a
 review of your uncommitted work alone. Your cursor opens on the oldest commit
 still in the review, or on that top row while the whole branch is in it.
 
+Every row carries the size of its commit as well: `3f +212 -48` is three
+files, 212 lines added and 48 deleted. The counts cost a pass over the whole
+branch, so the list does not wait for them -- it opens on the commits and
+fills the columns in when git answers. A merge row carries its first-parent
+diff, which is the change the review reads for it. No row carries the author:
+it is your own branch.
+
 A set that cannot be assembled is refused with the list still open and your
 cursor still on the row. Nothing is stored, and the review behind the list is
 the review that was there.

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -48,6 +48,24 @@ entry appears to end mid-note. Notes go through the renderer's own `wrap`, by di
 width — the same helper, not a copy, because splitting by byte passes every ASCII assertion
 and breaks the first CJK or emoji note.
 
+**The commit list's size columns are a column only while every row spends the same width on
+them.** Each row is fitted to a width it knows, and the date used to take whatever width its
+own words needed — which is invisible until something is drawn *left* of it, and then the
+size column beside a `5 days ago` sits two columns off the one beside a `60 minutes ago` and
+comparing two commits' sizes is arithmetic. Both the size and the date are therefore padded
+to the widest the listing carries, which is also what leaves every row the same number of
+columns wide. Dropping the date's padding alone reds one case in `trim_float_spec`, and it
+reds on the row *widths* rather than on the size's own offset: the size is pinned on its left
+by the subject's own fixed width either way.
+
+**That float's counts arrive after it is drawn, and the float can be gone by then.** The
+listing is a metadata query and near-instant; the sizes are a diff of every commit on the
+branch, which is what was refused when the counts were first left off a row. So the float
+opens on the listing and `git.branch_sizes` answers on a later tick — and `q` closing the
+window wipes its buffer, so the callback is written to ask both before it paints anything.
+An error thrown there lands in the messages rather than in any caller's `pcall`, which is
+where the spec reads for it.
+
 **A window-local highlight namespace reaches extmark highlights.** Attaching one with
 `nvim_win_set_hl_ns` changes what a group resolves to *in that window*, and that reaches a
 line background set by `line_hl_group`, the treesitter replay's extmarks at their higher

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -37,8 +37,14 @@ read correctly, and the verb and the noun are one word.
 commits that arrived through it are not listed beside your own. There is no limit on the
 rows, so a long branch keeps its oldest commits at the bottom of the list.
 
-The list does not show the author, because it is your own branch. It does not show the added
-and deleted counts, because they cost a second pass over the whole branch.
+The list does not show the author, because it is your own branch.
+
+**Every row shows the size of its commit**: the files it touched, and the lines it added and
+deleted. A box on every row asks *is this one worth reading*, and a subject cannot answer
+that — a formatter run over three hundred files and a one-line fix read alike. Those counts
+do cost a second pass over the whole branch, which is why the list never waits for them: it
+opens on the commits and fills the columns in when git answers. A merge row reports its
+first-parent diff, which is the one change the review reads for it.
 
 **Every row carries a box, and no row carries a mark.** What is in the review is stated on
 each row rather than inferred from one mark on one row, because a set with a hole in it is a

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -22,7 +22,7 @@ change there is felt through.
 | `diff.lua` | Unified-diff parsing, and the intra-line spans within a paired line | pure |
 | `drafts.lua` | Note text abandoned in a composer, keyed by absolute path — or by repository, for a **preamble** — in a store of its own | stateful (disk) |
 | `fade.lua` | The **faded** file rule: which rows one file's fade covers, and which group a faded row carries in place of its own | stateful (editor) |
-| `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes, and the pre-image a **trim** with a hole in it is built from | stateful (git) |
+| `git.lua` | Every shell-out in the plugin: scope resolution, `git diff`, blob hashes, the pre-image a **trim** with a hole in it is built from, and the one query answered on a later tick — how much each commit on the branch changed | stateful (git) |
 | `hl.lua` | The highlight groups: `default = true` links into whatever colorscheme is active, and the three families of blended twins — the **muted** window's, the **faded** file's and the **counterpart row**'s | stateful (editor) |
 | `init.lua` | The public surface a host reaches: `setup`, the user commands, `annotate(type)` | stateful (setup) |
 | `keymaps.lua` | Every key the review view binds — the diff's and the tree's — onto a buffer handed in, driving actions handed in | stateful (editor) |
@@ -33,7 +33,7 @@ change there is felt through.
 | `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named, and how a winbar is assembled from typed segments | pure |
 | `state.lua` | Persisted review progress, the blob comparisons over it — staleness, and touchedness kept in a function of its own — and each branch's **trim**, checked against `HEAD` before it is handed back | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
-| `trim_float.lua` | The float over the branch's commits: the first-parent listing from the base handed in, a checkbox on every row, and the pick that applies the **trim** they add up to | stateful (float) |
+| `trim_float.lua` | The float over the branch's commits: the first-parent listing from the base handed in, a checkbox and a size on every row, and the pick that applies the **trim** they add up to | stateful (float) |
 | `types.lua` | Annotation types: defaults, normalization, labels, and the directive that earns a type its keystroke | pure |
 | `view.lua` | The review view: the `CRView` it owns, the paint, navigation, delivery, opening and closing | stateful (windows) |
 | `view_layout.lua` | Where the review's windows are: the panes, the before pane, the toggle between the unified and split layouts, which of them is muted, and which group each lights its row in | stateful (windows) |

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -953,4 +953,91 @@ function M.branch_commits(root, base)
   return commits, nil
 end
 
+---@class CRCommitSize
+---@field added integer    Lines the commit added
+---@field deleted integer  Lines it deleted
+---@field files integer    Files it touched
+
+---How much each commit on the branch changed, answered on a later tick.
+---
+---**Asked apart from the listing, and that is the whole point of it.** `branch_commits` is a
+---metadata query and near-instant; this is a diff of every commit on the branch, and on a
+---long one it is the slowest thing either surface asks for. Made a field of that format it
+---would put the whole cost in front of the float opening -- which is exactly what was
+---refused when these counts were first left off a row. Asked here it costs the float
+---nothing: the rows are drawn from the listing and the columns fill when the answer lands.
+---
+---**One process for the whole branch**, for the reason the listing carries the merge flag
+---rather than asking per row: a commit at a time is a process per row of a list a reviewer
+---is free to take the whole of, and a second walk is a second answer to which commits are on
+---the branch. One question, one answer, and it is `--first-parent` from the same base so the
+---answer is keyed by the rows the listing drew.
+---
+---**`--numstat` and never `--shortstat`.** The short form is a sentence git writes for a
+---human and translates for their locale; the long form is two numbers and a path per file,
+---which is what `git diff --numstat` is for. A binary file prints `-` for both counts: it is
+---a file the commit touched and no lines anybody wrote, and it is counted that way.
+---
+---**`--diff-merges=first-parent` states what the row has to claim.** A merge is one row here
+---and the review reads its first-parent diff, so that is the size the row reports. Every git
+---above this plugin's floor already diffs a merge that way under `--first-parent`; the flag
+---says it rather than inheriting it, because a row claiming a size the review does not have
+---is worse than a row claiming none.
+---
+---The callback is handed nil when git cannot answer, and a row then carries no figures at
+---all. No sentence: a size sits beside the subject to be glanced at, and a reviewer who can
+---still read every subject and press every key has lost nothing worth a notification.
+---
+---It always lands on a later tick and where the editor can be touched, failure and answer
+---alike, so a caller has one rule to write against rather than two.
+---@param root string
+---@param base string Where the branch starts: the scope's identity
+---@param on_done fun(sizes: table<string, CRCommitSize>|nil) Keyed by full sha
+function M.branch_sizes(root, base, on_done)
+  local function answer(sizes)
+    vim.schedule(function()
+      on_done(sizes)
+    end)
+  end
+
+  local cmd = {
+    "git",
+    "log",
+    "--first-parent",
+    "--diff-merges=first-parent",
+    "--numstat",
+    -- The unit separator is what tells a commit's own line from the numstat lines under it:
+    -- those start with a count or a `-` and hold tabs, and nothing else here starts with a
+    -- character a path cannot begin with either.
+    "--format=%x1f%H",
+    base .. "..HEAD",
+  }
+  -- vim.system raises when the binary is missing, rather than reporting it to the callback.
+  local ok = pcall(vim.system, cmd, { text = true, cwd = root, timeout = DIFF_TIMEOUT_MS }, function(res)
+    if res.code ~= 0 then
+      return answer(nil)
+    end
+
+    local sizes, at = {}, nil
+    for _, entry in ipairs(vim.split(res.stdout or "", "\n", { trimempty = true })) do
+      local id = entry:match("^\31(%S+)$")
+      if id then
+        at = { added = 0, deleted = 0, files = 0 }
+        sizes[id] = at
+      elseif at then
+        local added, deleted = entry:match("^(%S+)\t(%S+)\t")
+        if added then
+          at.files = at.files + 1
+          at.added = at.added + (tonumber(added) or 0)
+          at.deleted = at.deleted + (tonumber(deleted) or 0)
+        end
+      end
+    end
+    answer(sizes)
+  end)
+  if not ok then
+    answer(nil)
+  end
+end
+
 return M

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -6,10 +6,24 @@
 ---branch starts at as plain values -- so nothing here reads the view, which is what keeps
 ---this module out of the cycle `view` and `annotate` already sit in.
 ---
----What a row carries is a checkbox, the short sha, the subject and the relative date. The
----checkbox is on every row because the question a reviewer answers here is *is this commit
----in my review*, one commit at a time, and a set with a hole in it is a set no single mark
----on a single row can state. Not the author -- you are reading your own branch.
+---What a row carries is a checkbox, the short sha, the subject, how much the commit changed
+---and the relative date. The checkbox is on every row because the question a reviewer
+---answers here is *is this commit in my review*, one commit at a time, and a set with a hole
+---in it is a set no single mark on a single row can state. The size is on every row because
+---that question needs an answer a subject cannot give: a formatter run over three hundred
+---files and a one-line fix read alike until the row says how big each one is.
+---
+---**The size was refused on this row once, and half of that refusal stands.** It was written
+---for a float where a reviewer picked one starting row: the question was *where do I start
+---reading*, which the subject answers, and what it refused was making the float wait on a
+---second pass over the whole branch -- the listing is a metadata query and near-instant,
+---while the counts are a diff of every commit on it. That cost has not changed, so it is
+---still refused: the float opens on the listing alone, and the columns fill when git answers
+---on a later tick. Nothing here waits for them, and a float closed before the answer arrives
+---is answered into nothing.
+---
+---Not the author -- you are reading your own branch, and that half of the refusal is
+---untouched.
 local git = require("codereview.git")
 local render = require("codereview.render")
 
@@ -35,9 +49,22 @@ local NS_TRIM = vim.api.nvim_create_namespace("codereview_trim")
 local CHECKED = "[x]"
 local UNCHECKED = "[ ]"
 
----Two spaces between the columns, so the box, the sha, the subject and the date read as
----four columns rather than as one sentence.
+---Two spaces between the columns, so the box, the sha, the subject, the size and the date
+---read as five columns rather than as one sentence. Inside the size it is one space, which
+---is what keeps its three figures one column of the row rather than three of them.
 local GAP = "  "
+
+---How the file count is spelled.
+---
+---A marker rather than a bare number: the rows carry no header, and a number standing
+---between a subject and two signed counts says how many of nothing. One letter rather than
+---the word, because the float is fifty columns at its narrowest and every column this takes
+---is a column the subject does not get.
+---
+---The two line counts are spelled `+N -M`, which is what the file header and the **sticky
+---header** already spell a size with -- and they take those surfaces' colors as well, so one
+---color means one thing wherever a reviewer meets it.
+local FILES = "%df"
 
 ---One column kept clear on the right, so a row that fills the float does not run into the
 ---border.
@@ -65,6 +92,30 @@ local function all_in(commits, checked)
   return true
 end
 
+---How wide each of the three size columns has to be drawn to line up down the listing.
+---
+---The widest figure any row carries, and no wider. A reviewer comparing two commits' sizes
+---is comparing two columns or they are doing arithmetic, and the sha column is padded to the
+---widest sha for the same reason.
+---
+---All three are zero until git answers, which is what leaves the columns off a row rather
+---than blank on it: a width reserved before the answer is a width the answer changes anyway.
+---@param commits CRCommit[]
+---@param sizes table<string, CRCommitSize>
+---@return { files: integer, added: integer, deleted: integer }
+local function size_widths(commits, sizes)
+  local at = { files = 0, added = 0, deleted = 0 }
+  for _, commit in ipairs(commits) do
+    local size = sizes[commit.id]
+    if size then
+      at.files = math.max(at.files, #FILES:format(size.files))
+      at.added = math.max(at.added, #("+%d"):format(size.added))
+      at.deleted = math.max(at.deleted, #("-%d"):format(size.deleted))
+    end
+  end
+  return at
+end
+
 ---Turn the commits into the float's rows.
 ---
 ---The subject keeps the buffer's own color, which is the brightest thing this float has,
@@ -72,16 +123,19 @@ end
 ---the date are what a row is found by, and the subject is what it is read for.
 ---
 ---Its highlight columns are byte offsets, not display columns -- a subject is free to be
----any width in either ruler, and the two part company at the first accented character.
+---any width in either ruler, and the two part company at the first accented character. Every
+---column to the right of it is placed by measuring back from the end of the row in bytes for
+---that reason, and never by adding up what is drawn.
 ---
----The checkbox column takes its width from the subject and from neither of the other two:
----a sha truncated is a sha a reviewer cannot match against `git log`, and a date is the
----narrowest thing on the row already.
+---The checkbox column takes its width from the subject, and so do the size columns; from
+---neither of the other two. A sha truncated is a sha a reviewer cannot match against
+---`git log`, and a date is the narrowest thing on the row already.
 ---@param commits CRCommit[]
 ---@param width integer Columns the float has to draw into
 ---@param checked boolean[] Whether each commit is in the review, by its place in the listing
+---@param sizes table<string, CRCommitSize> How much each commit changed, empty until git answers
 ---@return { lines: string[], marks: table[] }
-local function build(commits, width, checked)
+local function build(commits, width, checked, sizes)
   -- The top row's own box is checked only while every commit is, because that is what it
   -- says.
   local whole = all_in(commits, checked)
@@ -99,14 +153,45 @@ local function build(commits, width, checked)
   local indent = #CHECKED + #GAP + sha_width + #GAP
   local body = math.max(8, width - indent - MARGIN)
 
+  -- The right of a row: the size, then the date. Both are as wide as the widest the listing
+  -- carries and the same width on every row, which is the whole of what makes them columns
+  -- -- a date left to its own width moves the size beside it, and comparing two commits'
+  -- sizes is then arithmetic rather than a glance down the rows.
+  local size_at = size_widths(commits, sizes)
+  local stat_width = size_at.files > 0 and (size_at.files + 1 + size_at.added + 1 + size_at.deleted) or 0
+  local stat_format = ("%%%ds %%%ds %%%ds"):format(size_at.files, size_at.added, size_at.deleted)
+  local when_width = 0
+  for _, commit in ipairs(commits) do
+    when_width = math.max(when_width, vim.fn.strdisplaywidth(commit.when or ""))
+  end
+  local tail_width = stat_width + when_width + ((stat_width > 0 and when_width > 0) and #GAP or 0)
+
+  -- So the subject is the same width on every row as well, and it is what pays for both.
+  local room = body - (tail_width > 0 and tail_width + #GAP or 0)
+  room = math.max(8, room)
+
   for i, commit in ipairs(commits) do
+    local size = sizes[commit.id]
+    -- A commit git answered nothing for keeps its columns clear rather than pulling every
+    -- row under it out of line.
+    local stat = ""
+    if stat_width > 0 then
+      stat = size
+          and stat_format:format(FILES:format(size.files), ("+%d"):format(size.added), ("-%d"):format(size.deleted))
+        or (" "):rep(stat_width)
+    end
+
     local when = commit.when or ""
-    local room = body - (when ~= "" and vim.fn.strdisplaywidth(when) + #GAP or 0)
-    local subject = render.truncate(commit.subject, math.max(8, room))
+    local tail = stat
+    if when ~= "" then
+      when = (" "):rep(when_width - vim.fn.strdisplaywidth(when)) .. when
+      tail = tail ~= "" and (tail .. GAP .. when) or when
+    end
+    local subject = render.truncate(commit.subject, room)
     local box = checked[i] and CHECKED or UNCHECKED
     local head = box .. GAP .. ("%-" .. sha_width .. "s"):format(commit.sha) .. GAP .. subject
-    if when ~= "" then
-      head = head .. (" "):rep(math.max(#GAP, room - vim.fn.strdisplaywidth(subject) + #GAP)) .. when
+    if tail ~= "" then
+      head = head .. (" "):rep(math.max(#GAP, room - vim.fn.strdisplaywidth(subject) + #GAP)) .. tail
     end
 
     lines[#lines + 1] = head
@@ -119,6 +204,29 @@ local function build(commits, width, checked)
       col = #box + #GAP,
       opts = { end_col = #box + #GAP + #commit.sha, hl_group = "CodeReviewQueueIndex" },
     }
+    -- Measured back from the end of the row, in bytes: the subject between here and the sha
+    -- is any number of bytes wide at a given number of columns, and adding up what is drawn
+    -- would put every mark on this side of it one accented character out.
+    if size and stat_width > 0 then
+      local at = #head - #tail
+      marks[#marks + 1] = {
+        row = row,
+        col = at,
+        opts = { end_col = at + size_at.files, hl_group = "CodeReviewQueueState" },
+      }
+      local plus = at + size_at.files + 1
+      marks[#marks + 1] = {
+        row = row,
+        col = plus,
+        opts = { end_col = plus + size_at.added, hl_group = "CodeReviewStatAdd" },
+      }
+      local minus = plus + size_at.added + 1
+      marks[#marks + 1] = {
+        row = row,
+        col = minus,
+        opts = { end_col = minus + size_at.deleted, hl_group = "CodeReviewStatDel" },
+      }
+    end
     if when ~= "" then
       marks[#marks + 1] = {
         row = row,
@@ -209,16 +317,21 @@ function M.open(view, root, base)
   -- reviewer counting rows against commits would find one too many.
   vim.wo[win].wrap = false
 
+  ---How much each commit changed, empty until git answers. See the header: the listing is
+  ---what the float opens on, and this is what it fills in.
+  local sizes = {}
+
   ---Draw every row again from the boxes as they now stand.
   ---
   ---The whole listing rather than the one box that moved: the top row answers for all of
   ---them, so a toggle anywhere can change two rows -- and a rule that redrew only what it
-  ---believed had changed is a second answer to what a row says.
+  ---believed had changed is a second answer to what a row says. The size columns are as
+  ---wide as the listing's widest figure, so the answer arriving moves every row as well.
   ---
   ---One row is replaced by one row, so the cursor stays where the reviewer left it and
   ---nothing here has to put it back. A repaint that emptied the buffer first would not.
   local function paint()
-    local painted = build(commits, vim.api.nvim_win_get_width(win), checked)
+    local painted = build(commits, vim.api.nvim_win_get_width(win), checked, sizes)
     vim.bo[buf].modifiable = true
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, painted.lines)
     vim.bo[buf].modifiable = false
@@ -232,6 +345,24 @@ function M.open(view, root, base)
   -- Placed rather than left where a fresh window puts it, which is row one: that is the
   -- right row only while nothing is trimmed.
   pcall(vim.api.nvim_win_set_cursor, win, { at + 1, 0 })
+
+  -- The sizes, asked for after the rows are on screen and drawn whenever the answer
+  -- arrives. A reviewer is reading subjects and moving the cursor by then, and the paint
+  -- takes neither away: the rows are the same rows, in the same order, and the cursor sits
+  -- on the one it sat on.
+  --
+  -- **The float can be gone by the time git answers**, which is the ordinary end of a list
+  -- opened to check one thing: `q` closes the window and the buffer is wiped with it. So
+  -- both are asked before anything is written, and the answer is dropped rather than
+  -- painted into a window that is not there. Nothing here can be latched to the close
+  -- instead -- the window can also go with the tab it was in, or with the review behind it.
+  git.branch_sizes(root, base, function(answered)
+    if not answered or not vim.api.nvim_buf_is_valid(buf) or not vim.api.nvim_win_is_valid(win) then
+      return
+    end
+    sizes = answered
+    paint()
+  end)
 
   local function close()
     if vim.api.nvim_win_is_valid(win) then

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,7 +71,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `panel_spec` | Tree build, chain compaction, folding, subtree review, navigation, picker, dismissing and summoning the tree |
 | `queue_float_spec` | How the float draws an entry: the bar down every row it owns, the boundary between two, notes kept and wrapped by display width, dropping from anywhere inside one, and the two keys that act on the whole batch — one closing the float, one leaving it open |
 | `trim_spec` | The **trim**, at both of its seams: what a pick resolves to — every row of the listing read against git's own answer for the reading that row has always given, the oldest row at the merge base, the identity that does not move with the pre-image, the label, and the commit made afterwards that is in the review without the trim being touched; then the sets with a **hole** in them, which read from a pre-image that is built — the commit taken out of the middle, two that are not next to each other, the prefix reaching past the merge that must assemble nothing, the whole branch taken out, the commit no set can be built without, the same one succeeding beside what it depends on, the refs and the working tree the build must not touch, and the second resolve that finds the tree already built; then the **merge** on both sides of the rule that refuses it — taken out with an older commit left in, taken off the start of the branch with a hole above it, and a hole on a branch of its own with no merge on its first-parent line at all — and then what a reviewer sees of one, in a real view: the diff drawn again, the marks that survive and the one that does not, uncommitted and untracked work under it, syntax, navigation, collapse, both layouts, the entry annotating in it produces, what the queue still lists, where `gs` goes from it, and the pick that is refused — the sentence naming the commit and the file and no dependency, the store still holding the trim that was there, the review still on screen, and the same commit picked again beside the one it depends on; the merge picked out of the middle, whose sentence names no file at all, and the same merge picked off the start of the branch, which draws what the shipped trim drew; then what a session leaves behind, in a second copy of the fixture and a second process: the branch that opens where the reading stopped, the branch beside it holding its own, the rewritten commit that loses one and the sentence that says so once, the commit this repository does not have saying the same sentence beside one the branch still holds, and the detached `HEAD` that trims for the session, says it is not kept, and is gone in the session after |
-| `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the box on every row and the two directions `<Space>` moves it, the top row taking the whole branch in and out, the boxes a stored trim opens on, the cursor's opening row, `<CR>` applying a prefix and applying a set with a hole in it, the pick that is refused with the float left open on the row, the **merge** row checked with a commit older than it left in — the sentence about merges rather than about files, the float still open, the cursor still on it and the store still holding the trim that was there — the keys the footer names and the ones it does not, the rows still one each in a float too narrow to hold them whole, `gc` from the diff and from the tree, and the two refusals that open nothing |
+| `trim_float_spec` | The float over the branch's commits: what a row carries and what it must not, the first-parent listing that leaves out what a merge brought in, the rows a cap would take away, the box on every row and the two directions `<Space>` moves it, the top row taking the whole branch in and out, the boxes a stored trim opens on, the cursor's opening row, `<CR>` applying a prefix and applying a set with a hole in it, the pick that is refused with the float left open on the row, the **merge** row checked with a commit older than it left in — the sentence about merges rather than about files, the float still open, the cursor still on it and the store still holding the trim that was there — the keys the footer names and the ones it does not, the rows still one each in a float too narrow to hold them whole, `gc` from the diff and from the tree, and the two refusals that open nothing; then the **size** on a row: absent while the float opens, filled from git's own answer for each commit, the merge row carrying its first-parent diff, the columns lined up on both edges down the listing, the counts colored at byte offsets on the subject that is not ASCII, every row sized on a branch of sixty-five, and the float closed inside the window before the answer lands |
 | `focus_spec` | Queue-float focus across the async picker, submit closing the float, and where a submit under a **preamble** leaves the cursor |
 | `drafts_spec` | A draft outliving the session it was written in, and the **preamble**'s own key: per repository, one slot outside a checkout, and never the bare note's |
 | `queue_jump_spec` | Jumping from the queue float: where it lands, what it expands, and the three ways it cannot go |
@@ -113,7 +113,13 @@ interchangeable, and the assertions know which one they are looking at.
   so it is the only commit here that cannot leave a review on its own — without it a
   refusal has nothing to refuse, which is "a filter test needs a fixture only that filter
   can reject". Its commits are dated days apart, as offsets back from the moment the script
-  runs, so a relative date on a row is a fact a spec can check and never goes stale. The merge
+  runs, so a relative date on a row is a fact a spec can check and never goes stale. One of
+  the five subjects carries an em dash and is the only line in this fixture that is not
+  ASCII: the commit list places every column right of the subject by measuring back from the
+  end of the row in *bytes*, and across five ASCII subjects that lands exactly where
+  measuring in display columns lands — so an assertion over either ruler passes whichever one
+  the float used. Changing that subject's text moves the row-width and truncation
+  assertions with it. The merge
   is a third rule of its own: it is free on the row that takes it off the start of the branch
   and refused with a commit older than it left in, and one history holding one merge is what
   lets a spec make both claims about one row. `trim_spec` builds a **second copy**
@@ -625,6 +631,25 @@ so the out-of-core language path is still checked locally without ever failing C
   that, and says why: neither branch it trims has been trimmed before, so every box it meets
   is checked — which it asserts rather than assumes, because a box that started the other way
   would build the wrong reading for the process that reads it back.
+- **A case about a row in the commit list has to say which listing it is reading.** The
+  float opens on the commits and fills the size columns in when git answers, which is a later
+  tick — so `trim_float_spec` holds two readings of the same buffer: `rows`, taken as the
+  float opened and carrying no figure at all, and what `filled_rows` hands back after waiting
+  for one. Assert a size against the first and the case reds; assert *what a row carries*
+  against the second without listing the size and it reds the other way. The wait is a
+  condition and never a sleep: a fixed drain that is too short passes because nothing was
+  ever drawn, which is the same shape as a filter test with nothing to reject.
+- **The float closed before its figures arrive is a window a spec has to land inside.** The
+  answer is painted from a callback, so a float already wiped is a write into a dead buffer —
+  and the case for it only measures anything while the close really did beat the answer. The
+  block asserts that it did, off the rows it took at the open, rather than trusting the race
+  it just won. It also cannot wait on the float it closed, because there is nothing left to
+  observe: it opens a second float over the same branch and waits for *that* answer, which
+  asked git the same question second and therefore lands no earlier. What a write into a dead
+  buffer costs is a message and not a failure — an error thrown on a scheduled callback is
+  outside every `pcall` the caller has — so the assertion is over `:messages`, cleared
+  immediately before the close. Deleting the validity guard in `trim_float.lua` reds that one
+  case and nothing else in the suite.
 - **A refused merge takes two specs to pin, and each half passes while the other is broken.**
   The rule that refuses a **merge** above the leading run and the key that reaches it were
   built as separate slices, and neither file's cases red for the other's regression.

--- a/tests/codereview/trim_float_spec.lua
+++ b/tests/codereview/trim_float_spec.lua
@@ -15,6 +15,10 @@
 -- commits, one of them a merge with commits older than it, over a merge base that is not the
 -- oldest commit's parent, and one commit that rewrites the line an earlier one introduced.
 -- Every rule this file pins is invisible without it -- see the script's own header.
+--
+-- The size on a row arrives on a later tick: the float opens on the listing, and git answers
+-- after it. So every case here says which of the two it is reading -- the rows taken as the
+-- float opened, or the rows `filled_rows` has waited for the answer on.
 local h = require("tests.helpers")
 
 h.ui(110, 40)
@@ -59,6 +63,18 @@ local FREE = "docs: write the readme"
 ---The merge on the branch's own line of work. A **merge** cannot start a hole, so this row is
 ---the one whose refusal is about no file at all.
 local MERGE = "Merge branch 'lexer' into feature"
+---The one commit whose subject is not ASCII.
+---
+---Found rather than written down, and what it is wanted for is the property rather than the
+---text: its subject is a different number of bytes and of columns wide, which is the only
+---thing that tells a column placed by counting bytes from one placed by counting columns. A
+---spec naming the string would keep passing on a fixture that went back to plain ASCII.
+local WIDE
+for _, c in ipairs(first_parent) do
+  if #c.subject ~= vim.fn.strdisplaywidth(c.subject) then
+    WIDE = c
+  end
+end
 
 ---@param commits { subject: string }[]
 ---@return string[]
@@ -80,6 +96,38 @@ local function commit_named(subject)
   error(subject .. " is on no commit: " .. vim.inspect(subjects(first_parent)))
 end
 
+---What git says changed between two commits, as `{ files, added, deleted }`.
+---@param from string
+---@param to string
+---@return { files: integer, added: integer, deleted: integer }
+local function size_between(from, to)
+  local at = { files = 0, added = 0, deleted = 0 }
+  for _, l in ipairs(h.git_lines(fixture, { "diff", "--numstat", from, to })) do
+    local added, deleted = l:match("^(%S+)\t(%S+)\t")
+    if added then
+      at.files = at.files + 1
+      -- A binary file prints `-` for both counts: a file the commit touched, and no lines
+      -- anybody wrote.
+      at.added = at.added + (tonumber(added) or 0)
+      at.deleted = at.deleted + (tonumber(deleted) or 0)
+    end
+  end
+  return at
+end
+
+---What git says one commit changed.
+---
+---`<sha>^` is that commit's first parent whatever kind of commit it is, so this asks a merge
+---the same question it asks every other row -- and a merge's first-parent diff is exactly the
+---change the review reads for it. Counted from git's own output rather than taken from
+---anything the plugin produced: what a row claims is judged against git, never against
+---itself.
+---@param sha string
+---@return { files: integer, added: integer, deleted: integer }
+local function size_of(sha)
+  return size_between(sha .. "^", sha)
+end
+
 --- Reading the float ------------------------------------------------------------
 
 ---@param buf integer
@@ -95,6 +143,59 @@ end
 local function commit_rows(buf)
   local all = lines(buf)
   return vim.list_slice(all, 2, #all)
+end
+
+---What a row says its commit changed, read back off it as three numbers.
+---
+---The one place the size's spelling is written down, exactly as `box` is the one place the
+---box is read as a column. What the cases compare is git's numbers against the row's, and a
+---case matching `+1 -0` at every assertion would leave this file asserting the float's
+---format against itself.
+---@param row string
+---@return { files: integer, added: integer, deleted: integer }|nil nil while the row carries none
+local function stat_on(row)
+  local files, added, deleted = row:match("(%d+)f%s+%+(%d+)%s+%-(%d+)")
+  if not files then
+    return nil
+  end
+  return { files = tonumber(files), added = tonumber(added), deleted = tonumber(deleted) }
+end
+
+---The commit rows once git's answer has been drawn onto them.
+---
+---The float opens on the listing alone and fills the size columns when git answers, which is
+---a later tick -- so every case about a figure comes through here, and every case about the
+---float *opening* reads the rows taken at the open instead.
+---@param buf integer
+---@return string[]
+local function filled_rows(buf)
+  local ok = vim.wait(5000, function()
+    return stat_on(commit_rows(buf)[1] or "") ~= nil
+  end, 5)
+  assert(ok, "no size ever reached a row: " .. table.concat(commit_rows(buf), "\n"))
+  return commit_rows(buf)
+end
+
+---The text the float's own extmarks cover on a row, for one highlight group, in order.
+---
+---Read as the byte range each mark holds, applied to the line it is on -- which is the whole
+---reason to read a mark here at all. A subject is free to be any number of bytes wide at a
+---given number of columns, so a count placed by counting *columns* covers the bytes before
+---itself on the one row whose subject is not ASCII, and the number it is coloring is not the
+---number underneath it.
+---@param buf integer
+---@param row integer 1-based
+---@param group string
+---@return string[]
+local function marked(buf, row, group)
+  local text = lines(buf)[row]
+  local out = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_extmarks(buf, -1, 0, -1, { details = true })) do
+    if m[2] == row - 1 and m[4].hl_group == group and m[4].end_col then
+      out[#out + 1] = vim.trim(text:sub(m[3] + 1, m[4].end_col))
+    end
+  end
+  return out
 end
 
 ---Where the sha starts on a commit row, which is how wide the box column is drawn.
@@ -258,6 +359,23 @@ describe("the history this spec reads", function()
     end
     assert.is_true(at ~= nil and at < #first_parent, vim.inspect(subjects(first_parent)))
   end)
+
+  -- What makes a column's offset measurable at all. Every column right of the subject is
+  -- placed by measuring back from the end of the row in bytes, and across five ASCII
+  -- subjects that lands in the same place as measuring in display columns -- so an assertion
+  -- over either passes whichever ruler the float used.
+  it("carries one subject that is not ASCII", function()
+    assert.is_truthy(WIDE, vim.inspect(subjects(first_parent)))
+    assert.are_not.same(#WIDE.subject, vim.fn.strdisplaywidth(WIDE.subject), WIDE.subject)
+  end)
+
+  -- What makes the merge row's size measurable. The review reads a merge's first-parent
+  -- diff, and a row reporting the other one is only visible while the two are different
+  -- sizes -- on a merge that brought nothing of its own they are one answer.
+  it("gives the merge two diffs of different sizes to be read from", function()
+    local merge = commit_named(MERGE)
+    assert.are_not.same(size_between(merge.sha .. "^2", merge.sha), size_of(merge.sha))
+  end)
 end)
 
 --- The rows --------------------------------------------------------------------
@@ -370,9 +488,142 @@ describe("gc inside a branch review", function()
     assert.is_true(bound(assert(review.panel_buf))[vim.keycode("gc")] == true, "gc is not bound in the tree")
   end)
 
+  --- The size on a row ---------------------------------------------------------
+
+  -- `rows` was taken as the float opened, and it is the whole listing with no figure on it:
+  -- the float draws the rows it has and waits for nothing. A float that asked for the sizes
+  -- first would have them here, because it could not have drawn a row until it did.
+  it("opens on the listing alone, with no size on it yet", function()
+    for _, row in ipairs(rows) do
+      assert.is_nil(stat_on(row), row)
+    end
+  end)
+
+  local filled = filled_rows(buf)
+
+  it("fills in what each commit changed once git answers", function()
+    for i, c in ipairs(first_parent) do
+      assert.same(size_of(c.sha), stat_on(filled[i]), filled[i])
+    end
+  end)
+
+  -- The listing is `--first-parent`, so a merge is one row and one change: what it brought
+  -- onto this branch. A row carrying the size of everything under the merge would be
+  -- claiming a size the review it belongs to does not have.
+  it("gives the merge row the size the review reads for it", function()
+    local at = row_of(buf, MERGE) - 1
+    assert.same(size_of(commit_named(MERGE).sha), stat_on(filled[at]), filled[at])
+  end)
+
+  -- Two commits' sizes compare by eye or they compare by arithmetic. Measured in display
+  -- columns, which is the ruler an eye reads down -- and on both edges of the size, because
+  -- a column pinned only on its left is a column the date beside it can still push around.
+  it("lines the sizes up down the listing", function()
+    local starts, widths = {}, {}
+    for _, row in ipairs(filled) do
+      local at = assert(row:find("%d+f%s+%+%d"), row)
+      starts[#starts + 1] = vim.fn.strdisplaywidth(row:sub(1, at - 1))
+      widths[#widths + 1] = vim.fn.strdisplaywidth(row)
+    end
+    local function every(list)
+      return vim.tbl_map(function()
+        return list[1]
+      end, list)
+    end
+    assert.same(every(starts), starts, table.concat(filled, "\n"))
+    -- Every row ends on the same column as well, which is what keeps the date a column of
+    -- its own: left to its own width it shortens the row it is on and nothing under it.
+    assert.same(every(widths), widths, table.concat(filled, "\n"))
+  end)
+
+  it("carries nothing else beside the box and the size", function()
+    local width = box_width(buf)
+    for i, c in ipairs(first_parent) do
+      local size = size_of(c.sha)
+      local rest = filled[i]:sub(width + 1)
+      local carried = ("%s%s%df+%d-%d%s"):format(c.sha, c.subject, size.files, size.added, size.deleted, c.when)
+      assert.same((carried:gsub("%s+", "")), (rest:gsub("%s+", "")), filled[i])
+    end
+  end)
+
+  it("names the author nowhere once the size is on the row", function()
+    for _, row in ipairs(filled) do
+      assert.is_nil(row:find("Fixture Author", 1, true), row)
+    end
+  end)
+
+  -- The counts are colored where the counts are, read on the one row whose subject is not
+  -- ASCII. Placed by counting display columns instead, every mark on the right of that row
+  -- starts short of the figure it is for and ends inside it.
+  it("colors the counts at byte offsets rather than at display columns", function()
+    local at = row_of(buf, WIDE.subject)
+    local size = size_of(WIDE.sha)
+    assert.same({ ("+%d"):format(size.added) }, marked(buf, at, "CodeReviewStatAdd"), lines(buf)[at])
+    assert.same({ ("-%d"):format(size.deleted) }, marked(buf, at, "CodeReviewStatDel"), lines(buf)[at])
+    -- The file count and the date, in the quiet group both take: the two numbers on the row
+    -- that are neither added nor deleted lines.
+    assert.same({ ("%df"):format(size.files), WIDE.when }, marked(buf, at, "CodeReviewQueueState"), lines(buf)[at])
+  end)
+
   if vim.api.nvim_win_is_valid(win) then
     vim.api.nvim_win_close(win, true)
   end
+  codereview.close()
+end)
+
+--- The float closed before the answer -------------------------------------------
+
+-- The ordinary end of a list opened to check one thing: `q` before git has answered. The
+-- window goes and the buffer is wiped with it, and the answer then lands on a float that is
+-- not there.
+--
+-- The close has to happen *inside* that window or the case measures nothing -- a float that
+-- already has its figures has nothing left to write into a dead buffer -- so the block
+-- asserts that it did rather than trusting that it did.
+describe("a float closed before the figures arrive", function()
+  state.set_trim(root, nil)
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local win, buf = commits_by_key(review.win)
+  local opened = commit_rows(buf)
+
+  vim.cmd("messages clear")
+  h.feed("q")
+
+  -- Drained by opening the float again and waiting for *that* answer: the two ask git the
+  -- same question about the same branch and this one asked second, so its figures arriving
+  -- is what says the first one's answer has been delivered. A sleep would be a guess in both
+  -- directions -- too short and the case passes because nothing was ever answered.
+  local second, second_buf = commits_by_key(assert(view.current()).win)
+  filled_rows(second_buf)
+  local said = vim.fn.execute("messages")
+
+  it("really did close before any figure was drawn", function()
+    for _, row in ipairs(opened) do
+      assert.is_nil(stat_on(row), row)
+    end
+  end)
+
+  it("wiped the buffer the answer would have been drawn into", function()
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+    assert.is_false(vim.api.nvim_buf_is_valid(buf))
+  end)
+
+  -- Nothing is said and nothing is written. An answer painted into a wiped buffer or a
+  -- closed window raises from the callback it arrives on, which is not a place any pcall of
+  -- the caller's covers: it lands in the messages instead, named after the module it was
+  -- thrown from.
+  it("errors nowhere, and says nothing about it either", function()
+    assert.is_nil(said:find("trim_float", 1, true), said)
+    assert.is_nil(said:find("Invalid", 1, true), said)
+  end)
+
+  it("draws the float that is still open, so the answer went to the right one", function()
+    assert.is_true(vim.api.nvim_win_is_valid(second))
+    assert.is_truthy(stat_on(commit_rows(second_buf)[1]), commit_rows(second_buf)[1])
+  end)
+
+  h.feed("q")
   codereview.close()
 end)
 
@@ -1029,6 +1280,31 @@ describe("a float too narrow for the rows to fit whole", function()
     end
   end)
 
+  -- And again with the size on the rows, which is the state that has the least room of any
+  -- this float draws in. The subject pays for that column too.
+  local filled = filled_rows(buf)
+
+  it("still draws one row per commit with the size on it", function()
+    assert.same(#first_parent, #filled, table.concat(filled, "\n"))
+    for _, row in ipairs(lines(buf)) do
+      assert.is_true(vim.fn.strdisplaywidth(row) <= width, ("%d columns: %s"):format(vim.fn.strdisplaywidth(row), row))
+    end
+  end)
+
+  it("keeps the size and the date whole as well", function()
+    for i, c in ipairs(first_parent) do
+      assert.same(size_of(c.sha), stat_on(filled[i]), filled[i])
+      assert.is_truthy(filled[i]:find(c.when, 1, true), filled[i])
+    end
+  end)
+
+  it("took the room out of the subject", function()
+    local whole = vim.tbl_filter(function(i)
+      return filled[i]:find(first_parent[i].subject, 1, true) ~= nil
+    end, vim.tbl_keys(filled))
+    assert.is_true(#whole < #filled, table.concat(filled, "\n"))
+  end)
+
   h.feed("q")
   codereview.close()
   h.ui(110, 40)
@@ -1064,6 +1340,19 @@ describe("a branch longer than a capped list would show", function()
   -- branch being unreachable.
   it("still holds the oldest commit on the branch", function()
     assert.is_truthy(rows[#rows]:find(first_parent[#first_parent].subject, 1, true), rows[#rows])
+  end)
+
+  local filled = filled_rows(buf)
+
+  -- One answer covers the whole branch however long it is, and it is keyed by commit: the
+  -- filler commits are empty, so a row saying they changed something is a row wearing
+  -- another commit's figures. The newest row is one of them.
+  it("sizes every row on a branch this long, the empty commits included", function()
+    local sized = vim.tbl_filter(function(row)
+      return stat_on(row) ~= nil
+    end, filled)
+    assert.same(#filled, #sized, table.concat(filled, "\n"))
+    assert.same({ files = 0, added = 0, deleted = 0 }, stat_on(filled[1]), filled[1])
   end)
 
   h.feed("q")

--- a/tests/fixtures/mkcommits.sh
+++ b/tests/fixtures/mkcommits.sh
@@ -9,7 +9,7 @@
 #
 #   B0  chore: seed the repository        master
 #   B1  chore: bump the year              master, and the merge base
-#   c1  feat: read the config file        feature
+#   c1  feat: read the config file …      feature, and the one subject that is not ASCII
 #   c2  test: cover the config reader     feature
 #   s1  fix: tighten the lexer            lexer, off B1 -- arrives through the merge
 #   M   Merge branch 'lexer'              feature
@@ -36,6 +36,14 @@
 # that filter can reject. c2 and c3 are on opposite sides of the merge on purpose: they
 # are not next to each other, so taking both out applies the two of them in turn instead
 # of reading a tree that some commit already has.
+#
+# c1's subject carries an em dash, and it is the only line here that is not ASCII. A row in
+# the commit list places its highlights at byte offsets, and every column to the right of the
+# subject is measured back from the end of the row: with five ASCII subjects the byte ruler
+# and the display ruler agree, so a count drawn by adding up what is *drawn* lands exactly
+# where a count drawn by counting bytes does, and an assertion over either passes. One
+# multi-byte character in one subject is what pulls the two rulers apart -- the same reason
+# mkfixture keeps a `café 🎉` line, arriving at a different subsystem.
 #
 # The commits are dated apart from each other, so the relative date on a row is a fact a
 # reader can check rather than "0 seconds ago" five times over. Each date is an offset back
@@ -80,7 +88,7 @@ commit $((6 * DAY)) "chore: seed the repository"
 git checkout -qb feature
 printf 'local port = 8080\nlocal host = "localhost"\n' > src/config.lua
 git add -A
-commit $((5 * DAY)) "feat: read the config file"
+commit $((5 * DAY)) "feat: read the config file — port and host"
 
 printf 'local cfg = require("config")\nassert(cfg.port)\n' > src/config_spec.lua
 git add -A


### PR DESCRIPTION
A box on every row asks whether that commit is worth reading, and a subject cannot answer it:
a formatter run over three hundred files and a one-line fix read alike. Each row now carries
the files its commit touched and the lines it added and deleted.

## The refusal this overturns, and the half of it that stands

The commit float's docstring records that these columns are not on a row because they cost a
second pass over the whole branch. That was written for a float where a reviewer picked one
starting row — the question was *where do I start reading*, which a subject answers. Since
#152 every commit carries a box, so the question is *is this one worth reading*.

**The blocking cost still stands.** The listing is a metadata query and near-instant; the
counts are a diff of every commit on the branch. So the float opens on the listing alone and
fills the columns in when git answers. An answer reaching a float that has since been closed
is dropped rather than painted into a wiped buffer — both the buffer and the window are
checked, because the window can also go with the tab it was in or with the review behind it.

**The author stays off the row.** That half of the refusal is untouched, and there is now an
assertion that it is still true once the size is on the row.

## Details worth knowing

- One process for the whole branch, keyed by commit — the same shape as the merge flag riding
  the existing listing rather than a second walk.
- `--numstat` and never `--shortstat`: the short form is a sentence git writes for a human and
  translates for their locale. A binary file prints `-` for both counts, and is recorded as a
  file touched with no lines anybody wrote.
- `--diff-merges=first-parent`, because the listing is first-parent and a merge is one row: the
  size a row claims is the change the review reads for it.
- The size and the date are padded to the widest the listing carries, so two commits' sizes
  compare down a column rather than by arithmetic.

## The fixture gains an em dash

The oldest branch commit's subject is no longer ASCII. Every column right of the subject is
placed by measuring back from the end of the row **in bytes**, and across five ASCII subjects
that lands exactly where measuring in display columns lands — so an assertion over either
passes whichever ruler the float used. One multi-byte character is what pulls the two apart.
The fixture's row-width and truncation assertions shift with that subject text.

Closes #154
