### PR TITLE
fix(git): say why a pick was refused before saying which

### DIFF
--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -293,6 +293,16 @@ end
 ---@field total integer  How many the branch has
 ---@field hole boolean   Whether a commit was taken out with an older one left in
 
+---What a reviewer is told when a pick cannot be assembled.
+---
+---**The reason comes first and the commit comes last.** These sentences reach a reviewer
+---through whatever notification surface the host wired up, and one that shows a single line
+---truncates the tail. Built the other way round -- the commit, then its subject, then the
+---reason -- the subject sits between the reader and the only part they can act on, and a long
+---subject pushes the reason off the end entirely. A merge subject is the longest git writes,
+---which made the one message that exists to carry a reason the message most likely to lose it.
+---Ordered this way what truncation costs is the sha, and the sha is on the row the cursor is
+---already on.
 ---@param commit CRCommit
 ---@param conflicts string[]
 ---@param err string|nil
@@ -302,13 +312,17 @@ local function refusal(commit, conflicts, err)
   -- files, and naming the kept commit that introduced the conflicting region would take a
   -- heuristic pass of its own that can name the wrong commit confidently.
   if #conflicts > 0 then
-    return ("Taking out %s %s conflicts in %s — the review is unchanged"):format(
+    return ("Conflicts in %s — %s %s cannot be taken out on its own, and the review is unchanged"):format(
+      table.concat(conflicts, ", "),
       commit.sha,
-      commit.subject,
-      table.concat(conflicts, ", ")
+      commit.subject
     )
   end
-  return ("Taking out %s %s could not be assembled — %s"):format(commit.sha, commit.subject, err or "git refused it")
+  return ("%s — %s %s cannot be taken out, and the review is unchanged"):format(
+    err or "git refused it",
+    commit.sha,
+    commit.subject
+  )
 end
 
 ---What a reviewer is told when they take a merge out of the middle of a trim.
@@ -319,11 +333,16 @@ end
 ---them. What they can act on is the reason, and the reason is that the merge is not the
 ---thing they think they are taking out: merging the default branch moves the merge base
 ---forward, so everything that merge brought is already outside this review.
+---
+---**It names no subject either.** A merge is called `Merge remote-tracking branch 'X' into
+---Y`, which says nothing the word *merge* does not already say and spends sixty characters
+---saying it -- which is what pushed the reason out of this sentence before the order changed.
 ---@param commit CRCommit
 ---@return string
 local function merge_refusal(commit)
-  local named = ("Taking out the merge %s %s is not needed"):format(commit.sha, commit.subject)
-  return named .. ": a merge brings nothing the review does not already read — the review is unchanged"
+  return ("A merge brings nothing the review does not already read — %s stays in, and the review is unchanged"):format(
+    commit.sha
+  )
 end
 
 ---What a **trim** leaves a branch review reading from.

--- a/tests/codereview/trim_float_spec.lua
+++ b/tests/codereview/trim_float_spec.lua
@@ -1070,7 +1070,20 @@ describe("<Space> on the merge row, with a commit older than it left in", functi
   it("is told which merge", function()
     local merge = commit_named(MERGE)
     assert.is_true(h.notified(msgs, merge.sha), vim.inspect(msgs))
-    assert.is_true(h.notified(msgs, merge.subject), vim.inspect(msgs))
+  end)
+
+  -- Pressed from the float the sentence is the same one, and it is here that its length is
+  -- worst: the merge a reviewer meets on a real branch is `Merge remote-tracking branch
+  -- 'origin/master' into <branch>`, and carrying that subject pushed the reason past the end
+  -- of a one-line notification.
+  it("is told the reason before the sha, and no subject at all", function()
+    local merge = commit_named(MERGE)
+    assert.is_false(h.notified(msgs, merge.subject), vim.inspect(msgs))
+    local said = vim.tbl_filter(function(m)
+      return m:find("brings nothing", 1, true) ~= nil
+    end, msgs)
+    assert.same(1, #said, vim.inspect(msgs))
+    assert.same(1, said[1]:find("A merge brings nothing"), said[1])
   end)
 
   -- The teeth against a rule that attempts the merge and rewords whatever the merge reported:

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -1104,7 +1104,24 @@ describe("the merge picked out of the middle", function()
 
   it("names the merge it refused", function()
     assert.is_true(h.notified(msgs, short), vim.inspect(msgs))
-    assert.is_true(h.notified(msgs, merge.subject), vim.inspect(msgs))
+  end)
+
+  -- A merge is called `Merge remote-tracking branch 'X' into Y`: sixty characters that say
+  -- nothing the word *merge* does not, in front of the only part a reviewer can act on.
+  it("names no subject, because a merge's subject says nothing the word merge does not", function()
+    assert.is_false(h.notified(msgs, merge.subject), vim.inspect(msgs))
+  end)
+
+  -- The teeth against the sentence going back to reading `Taking out <sha> <subject> ...`: a
+  -- surface that shows one line truncates the tail, so a reason built last is a reason a
+  -- reviewer never reads. What truncation is allowed to cost is the sha, which is on the row
+  -- their cursor is on.
+  it("says why before it says which, so a truncated line still carries the reason", function()
+    local said = vim.tbl_filter(function(m)
+      return m:find("brings nothing", 1, true) ~= nil
+    end, msgs)
+    assert.same(1, #said, vim.inspect(msgs))
+    assert.same(1, said[1]:find("A merge brings nothing"), said[1])
   end)
 
   -- The teeth against a rule that attempts the merge and rewords what `merge-tree` said: that


### PR DESCRIPTION
Taking a merge out of the middle of a **trim** is refused, correctly. What a reviewer read was
this, and nothing after it:

```
Taking out the merge f61a7fcc20 Merge remote-tracking branch 'origin/master' into docs/js-0…
```

## Why the reason went missing

All three refusals put a variable-length subject between the identifier and the payload:

```
Taking out <sha> <subject> <the reason> — the review is unchanged
```

A merge subject is the longest git writes. Measured against the branch above, the sentence ran
198 characters and the reason did not begin until character 102, so any surface showing one
line truncated before it. That is not a property of a particular notification plugin — the
sentence was simply built reason-last.

The case is not incidental. This message exists **because** a file collision told the reviewer
nothing they could act on, and a merge is the one commit type whose subject is guaranteed to be
long. The message designed to carry a reason was the one most likely to lose it.

## What changed

All three refusals lead with the reason and name the commit last, so what truncation costs is
the sha — which is on the row the cursor is already on.

```
A merge brings nothing the review does not already read — 86bb562 stays in, and the review is unchanged
Conflicts in src/config_spec.lua — db4bd2a test: assert the host as well cannot be taken out on its own, …
```

The merge refusal **names no subject at all**. `Merge remote-tracking branch 'X' into Y` says
nothing the word *merge* does not already say, and spends sixty characters saying it. The
conflict refusal keeps its subject, because a normal commit's subject is how a reviewer
recognizes which commit was refused — it just moves behind the reason.

## No behaviour moves

The same sets are refused for the same reasons, the store is still untouched, and the float
still stays open on the row. Verified against the history fixture: a merge taken out of the
middle refuses, a merge inside the leading run still resolves to `last 2` over
`README.md src/config_spec.lua`, and a non-merge conflict still names its files and no
dependency commit.

Two assertions were flipped rather than added: both specs asserted the merge subject **is** in
the message, which is now the opposite of the rule.

The new ordering assertions were mutation-checked — restoring the old
`Taking out <sha> … is not needed: <reason>` order turns exactly those two red and nothing else.

Closes #161
