### PR TITLE
docs(context): land the checkout vocabulary and its ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,24 @@ receives it.
 
 ### Reviewing
 
+**Checkout**:
+One working directory of a repository — the main clone or any git worktree of it. It is the
+unit everything is scoped to: a **queue**, an **archive**, the **trims** and the reviewed
+marks belong to one checkout, and two checkouts of one repository share none of them.
+_Avoid_: session (a session is an agent's, see **Target**), worktree (a **scope** name),
+repository, root, project
+
+**Switch**:
+Move the review from one **checkout** to another, in place. Said of checkouts only — changing
+what a review covers is a change of **scope** and is never a switch.
+_Avoid_: jump, cd, change directory, move, retarget
+
+**Orphaned**:
+Said of a **checkout** whose stored review state is still on disk after its directory is gone,
+so nothing can reach the queue, archive or marks inside it. Removed by a *sweep*, which is
+the plugin's word for discarding aged stored state — not git's *prune*.
+_Avoid_: stale (an annotation's line anchors, see **Stale**), pruned, dead, abandoned, expired
+
 **Scope**:
 What a review covers — a branch, the staged or unstaged changes, the whole worktree,
 whatever changed since the last **batch** went out, or any git revspec.
@@ -199,7 +217,7 @@ The prose a reviewer writes above a **batch**, addressed to the receiving agent,
 an **annotation**. It says what the batch is about as a whole — which part matters most,
 what to ignore, how the pieces relate — and the payload renders it above the header, where
 it is read before the findings. Composed at **submit** time and never held in the **queue**,
-which keeps **entries** and nothing else. A **draft** of one is kept per repository, because
+which keeps **entries** and nothing else. A **draft** of one is kept per **checkout**, because
 a preamble is about a batch and not about a file. An **immediate send** carries none
 (ADR-0004), and a copied payload carries none either: only a **dispatch** carries one — and
 a dispatch keeps it, in the **archive**, because it is part of what was sent. It belongs to
@@ -231,7 +249,7 @@ Delivering a single annotation on its own, without it joining the queue.
 _Avoid_: quick note, one-off, direct send
 
 **Archive**:
-The batches already dispatched from a repository, kept after the queue that held them was
+The batches already dispatched from a **checkout**, kept after the queue that held them was
 cleared — the **entries** as they went and the **preamble** they went under. Only a
 **dispatch** writes it, so a payload copied to a register is not in it. Read-only, which is
 a claim about the record and not a feature left unwritten.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ to close the review.
 | `gs` | Cycle scope and draw again in place |
 | `gr` | Read the diff again from git |
 | `gp` | Show or hide the file tree |
-| `gl` | Switch between the unified and split layouts |
+| `gl` | Toggle the unified and split layouts |
 | `gb` | Read the last dispatched batch back |
 | `gc` | List the commits on the branch, and check the ones to review |
 | `gA` | Show or hide archived entries, for the rest of the session |

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -99,7 +99,7 @@ Buffer-local, inside the review view:
                      joins once a batch has been dispatched
     gr               Re-read the diff from git
     gp               Show or hide the file tree
-    gl               Switch between the unified and split layouts
+    gl               Toggle the unified and split layouts
     gb               Read the last dispatched batch back
     gc               List the commits on the branch and check the ones to
                      review -- see |codereview-commits|
@@ -146,7 +146,7 @@ In the file tree:                                         *codereview-tree*
     <C-p>            Jump to a file by name
     <Tab>            Back to the diff
     gp               Dismiss the tree, landing back in the diff
-    gl               Switch between the unified and split layouts
+    gl               Toggle the unified and split layouts
     gb               Read the last dispatched batch back
     gc               List the commits on the branch and check the ones to
                      review -- see |codereview-commits|

--- a/docs/adr/0007-the-plugin-ships-the-checkout-picker.md
+++ b/docs/adr/0007-the-plugin-ships-the-checkout-picker.md
@@ -1,0 +1,17 @@
+# The plugin ships the checkout picker, as the default `pick_checkout` adapter
+
+A **switch** needs a list of **checkouts** and a way to choose one from it. The plugin builds
+the list itself, from `git worktree list`, and treats the chooser as the default
+implementation of a `pick_checkout` adapter — the shape ADR-0003 gave the composer, not the
+shape `pick_file` has, where the plugin ships nothing at all.
+
+The split follows what each side knows. What a checkout *is* is the plugin's own knowledge,
+and `git worktree list` does not move under it the way the agent tooling behind ADR-0001
+does. How a list is put in front of a reviewer is the host's, and every configuration already
+has a picker.
+
+## Consequences
+
+The listing is worktrees of the current repository only. Reviewing a checkout of a different
+repository needs a host adapter until cross-repository listing exists, which is a deliberate
+deferral and not an oversight.

--- a/docs/adr/0008-a-reviews-checkout-is-v-root.md
+++ b/docs/adr/0008-a-reviews-checkout-is-v-root.md
@@ -1,0 +1,22 @@
+# A review's checkout is `V.root`, never the working directory
+
+A **switch** sets the review tab's working directory with `:tcd`, but nothing in the plugin
+reads it back. `V.root` is what every operation resolves against. The `:tcd` is there for the
+**host** — the LSP root, the gitsigns base, a relative `:e` — and for nothing else.
+
+Trusting the working directory looked equivalent and is not. Neovim silently resets a tab's
+local directory to the global one once that directory is deleted, and fires **no**
+`DirChanged` when it does. An agent worktree pruned while its review is open therefore leaves
+the tab pointing at a live and unrelated checkout, with no event for a cache to hang on. A
+review that read the working directory would go on working, and be wrong.
+
+## Consequences
+
+Every working-directory read inside a review is a bug, including a convenient one.
+`open_file` already joins from `V.root` (`view.lua:1299`) and is the pattern to copy.
+
+A review whose checkout was deleted stays open and readable — it needs no directory to show a
+diff it already holds — with only the operations that need git switched off.
+
+The invariant that a review tab's working directory equals `V.root` is therefore a courtesy
+to the host, not a thing the plugin may rely on. It can be broken with no warning at all.

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -113,7 +113,7 @@ function M.diff(buf, view)
     ["gp"] = { view.toggle_panel, "Show or hide the file tree" },
     -- From the `g` family the other view-level commands come from, and clear of `gt`/`gT`,
     -- which are how `<CR>`'s new tab is returned from.
-    ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
+    ["gl"] = { view.toggle_layout, "Toggle the unified and split layouts" },
     -- `gb` for the **batch**, from the same `g` family. It opens the surface the command
     -- opens, so a reviewer reads one fact off one surface however they asked for it.
     ["gb"] = { view.last_batch, "Read the last batch back" },
@@ -211,7 +211,7 @@ function M.panel(buf, view)
     ["<C-p>"] = { view.pick_file, "Jump to a file" },
     ["<Tab>"] = { view.toggle_focus, "Focus the diff" },
     ["gp"] = { view.toggle_panel, "Hide the file tree" },
-    ["gl"] = { view.toggle_layout, "Switch between the unified and split layouts" },
+    ["gl"] = { view.toggle_layout, "Toggle the unified and split layouts" },
     ["gb"] = { view.last_batch, "Read the last batch back" },
     ["gc"] = { view.commit_list, "List the commits on the branch, and trim the review" },
     ["gA"] = { view.toggle_archived, "Show or hide archived entries" },

--- a/lua/codereview/queue.lua
+++ b/lua/codereview/queue.lua
@@ -1,7 +1,7 @@
 ---The annotation queue.
 ---
 ---Annotate many places, submit once. Module-level rather than per-view because the queue
----is what you submit, not what you are looking at: switching scope or reopening the view
+---is what you submit, not what you are looking at: changing scope or reopening the view
 ---must not scatter a review you have not sent yet.
 local M = {}
 

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -585,7 +585,7 @@ local function belongs_to_before(V, anchor)
   return render.is_before_key(render.line_key(file.path, file.hunks[anchor.hunk].lines[anchor.line]))
 end
 
----Switch between the unified and split layouts, from either pane or from the file tree.
+---Toggle the unified and split layouts, from either pane or from the file tree.
 ---
 ---Configuration decides the layout a review opens in; this decides it from there on, and
 ---the choice is remembered for the rest of the session rather than for this review only.


### PR DESCRIPTION
The vocabulary and the two decision records that the rest of #171 is written against, so every later slice forks from a trunk where **Checkout**, **Switch** and **Orphaned** already mean one thing each.

Two glossary entries were wrong rather than merely absent. The **Archive** and the preamble **Draft** both claimed to be kept per repository; both have always been stored per checkout, keyed on the root path, so two worktrees of one repository have never shared either. The prose described behaviour the code never had.

The layout toggle said "switch", which the glossary now reserves for moving a review between checkouts. It said so in five places — both keymaps, the handler's own doc comment, the README table and the help file — while the handler has been called `toggle_layout` throughout. `gl` now reads "Toggle the unified and split layouts" and agrees with its own name.

ADR-0007 records that the plugin ships the checkout picker as the default `pick_checkout` adapter. ADR-0008 records that a review's checkout is its own root and never the working directory, together with the finding it rests on: Neovim silently resets a tab's local directory to the global one when that directory is deleted, and fires no `DirChanged` for it.

No behaviour changes. `make all` is green — 36 spec files, 0 failures, 0 errors.

Closes #172