### PR TITLE
feat(view): take a run of commits out in one press

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ asked to look at it.
 | Key | Action |
 | --- | --- |
 | `<Space>` | Take the commit under the cursor in or out of the review |
+| `<Space>` in visual mode | Take every commit in the rows you drew in or out together |
 | `]c` `[c` | Next / previous checked commit |
 | `<CR>` | Apply the boxes and close |
 | `q` / `<Esc>` | Close and change nothing |
@@ -216,9 +217,18 @@ mechanical rename — and the commits older than it stay in the review. The labe
 differently, because the reading is no longer a run of commits: `branch vs origin/master ·
 4 of 5`.
 
+A run of commits — a rebase's worth of fixups, a stretch of mechanical churn — costs one
+press rather than one per row. Draw the rows in visual mode and press `<Space>` once. The
+rows all become the same rather than each one flipping, and what they become follows the row
+you started on: start on a checked row and the whole run leaves the review, start on an
+unchecked one and the whole run comes back in. So a run that is already half checked resolves
+the way you drew it rather than the way it happened to be.
+
 The top row is "All commits", and it works both ways. Check it and the whole branch is back
 in the review. Uncheck it and every commit leaves, which is a review of your uncommitted work
-alone, labelled `0 of 5`.
+alone, labelled `0 of 5`. A run that reaches that row leaves it alone and treats the commits
+under it normally — it already means every box at once, and a run that happens to touch the
+top of the list should not do something larger than you drew.
 
 On a long branch, `]c` and `[c` move between the commits you have checked, so coming back to
 a decision you already made costs a keystroke instead of a scroll. Neither wraps: at the last

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -169,6 +169,7 @@ The commit list                                        *codereview-commits*
 `gc` opens it over a branch review, and it lists the branch's commits newest
 first, one row each: >
     <Space>          Take the commit under the cursor in or out
+    <Space> (visual) Take the rows you drew in or out together
     ]c [c            Next / previous checked commit
     <CR>             Apply the boxes and close
     q <Esc>          Close, applying nothing
@@ -178,10 +179,18 @@ than inferred from one mark -- and the commits you keep do not have to be next
 to each other. Uncheck one commit in the middle and the commits older than it
 stay in the review.
 
+A run of commits costs one press rather than one per row: draw the rows in
+visual mode and press `<Space>` once. The rows all become the same rather
+than each one flipping, and what they become follows the row you started on
+-- start on a checked row and the whole run leaves the review, start on an
+unchecked one and the whole run comes back in.
+
 The top row is "All commits" and it works both ways: checked it puts the whole
 branch back in the review, unchecked it takes every commit out, which leaves a
-review of your uncommitted work alone. Your cursor opens on the oldest commit
-still in the review, or on that top row while the whole branch is in it.
+review of your uncommitted work alone. A run that reaches that row leaves it
+alone and treats the commits under it normally. Your cursor opens on the
+oldest commit still in the review, or on that top row while the whole branch
+is in it.
 
 `]c` and `[c` move between the commits that are checked, which is how a long
 branch is walked back through without scrolling. Neither wraps: at the last

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -576,6 +576,21 @@ case the header exists for.
 **`nvim_win_call` propagates only the first return value.** Returning `line("w0"), line("w$")`
 from it silently loses the end of the range.
 
+**A key bound in visual mode has to leave visual mode itself, and on a float whose `<Esc>`
+closes it that is not free.** A Lua callback runs without leaving visual mode — which is what
+lets it read `line("v")`, the end the reviewer began on, while the selection is still live —
+so the mode is still there when the callback returns. Feeding a key back is what ends it, and
+which key matters: the commit list binds `<Esc>` to close, so it leaves visual mode with
+`<C-\><C-n>` and feeds it *unmapped* — the key that leaves a mode must not be a key the
+surface has taken for something else. Measured on that float: with nothing fed the mode stays
+`V` after the press; fed unmapped, the mode is `n` and the float is still open.
+
+**A float's title and footer are clipped from the left when they outgrow its border**, with a
+`<` in place of what was cut and no error anywhere. So a footer is a width budget and not a
+sentence: the commit list is fifty columns at its narrowest, and its footer is exactly fifty
+columns wide including the space at each end. A key added to it is paid for by a word taken
+off another.
+
 **One terminal resize fires `VimResized` *and* `WinResized`, so a callback on both runs
 twice.** Measured by driving a real Neovim over a pty and resizing the pty three times:
 

--- a/lua/codereview/trim_float.lua
+++ b/lua/codereview/trim_float.lua
@@ -36,6 +36,13 @@
 ---so `/`, `n`, `N`, `gg` and `G` reach a commit by its subject and reach the ends of the
 ---list already. Nothing below may be mapped over them: a key this float takes is a key a
 ---reviewer no longer has, and none of them is worth what it would cost.
+---
+---**A run of rows pressed together is made uniform, and flipping each of them was refused.**
+---Flipping every row a reviewer drew over is the cheaper rule and the obvious reading of the
+---key -- and over a run that is already mixed it hands back a set they have to work out row
+---by row, which is the state the press was reached for to get out of. What the rows become
+---follows the row the run started at, so the answer is read off where the motion began rather
+---than off whatever the rows between the two ends happen to hold.
 local git = require("codereview.git")
 local render = require("codereview.render")
 
@@ -386,7 +393,13 @@ function M.open(view, root, base)
     title_pos = "center",
     -- Only what works. A key that is not built is not advertised: a footer offering one is
     -- a promise the float cannot keep.
-    footer = " Space toggle · ]c/[c checked · ⏎ apply · q close ",
+    --
+    -- Fifty columns, which is the narrowest this float is ever drawn: a footer wider than
+    -- the border it sits on is clipped from the left, silently, and the keys go with it. The
+    -- run is what the room went to -- the two spellings of the one key read as one item
+    -- together, and the jump pair gives up the word that said what it moves between, which
+    -- its own brackets say to anybody who has met `]f` or `]h`.
+    footer = " Space toggle, v rows · ]c/[c · ⏎ apply · q close ",
     footer_pos = "center",
   })
   -- The rows are fitted to a width they know, so that every one of them stays one row.
@@ -453,26 +466,71 @@ function M.open(view, root, base)
     end
   end
 
-  ---Take the commit under the cursor in or out of the review, and say so on its row.
+  ---Take a run of rows in or out of the review, and say so on every one of them.
   ---
-  ---On the top row it is every commit at once, in whichever direction that row's own box is
-  ---not already pointing: checked, so a narrowed review is widened back out with one key,
-  ---and unchecked, which leaves a review of the reviewer's uncommitted work. Nothing is
-  ---applied and nothing is stored -- `<CR>` is what does that, so a reviewer builds the set
-  ---they want before the review behind them redraws once.
-  local function toggle()
-    local row = vim.api.nvim_win_get_cursor(win)[1]
-    if row == 1 then
+  ---One row is a run of one, which is what a press with no motion behind it is. On the top
+  ---row that is every commit at once, in whichever direction that row's own box is not
+  ---already pointing: checked, so a narrowed review is widened back out with one key, and
+  ---unchecked, which leaves a review of the reviewer's uncommitted work. Nothing is applied
+  ---and nothing is stored -- `<CR>` is what does that, so a reviewer builds the set they want
+  ---before the review behind them redraws once.
+  ---
+  ---**A longer run is made uniform rather than flipped row by row**, and what its rows become
+  ---is read off the row it started at. See the header for what that refuses.
+  ---
+  ---The top row inside a longer run is stepped over rather than folded into it: it is not a
+  ---commit, and it already means *every box at once* -- a run that happened to reach the top
+  ---of the list would otherwise do something far larger than the reviewer drew. A run that
+  ---started there is read from the first commit in it instead, that row being the first one
+  ---the run can act on at all.
+  ---
+  ---Every press comes through here, however many rows it carries, so the repaint that follows
+  ---it -- the boxes, the top row's own box and the count on the title -- is one answer to what
+  ---the reviewer did rather than two that have to agree.
+  ---@param first integer The first row of the run, 1-based
+  ---@param last integer The last row of the run
+  ---@param from integer The row the run started at, which is what decides the direction
+  local function toggle(first, last, from)
+    if last == 1 then
       local whole = all_in(commits, checked)
       for i = 1, #commits do
         checked[i] = not whole
       end
     else
-      -- The listing starts one row below the top row, so the cursor's row is the commit's
-      -- place in it plus one.
-      checked[row - 1] = not checked[row - 1]
+      -- The listing starts one row below the top row, so a row is the commit's place in it
+      -- plus one.
+      local head = math.max(first, 2)
+      local want = not checked[math.max(from, head) - 1]
+      for row = head, last do
+        checked[row - 1] = want
+      end
     end
     paint()
+  end
+
+  ---The row under the cursor, pressed on its own.
+  local function toggle_row()
+    local row = vim.api.nvim_win_get_cursor(win)[1]
+    toggle(row, row, row)
+  end
+
+  ---The rows a reviewer drew over, pressed together.
+  ---
+  ---`v` is the end the run started at and the cursor is the end it stopped at, whichever way
+  ---round the two are on the screen. Read from those two rather than from `'<` and `'>`: those
+  ---marks are not written until visual mode is left, and they say which row is higher rather
+  ---than which one the reviewer began on -- which is the whole of what decides the direction.
+  ---
+  ---Visual mode is left on the way out, so the reviewer is back in the mode every other key on
+  ---this float is pressed in. Left with `<C-\><C-n>` rather than with `<Esc>`, and fed
+  ---unmapped: `<Esc>` is this float's own key for closing, so a press that let that mapping
+  ---run would shut the list on the reviewer as they built a set on it. The composer settles
+  ---out of a mode the same way, for the same reason -- the key that leaves a mode must not be
+  ---a key the surface has taken for something else.
+  local function toggle_run()
+    local from, to = vim.fn.line("v"), vim.fn.line(".")
+    toggle(math.min(from, to), math.max(from, to), from)
+    vim.api.nvim_feedkeys(vim.keycode("<C-\\><C-n>"), "n", false)
   end
 
   ---Move to the next or the previous commit that is checked.
@@ -553,7 +611,13 @@ function M.open(view, root, base)
     view.trim_to(skipped)
   end
 
-  vim.keymap.set("n", "<Space>", toggle, { buffer = buf, desc = "Take this commit in or out of the review" })
+  vim.keymap.set("n", "<Space>", toggle_row, { buffer = buf, desc = "Take this commit in or out of the review" })
+  vim.keymap.set(
+    "x",
+    "<Space>",
+    toggle_run,
+    { buffer = buf, desc = "Take the commits on these rows in or out of the review" }
+  )
   vim.keymap.set("n", "]c", function()
     jump(true)
   end, { buffer = buf, desc = "Next checked commit" })

--- a/tests/README.md
+++ b/tests/README.md
@@ -640,6 +640,27 @@ so the out-of-core language path is still checked locally without ever failing C
   cases, moving instead of reporting on an empty set reds two, and jumping to the next *row*
   rather than the next *checked* row reds four. The scattered set is what gives that last one
   its teeth: over a run with no hole in it, the two rules are one rule.
+- **A run of rows pressed together has to be pressed over a *mixed* run.** "Make every row in
+  the run the same" and "flip each row in the run" produce the same rows over a run that is
+  uniform, so a block that drew its run over an untouched listing passes against either rule
+  and asserts nothing about the one the key exists for. `trim_float_spec` takes two rows out
+  first, and not next to each other, before it draws anything. The direction is the second
+  half: a run drawn downward from a checked row reads the same under "follows the row the run
+  started at" and under "follows the row nearest the top of the list", so one block draws its
+  run *upward* from an unchecked row, which is the only shape that tells the two apart.
+  Measured: flipping each row instead of making them uniform reds six cases, reading the
+  direction off the top of the run reds the two in the upward block, and folding the
+  `All commits` row into a run that reaches it reds one. The `<CR>` block stays green under
+  all three, because the run it applies is uniform — which is the trap itself, seen from the
+  other side.
+- **A visual-mode key on this float has to be fed with the keys that draw the rows.** The
+  press reads `line("v")` while the selection is still live, because `'<` and `'>` are not
+  written until visual mode is left and say which row is *higher* rather than which one the
+  reviewer began on — the same trap the review path's own visual capture is recorded under
+  above. `trim_float_spec`'s driver feeds the motion and the press together, from the row the
+  run starts at, so a run drawn upward is fed upward. It also asserts the reviewer is left in
+  normal mode on a float that is still open: leaving visual mode means feeding a key back, and
+  `<Esc>` — the obvious one — is this float's own key for closing.
 - **A box a spec reads has to be read as a column, and which spelling means *in* has to be
   learned rather than written down.** `trim_float_spec` takes the box column's width from
   where the sha starts on a row, and takes the checked spelling off a float opened over a

--- a/tests/codereview/trim_float_spec.lua
+++ b/tests/codereview/trim_float_spec.lua
@@ -262,6 +262,23 @@ local function toggle(win, row)
   h.feed("<Space>")
 end
 
+---Draw a run of rows in visual mode and press the key once on it.
+---
+---Drawn from `from` to `to` and never from the top of the run down: which end the reviewer
+---began on is what decides the direction, and a helper that always started at the higher row
+---could not press a run drawn upward at all. The keys and the press go in together, because
+---the float reads where the run started while the selection is still live -- `'<` and `'>`
+---are not written until visual mode is left, which is the recorded trap the review path's own
+---visual capture walked into.
+---@param win integer
+---@param from integer The row the run starts at
+---@param to integer The row it ends at
+local function toggle_run(win, from, to)
+  vim.api.nvim_win_set_cursor(win, { from, 0 })
+  local rows = math.abs(to - from)
+  h.feed("V" .. (rows > 0 and rows .. (to > from and "j" or "k") or "") .. "<Space>")
+end
+
 ---The row the cursor is on, which is what every key that moves it is judged by.
 ---@param win integer
 ---@return integer
@@ -278,10 +295,11 @@ local function chrome(win, field)
 end
 
 ---@param buf integer
----@return table<string, boolean> Every left-hand side bound in normal mode
-local function bound(buf)
+---@param mode? string The mode to read, normal by default
+---@return table<string, boolean> Every left-hand side bound in it
+local function bound(buf, mode)
   local lhs = {}
-  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, mode or "n")) do
     lhs[vim.keycode(m.lhs)] = true
   end
   return lhs
@@ -696,6 +714,16 @@ describe("the keys on the float", function()
     assert.is_truthy(footer:find("[c", 1, true), footer)
   end)
 
+  -- The key that is not a key of its own: the same `<Space>`, pressed over rows a reviewer
+  -- drew. A footer that named only the single press would leave the whole of this feature
+  -- something a reviewer has to guess at.
+  it("advertises that a run of rows can be pressed together", function()
+    local win = commits_by_key(review.win)
+    local footer = chrome(win, "footer")
+    h.feed("q")
+    assert.is_truthy(footer:find("v rows", 1, true), footer)
+  end)
+
   -- The other half of the same claim: the footer names what the float has, and the float has
   -- nothing the footer does not name. `<Esc>` is the one key beside those the footer lists,
   -- and `close` is what it does.
@@ -718,6 +746,17 @@ describe("the keys on the float", function()
       ["[c"] = true,
       q = true,
     }, lhs)
+  end)
+
+  -- And the same claim in the mode this float bound a key in second. A reviewer in visual
+  -- mode still has every key visual mode gives them, `o` and `iw` and the operators included:
+  -- the one key taken there is the one that presses the rows they drew.
+  it("binds one key in visual mode, and it is the one that toggles", function()
+    local win, buf = commits_by_key(review.win)
+    local lhs = bound(buf, "x")
+    h.feed("q")
+    assert.is_false(vim.api.nvim_win_is_valid(win))
+    assert.same({ [vim.keycode("<Space>")] = true }, lhs)
   end)
 
   codereview.close()
@@ -1135,6 +1174,346 @@ describe("one press, the title, the footer and the jump pair", function()
 
   h.feed("q")
   codereview.close()
+end)
+
+--- A run of rows in one press ---------------------------------------------------
+
+-- Every run pressed below is **mixed** -- some of its rows checked and some not -- and that
+-- is the whole of what these blocks measure. Over a run that is uniform, "make them all the
+-- same" and "flip each of them" produce the same rows, so a block that drew its run over an
+-- untouched listing would pass against either rule and assert nothing about the one this key
+-- exists for.
+--
+-- The direction is the other half. A run drawn downward from a checked row and one drawn
+-- upward from an unchecked row answer differently, and only the second can tell "follows the
+-- row the run started at" from "follows the row nearest the top of the list" -- which is the
+-- same reading on every run drawn the easy way.
+
+describe("a run of rows drawn downward over a mixed set", function()
+  state.set_trim(root, nil)
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local win, buf = commits_by_key(review.win)
+  local last = #lines(buf)
+
+  -- Two rows out of the four the run will cover, and not next to each other: the run the
+  -- press meets holds checked rows and unchecked rows in the middle of it.
+  toggle(win, 3)
+  toggle(win, 5)
+  local before = checked(buf)
+
+  -- Where the jump pair went under that set, so where it goes after the press is a change
+  -- rather than a coincidence.
+  vim.api.nvim_win_set_cursor(win, { 1, 0 })
+  h.feed("]c")
+  local was = cursor_row(win)
+
+  -- The press. From row 2, which is checked, down to row 5: every row in the run follows row
+  -- 2 out of the review, including the two that were already out.
+  toggle_run(win, 2, 5)
+  local after = checked(buf)
+  local title = chrome(win, "title")
+  local mode = vim.api.nvim_get_mode().mode
+  local still_open = vim.api.nvim_win_is_valid(win)
+  local stored = state.trim(root)
+
+  vim.api.nvim_win_set_cursor(win, { 1, 0 })
+  h.feed("]c")
+  local now = cursor_row(win)
+
+  it("really did press over a run that was already mixed", function()
+    assert.same({ 2, 4, last }, before, table.concat(lines(buf), "\n"))
+  end)
+
+  -- The teeth. Flipping each row instead would have put rows 3 and 5 back in and taken rows
+  -- 2 and 4 out, which is a set with the same number of boxes in it and a different set.
+  it("makes every row in the run the same rather than flipping each of them", function()
+    assert.same({ last }, after, table.concat(lines(buf), "\n"))
+  end)
+
+  it("leaves the row below the run alone", function()
+    assert.same(IN, box(buf, last), lines(buf)[last])
+  end)
+
+  it("counts what the press left on the title", function()
+    assert.is_truthy(title:find(("%d of %d"):format(1, #first_parent), 1, true), title)
+  end)
+
+  -- The pair reads the boxes the press left, and not the ones the float opened on. It landed
+  -- on row 2 before the press, and row 2 is one of the rows the press took out.
+  it("moves the jump pair onto the set the press left", function()
+    assert.same(2, was)
+    assert.same(last, now)
+  end)
+
+  -- Visual mode is left behind, and `<Esc>` is what leaves it -- which is also this float's
+  -- own key for closing. A press that let that mapping run would close the float on the
+  -- reviewer the moment they pressed it.
+  it("leaves the reviewer in normal mode, on a float that is still open", function()
+    assert.same("n", mode)
+    assert.is_true(still_open)
+  end)
+
+  it("did all of that with nothing applied", function()
+    assert.is_nil(stored)
+  end)
+
+  h.feed("q")
+  codereview.close()
+end)
+
+describe("a run of rows drawn upward over a mixed set", function()
+  state.set_trim(root, nil)
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local win, buf = commits_by_key(review.win)
+  local last = #lines(buf)
+
+  -- The two oldest rows out, so the run is mixed again -- and this time the row the run
+  -- starts at is one of the unchecked ones, sitting at the *bottom* of it.
+  toggle(win, last)
+  toggle(win, last - 1)
+  local before = checked(buf)
+
+  -- From the oldest row up to row 3. The run starts unchecked, so every row in it is checked
+  -- back in.
+  toggle_run(win, last, 3)
+  local after = checked(buf)
+  local title = chrome(win, "title")
+  local stored = state.trim(root)
+
+  it("really did press over a run that was already mixed", function()
+    assert.same({ 2, 3, 4 }, before, table.concat(lines(buf), "\n"))
+  end)
+
+  -- The teeth for *which* row decides. Reading the direction off the top of the run instead
+  -- -- row 3, which is checked -- would have taken all four rows out. Flipping each of them
+  -- would have left rows 3 and 4 out and rows 5 and 6 in.
+  it("follows the row the run started at rather than the row nearest the top", function()
+    local every = {}
+    for row = 1, last do
+      every[row] = row
+    end
+    assert.same(every, after, table.concat(lines(buf), "\n"))
+  end)
+
+  -- And the top row's own box answers for the listing again, which is the reading the title
+  -- falls back to its single count on.
+  it("puts the whole branch back in, as the title says with one count", function()
+    assert.same(IN, box(buf, 1), lines(buf)[1])
+    assert.is_nil(title:find(" of ", 1, true), title)
+    assert.is_truthy(title:find(tostring(#first_parent), 1, true), title)
+  end)
+
+  it("did all of that with nothing applied", function()
+    assert.is_nil(stored)
+  end)
+
+  h.feed("q")
+  codereview.close()
+end)
+
+describe("a run that reaches the row above the commits", function()
+  state.set_trim(root, nil)
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local win, buf = commits_by_key(review.win)
+  local last = #lines(buf)
+
+  -- One row out of the three commits the run will cover.
+  toggle(win, 4)
+  local before = checked(buf)
+
+  -- Drawn from the top row down, which is the run a reviewer draws with `gg` and a motion.
+  -- The top row is not a commit, so the direction is read from row 2 -- the first row in the
+  -- run that the press can act on.
+  toggle_run(win, 1, 4)
+  local after = checked(buf)
+  local stored = state.trim(root)
+
+  it("really did press over a run that was already mixed", function()
+    assert.same({ 2, 3, 5, last }, before, table.concat(lines(buf), "\n"))
+  end)
+
+  -- The teeth, and both of them are in this one set. Treating the top row as a commit would
+  -- have taken the whole branch out, rows 5 and 6 included -- a set far larger than the four
+  -- rows the reviewer drew. Reading the direction off that row rather than off the first
+  -- commit under it would have checked the run back in instead.
+  it("leaves that row alone and treats the commits under it normally", function()
+    assert.same({ 5, last }, after, table.concat(lines(buf), "\n"))
+  end)
+
+  it("did all of that with nothing applied", function()
+    assert.is_nil(stored)
+  end)
+
+  h.feed("q")
+  codereview.close()
+end)
+
+-- A run of one row is a press on that row, in both places a press can mean something: a
+-- commit, and the row that answers for all of them. Read as the whole box column off two
+-- floats rather than as one row off one, so a visual press that moved some *other* row is a
+-- case that reds.
+describe("one row drawn in visual mode", function()
+  state.set_trim(root, nil)
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+
+  ---Every box on a float of its own, after `press` has been made on it.
+  ---@param press fun(win: integer)
+  ---@return string[]
+  local function boxes_after(press)
+    local win, buf = commits_by_key(review.win)
+    press(win)
+    local out = {}
+    for row = 1, #lines(buf) do
+      out[row] = box(buf, row)
+    end
+    h.feed("q")
+    return out
+  end
+
+  -- Nothing is stored until `<CR>`, so all four floats below open on the same boxes as this
+  -- one and each press is read against it.
+  local opened = boxes_after(function() end)
+  local visual_row = boxes_after(function(win)
+    vim.api.nvim_win_set_cursor(win, { 3, 0 })
+    h.feed("v<Space>")
+  end)
+  local normal_row = boxes_after(function(win)
+    toggle(win, 3)
+  end)
+  local visual_top = boxes_after(function(win)
+    vim.api.nvim_win_set_cursor(win, { 1, 0 })
+    h.feed("v<Space>")
+  end)
+  local normal_top = boxes_after(function(win)
+    toggle(win, 1)
+  end)
+
+  -- Without this, two floats that both did nothing agree with each other and every case
+  -- below passes against a key that is not bound at all.
+  it("really did move a box on each of those floats", function()
+    assert.are_not.same(opened, visual_row, table.concat(visual_row, " "))
+    assert.are_not.same(opened, visual_top, table.concat(visual_top, " "))
+  end)
+
+  it("takes the commit out exactly as a press in normal mode does", function()
+    assert.same(normal_row, visual_row)
+  end)
+
+  it("means every box on the top row, exactly as a press in normal mode does", function()
+    assert.same(normal_top, visual_top)
+  end)
+
+  codereview.close()
+end)
+
+-- What the store is handed after a run, read off the boxes rather than off the press. A run
+-- that painted correctly and tracked something else would look right on the screen and
+-- review the wrong commits, which is the one failure here a reviewer cannot see.
+describe("<CR> after a run", function()
+  state.set_trim(root, nil)
+  codereview.open()
+  local review = assert(view.current(), "no review view opened")
+  local files_before = #review.files
+  local win, buf = commits_by_key(review.win)
+  local last = #lines(buf)
+
+  -- The three oldest rows, drawn from the newest of them down: a prefix off the start of the
+  -- branch, which is a set that can always be built -- the refusals are `<CR>`'s own claim
+  -- and they are pinned elsewhere in this file.
+  toggle_run(win, 4, last)
+
+  -- What the boxes say, taken off the screen before the key that applies them, and resolved
+  -- through git rather than through anything the float produced.
+  local out = {}
+  for row = 2, last do
+    if box(buf, row) ~= IN then
+      out[#out + 1] = assert(h.git_lines(fixture, { "rev-parse", lines(buf)[row]:match("%x+") })[1])
+    end
+  end
+  h.feed("<CR>")
+  local stored = vim.deepcopy(state.trim(root))
+  table.sort(out)
+  if stored then
+    table.sort(stored)
+  end
+
+  it("really did leave three rows unchecked and the rest in", function()
+    assert.same(3, #out)
+  end)
+
+  it("applies exactly the commits the boxes left unchecked", function()
+    assert.same(out, stored)
+  end)
+
+  it("says on the label what the run left in the review", function()
+    assert.is_truthy(assert(view.current()).scope.label:find("last 2", 1, true))
+  end)
+
+  it("draws the diff again, narrower than it was", function()
+    assert.is_true(#assert(view.current()).files < files_before)
+  end)
+
+  state.set_trim(root, nil)
+  codereview.close()
+end)
+
+-- The footer names one more key than it did, and it is drawn on a border it has to fit
+-- inside: a footer wider than the float is clipped from the left, silently, taking the keys
+-- with it. Measured against the window rather than against a number written here, and at the
+-- narrowest this float is ever drawn -- which is where the room runs out.
+describe("the footer on the narrowest float this opens", function()
+  ---The float's width and what its border says, on a terminal of `columns` columns.
+  ---@param columns integer
+  ---@return { columns: integer, width: integer, footer: string }
+  local function opened_on(columns)
+    h.ui(columns, 40)
+    state.set_trim(root, nil)
+    codereview.open()
+    local review = assert(view.current(), "no review view opened")
+    local win = commits_by_key(review.win)
+    local at = {
+      columns = vim.o.columns,
+      width = vim.api.nvim_win_get_width(win),
+      footer = chrome(win, "footer"),
+    }
+    h.feed("q")
+    codereview.close()
+    return at
+  end
+
+  -- Two terminals two columns apart, both too narrow for a share of the screen to reach the
+  -- width this float refuses to go under. A share alone would draw them apart, so their being
+  -- one width is the floor and can be nothing else -- and the floor is the case the footer
+  -- has to survive.
+  local narrow = opened_on(62)
+  local narrower = opened_on(60)
+  h.ui(110, 40)
+
+  it("really did open at the width this float stops shrinking at", function()
+    assert.same(narrow.columns - 2, narrower.columns)
+    assert.same(
+      narrow.width,
+      narrower.width,
+      ("%d columns on %d, %d on %d"):format(narrow.width, narrow.columns, narrower.width, narrower.columns)
+    )
+  end)
+
+  it("keeps every key it names inside the border it is drawn on", function()
+    local drawn = vim.fn.strdisplaywidth(narrow.footer)
+    assert.is_true(drawn <= narrow.width, ("%d columns of footer on %d: %s"):format(drawn, narrow.width, narrow.footer))
+  end)
+
+  -- And that the keys are all still on it at that width, which is what being clipped takes
+  -- away first.
+  it("still names every key the float has", function()
+    for _, key in ipairs({ "Space", "v rows", "]c", "[c", "⏎", "q close" }) do
+      assert.is_truthy(narrow.footer:find(key, 1, true), narrow.footer)
+    end
+  end)
 end)
 
 --- Applying the boxes -----------------------------------------------------------


### PR DESCRIPTION
Taking six consecutive commits out of a review cost six cursor moves and six presses, and the
commits a reviewer wants out are usually a run — a rebase's worth of fixups, a stretch of
mechanical churn. Now they draw the rows in visual mode and press `<Space>` once.

**The rows are made uniform rather than each one flipping.** Over a run that is already mixed,
a per-row flip hands back a set the reviewer has to work out; making them the same hands back
the one they asked for. What they become follows the row the run **started** at, so the answer
is read off where the motion began rather than off whatever the run happens to hold — start on
a checked row and the whole run leaves the review, start on an unchecked one and it comes back
in.

**The `All commits` row inside a run is stepped over rather than folded in.** It is not a
commit and it already means *every box at once*, so a run that happens to reach the top of the
list does not do something far larger than was drawn. Pressed on its own — in visual mode as in
normal mode — it keeps meaning what it always did.

Every press goes through the one function that repaints, so the boxes, the top row's own box
and the count on the title are one answer to what the reviewer did rather than two that have to
agree. Normal-mode `<Space>` is untouched, and `<CR>` applies exactly the set the boxes show.

The footer reads `Space toggle, v rows · ]c/[c · ⏎ apply · q close`. It was already exactly
fifty columns, which is the narrowest this float is drawn, and a footer wider than its border
is clipped from the left with the keys inside it — so the jump pair gives up the word that said
what it moves between to pay for the key that arrived.

Closes #167.