### PR TITLE
fix(view): keep a review readable when its checkout is deleted

### DIFF
--- a/docs/adr/0008-a-reviews-checkout-is-v-root.md
+++ b/docs/adr/0008-a-reviews-checkout-is-v-root.md
@@ -5,18 +5,53 @@ reads it back. `V.root` is what every operation resolves against. The `:tcd` is 
 **host** — the LSP root, the gitsigns base, a relative `:e` — and for nothing else.
 
 Trusting the working directory looked equivalent and is not. Neovim silently resets a tab's
-local directory to the global one once that directory is deleted, and fires **no**
-`DirChanged` when it does. An agent worktree pruned while its review is open therefore leaves
-the tab pointing at a live and unrelated checkout, with no event for a cache to hang on. A
-review that read the working directory would go on working, and be wrong.
+local directory to the global one once that directory is deleted, and emits nothing a cache
+can hang on when it does. An agent worktree pruned while its review is open therefore leaves
+the tab pointing at a live and unrelated checkout. A review that read the working directory
+would go on working, and be wrong.
+
+## What actually happens, measured
+
+Neovim 0.12, macOS, with a tab's own directory deleted while that tab is current:
+
+| moment | what fires | `getcwd()` | `getcwd(0, 0)` |
+| --- | --- | --- | --- |
+| the directory is deleted | **nothing at all** | `""` | the deleted directory |
+| leaving that tab | `DirChangedPre` + `DirChanged`, scope `global` | the other tab's | the deleted directory |
+| coming back to it | `DirChangedPre`, scope `tabpage` — and **no** `DirChanged` | the **global** directory | the deleted directory |
+
+Read the second row before concluding an event exists to use: a `DirChanged` does arrive, and
+it describes the *other* tab. The one that would say this tab's answer has changed — a
+`DirChanged` at `tabpage` scope on re-entry — never arrives. `haslocaldir()` goes on answering
+`1` throughout, and `vim.uv.cwd()` is `nil` for as long as the tab is not left.
+
+So `""` is not the standing answer, and reasoning as though it were is the trap. Stay in the
+tab and a working-directory read is empty and fails loudly; leave and come back and it names
+a live, unrelated checkout, resolves, succeeds and is wrong.
 
 ## Consequences
 
 Every working-directory read inside a review is a bug, including a convenient one.
-`open_file` already joins from `V.root` (`view.lua:1299`) and is the pattern to copy.
+`open_file` joins from `V.root` and is the pattern to copy.
+
+**Including the reads that are not in this code.** Any call that absolutises a relative path
+reads the working directory, and Neovim's own library does it silently: `vim.filetype.match`
+puts a relative filename through `vim.fs.abspath`, which is an `assert(vim.uv.cwd())`. The
+syntax pass asked it for a language by a repository-relative path and therefore *raised* on
+every paint and every cursor move once the checkout was gone — a review made unusable with no
+git call anywhere near it. Four slices read this ADR and none caught that, because the prose
+above only warned about reads a grep for `getcwd` would find. It is not enough to keep
+`getcwd` out of a review: a path handed to any library has to be joined from `V.root` first.
 
 A review whose checkout was deleted stays open and readable — it needs no directory to show a
-diff it already holds — with only the operations that need git switched off.
+diff it already holds — with the operations that need the checkout refused by name. That
+verdict is re-tested per operation and never latched, so a directory that comes back works
+again at the next keypress.
+
+There is exactly one place in the plugin where the two candidate answers differ, and it is
+this one. `tests/codereview/frozen_spec.lua` is therefore where this ADR is proved rather
+than restated; the mutation at the end of that file is the proof, and every other spec is
+satisfied by an implementation that reads the tab and happens to agree.
 
 The invariant that a review tab's working directory equals `V.root` is therefore a courtesy
 to the host, not a thing the plugin may rely on. It can be broken with no warning at all.

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -910,3 +910,58 @@ back to the diff window, so choosing an agent from the queue float dumped the cu
 the diff — where `<C-s>` hits the *main* buffer's mapping, which submits the batch but
 leaves the float open behind it. It also has to drive its own repaint: the picker is
 asynchronous, so anything run after the call returns paints before a target exists.
+
+## A checkout deleted underneath a review
+
+This section is #177's and stands on its own; the **orphan** sweep's rules are elsewhere,
+because that is about *stored state* and this is about the *live review*.
+
+**A relative path handed to any library is a working-directory read.** ADR-0008 says every
+working-directory read inside a review is a bug, and this is the shape of it that no grep
+for `getcwd` finds. `vim.filetype.match({ filename = path })` absolutises a relative name
+through `vim.fs.abspath`, which is an `assert(vim.uv.cwd())` — so the syntax pass asking for
+a language by a repository-relative path *raised*, on every paint and every cursor move,
+once the review's checkout was deleted and the tab had no working directory left. The review
+became unreadable with no git call anywhere near it. It joins from `V.root` now. Anything
+else handing a path to a Neovim library owes the same join.
+
+**`vim.uv.cwd()` is nil only while the reviewer stays in the tab.** Leave it and come back
+and Neovim adopts the global directory, so the crash above heals itself and the wrongness
+that replaces it is silent. That is why the two are asserted in different acts of
+`frozen_spec` and why one measurement of "what does `getcwd()` say" answers neither
+question on its own.
+
+**Reconciling under a gone checkout does not fail — it lies.** `git.hash_worktree` stats
+each path before it runs git, so with the checkout gone `present` is empty and it returns
+`{}` *without spawning git at all*. Every working-tree annotation then compares "no hash"
+against its capture blob, is flagged **stale**, and is written to the store that way; the
+reviewer is told a count that is false about work they still have to send. This is why the
+operations needing the checkout are refused rather than run with a warning in front of
+them: the obscure failure was not an error message, it was a plausible number.
+
+**The verdict is never latched, and that is a rule rather than laziness.** A stat says
+"gone" for a directory that is briefly absent — an unmounted volume, an agent rebuilding a
+worktree at the same path. Stored state needs a grace period because nothing re-asks it; a
+live review is re-asked every time a key is pressed, so re-testing is both cheaper and more
+correct than remembering. The announcement latch clears with it, or a reviewer who gets the
+worktree back is never told it is usable again.
+
+**A switch is the only way out, so its listing cannot be built the obvious way.**
+`git.checkouts` is asked from the checkout the plugin is acting on, which is exactly the
+directory that went — `vim.system` raises on a cwd that is not there, the list comes back
+empty, and the reviewer is told no checkout can be opened. It is asked again from the global
+working directory, which is never moved. Strictly that lists the repository the reviewer is
+standing in rather than the one the dead review was of; nothing can list the latter, because
+a linked checkout's git directory is reached *through* the directory that is gone. The
+fallback is gated on the checkout being absent, not on the list being empty — an empty list
+from a checkout that exists means git named nothing openable in *that* repository, and
+answering it with another repository's checkouts is the cross-repository listing #171 rules
+out.
+
+**`open` resolving its own checkout was the other half of the stranding.** It read `getcwd()`
+raw, which answers `""` in such a tab, and `vim.system` raises on an empty cwd rather than
+reporting a failure — so `:CodeReview` said "not inside a git repository" to a reviewer
+sitting inside one. It resolves through `state.current_checkout` now, which already carried
+that fall-through. Note what this does *not* buy: with a review open, `current_checkout`
+answers that review's root, so reopening cannot rescue a review whose own checkout is the
+one that went. The switch is the gesture for that; this is for the tab afterwards.

--- a/lua/codereview/checkout.lua
+++ b/lua/codereview/checkout.lua
@@ -77,6 +77,30 @@ function M.switch()
   end
 
   local checkouts = git.checkouts(root)
+
+  -- **A review whose checkout was deleted underneath it can still be left.**
+  --
+  -- The listing is built by asking git from the checkout the plugin is acting on, and that
+  -- is exactly the directory that went: `vim.system` raises on a cwd that is not there, so
+  -- the answer is an empty list and the reviewer is told no checkout can be opened. With
+  -- `:CodeReview` resolving through the same question, a switch is the only way out of such
+  -- a review -- so the one gesture that must keep working is the one a deletion took away.
+  --
+  -- Asked again from the *global* working directory, which is the checkout Neovim started
+  -- in: it is never moved (ADR-0008), which is the whole of why a reviewer can always get
+  -- back to where they began. Strictly the repository it lists is the one the reviewer is
+  -- standing in rather than the one the dead review was of. Nothing can list the latter --
+  -- a linked checkout's git directory is reached through the directory that is gone -- and
+  -- in the case this exists for the two are the same repository anyway.
+  --
+  -- Gated on the checkout being gone, not merely on an empty list. An empty list from a
+  -- checkout that is *there* means git named nothing openable in that repository, and
+  -- answering that with another repository's checkouts would be the cross-repository
+  -- listing #171 rules out.
+  if #checkouts == 0 and (vim.uv.fs_stat(root) or {}).type ~= "directory" then
+    checkouts = git.checkouts(vim.fn.getcwd(-1, -1))
+  end
+
   if #checkouts == 0 then
     -- Reachable only when git listed nothing this plugin could open: every checkout it
     -- named was bare, or gone, or unresolvable. Said rather than opening an empty picker,

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -88,8 +88,17 @@ local roots = {}
 ---thing worth more: a `git init` in the directory they are in is visible at the next redraw
 ---rather than after a restart.
 ---
----`M.root` is left alone for that same reason. Opening a review and capturing an annotation
----both ask it, and both have to see a repository the moment it exists.
+---`M.root` is left alone for that same reason, and **capture** still asks it directly: an
+---annotation taken in a directory that has just become a repository has to be filed in it.
+---
+---Opening a review no longer asks it. `open` resolves through `current_checkout`, which is
+---memoised here — because resolving it separately meant resolving it with a raw `getcwd()`,
+---and that answers `""` in a tab whose own directory was deleted, where `vim.system` raises
+---rather than reporting a failure. A second copy of the question was a second chance to
+---answer it differently, and it did. What the memo costs `open` is a `git init` *inside* a
+---checkout it has already resolved: the directory keeps naming the outer checkout until the
+---session ends. A repository appearing where there was none is unaffected, because that
+---answer was never remembered.
 ---@param dir string|nil
 ---@return string|nil root nil for a directory inside no checkout, and for no directory
 function M.root_cached(dir)

--- a/lua/codereview/syntax.lua
+++ b/lua/codereview/syntax.lua
@@ -68,7 +68,18 @@ local function parser_available(lang)
 end
 
 ---Treesitter language for a path, or nil when there is no parser for it.
----@param path string
+---
+---**Hand this an absolute path from inside a review.** `vim.filetype.match` absolutises a
+---relative name for itself, through `vim.fs.abspath`, which is an `assert(vim.uv.cwd())` --
+---so a relative name is a working-directory read wearing a filetype's clothes. It raises,
+---rather than answering wrongly, once the review's **checkout** is deleted and the tab it
+---is drawn in has no working directory at all. That is ADR-0008's rule reached through a
+---library call instead of through plugin code, and it is why the ADR says *every*
+---working-directory read inside a review is a bug, including a convenient one.
+---
+---Still typed as any path, and still asked with a relative one from outside a review, where
+---there is no root to join from and a working directory is the honest answer.
+---@param path string Absolute, when the caller has a review's root to join from
 ---@return string|nil
 function M.lang_for(path)
   local ft = vim.filetype.match({ filename = path })
@@ -311,7 +322,11 @@ function M.apply(view, ns, group_for)
     -- The panes hold the same rows, so one pane's bounds answer for both.
     local near = maps.first <= hi and maps.last >= lo
     if near and not file.binary and not view.syntax_painted[file.path] then
-      local lang = M.lang_for(file.path)
+      -- Joined from the review's root, never left relative: the language question is
+      -- answered by a call that absolutises what it is given, so a relative path here reads
+      -- the working directory and raises once the checkout is gone. `open_file` joins from
+      -- the same authority, which is the pattern ADR-0008 names.
+      local lang = M.lang_for(vim.fs.joinpath(view.root, file.path))
       if lang then
         local group_of = group_for and group_for(fi) or nil
         -- An untracked file has no committed pre-image; its "after" is the working tree.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -67,6 +67,7 @@ local NS = vim.api.nvim_create_namespace("codereview")
 ---@field syntax_painted table<string, boolean>|nil      Path -> already replayed onto this render
 ---@field syntax_rows table<integer, CRFileRows>|nil     File index -> where its lines are drawn
 ---@field dims string|nil                 The size of every review window the last paint was made at
+---@field told_gone boolean|nil           Whether the reviewer has been told this checkout is gone
 
 ---@type CRView|nil
 local V = nil
@@ -97,6 +98,87 @@ end
 ---@param msg string
 local function info(msg)
   vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
+
+--- A checkout that dies underneath a review ------------------------------------
+
+-- An agent prunes the worktree it was working in while the review of it is open. The diff
+-- and the annotations on it are already in memory and need no directory, so the review
+-- stays open and readable and the reviewer loses nothing they were in the middle of. What
+-- goes is only what genuinely needs the checkout, and it is refused with a reason rather
+-- than left to fail through git.
+--
+-- **Readable is not free, and it is not only about git.** Every path that absolutises a
+-- relative name reads the working directory, including paths inside Neovim's own library:
+-- the syntax pass asked `vim.filetype.match` for a language by a repository-relative name,
+-- and that raised on every paint and every cursor move once the tab had no working
+-- directory. `syntax.lua` joins from the review's root now, for the reason everything here
+-- resolves against it (ADR-0008).
+
+---The one sentence both doors say, because it is one fact.
+---
+---A reviewer who meets it at a refusal and again on coming back should recognise it, and a
+---second phrasing would be a second rule to keep true.
+local GONE = "The checkout under this review is gone"
+
+---Whether the **checkout** this review is on is still there.
+---
+---**Read from `V.root` and from nothing else.** This is the one question in the plugin
+---whose two candidate answers actually differ: the working directory reads `""` inside the
+---tab and, once that tab has been left and re-entered, the *global* checkout -- which is
+---live, unrelated and would report this review as perfectly healthy. That is ADR-0008's
+---whole case, and this predicate is where it is spent.
+---
+---**Never latched.** A directory that is briefly absent -- an unmounted volume, an agent
+---rebuilding a worktree at the same path -- costs nothing here but a refusal that stops
+---applying at the next keypress. The grace period the **orphan** sweep needs is for stored
+---state, which cannot be re-tested by pressing a key again; a live review can be.
+---@return boolean
+local function checkout_gone()
+  if not V then
+    return false
+  end
+  local stat = vim.uv.fs_stat(V.root)
+  if stat and stat.type == "directory" then
+    -- Back, so the announcement is owed again if it goes a second time.
+    V.told_gone = nil
+    return false
+  end
+  return true
+end
+
+---Refuse an operation that needs the checkout, naming what needed it.
+---
+---**Always speaks.** A key pressed twice says why twice: silence is the obscure failure this
+---replaces, and a reviewer holding `gs` must not be left watching nothing happen.
+---
+---Refusing rather than warning-and-continuing is the point for the reconciliation in
+---particular. `hash_worktree` stats each path before it runs git, so under a gone checkout
+---it returns nothing without spawning git at all -- and every working-tree annotation then
+---compares "no hash" against its capture blob, is flagged **stale**, and is written to the
+---store that way. The reviewer would be told a number that is a lie about work they still
+---have to send.
+---@param needed string What the refused operation needs the checkout for
+---@return boolean refused
+local function without_checkout(needed)
+  if not checkout_gone() then
+    return false
+  end
+  warn(("%s — %s needs it"):format(GONE, needed))
+  return true
+end
+
+---Say it once, unprompted.
+---
+---Latched separately from the refusals above: they answer an operation, this answers the
+---review. Being told at a key you pressed and again when you come back to the diff is two
+---different sentences at two different moments, not one sentence repeated.
+local function tell_gone()
+  if V.told_gone then
+    return
+  end
+  V.told_gone = true
+  warn(GONE .. " — the diff and its annotations are still here, and gS switches elsewhere")
 end
 
 ---@return CRView|nil
@@ -1171,6 +1253,9 @@ function M.refresh()
   if not M.current() then
     return
   end
+  if without_checkout("re-reading the diff") then
+    return
+  end
   local cfg = config.get()
   local files, err =
     git.collect(V.scope, V.root, { context = cfg.context, untracked = cfg.untracked, spans = cfg.spans })
@@ -1206,6 +1291,13 @@ local function judge_archive()
     V.touched, V.untouched, V.judged = {}, nil, nil
     return
   end
+  -- Silently, and without disturbing what is already tallied. Two git invocations is what
+  -- this costs, so it is one of the operations a gone checkout switches off -- but it says
+  -- nothing a reviewer has to act on, exactly as its own docstring argues, so it does not
+  -- get a sentence of its own beside the refusal of whatever key led here.
+  if checkout_gone() then
+    return
+  end
   local state = require("codereview.state")
   V.touched, V.untouched = state.reconcile_archive(V.root, V.files)
   V.judged = state.archive_writes()
@@ -1215,6 +1307,9 @@ end
 ---the blob comparison invalidated.
 function M.reconcile()
   if not V then
+    return
+  end
+  if without_checkout("reconciling") then
     return
   end
   judge_archive()
@@ -1234,6 +1329,9 @@ end
 ---@param spec string|nil nil cycles to the next scope this repository offers
 function M.set_scope(spec)
   if not M.current() then
+    return
+  end
+  if without_checkout("changing scope") then
     return
   end
   if not spec then
@@ -1313,6 +1411,12 @@ function M.open_file()
   if not anchor then
     return
   end
+  -- Before the readability test below, which would otherwise answer this case with "the
+  -- file does not exist in the working tree" -- true, and misleading: it sends a reviewer
+  -- looking for a deleted file when what went is everything around it.
+  if without_checkout("opening the file") then
+    return
+  end
   local file = V.files[anchor.file]
   local abs = vim.fs.joinpath(V.root, file.path)
   if vim.fn.filereadable(abs) == 0 then
@@ -1374,6 +1478,12 @@ M.hand_to_diff = hand_to_diff
 ---than inventing line 1: a file header knows which file and nothing about where in it.
 function M.open_diff()
   if not M.current() then
+    return
+  end
+  -- The same act through the host's door. What is handed over is an absolute path inside
+  -- the checkout plus the refs its scope is between, and a diff tool given those runs git
+  -- in a directory that is not there.
+  if without_checkout("the diff tool") then
     return
   end
   local anchor = anchor_at_cursor()
@@ -1670,6 +1780,9 @@ function M.commit_list()
   if not v then
     return
   end
+  if without_checkout("listing the commits") then
+    return
+  end
   if v.scope.name ~= "branch" then
     info(("Commits are listed for a branch review — this review is %s"):format(v.scope.label))
     return
@@ -1708,6 +1821,9 @@ end
 function M.trim_to(skipped)
   local v = M.current()
   if not v then
+    return
+  end
+  if without_checkout("trimming") then
     return
   end
   local refused = require("codereview.git").trim_refusal(v.root, v.scope.identity, skipped)
@@ -1797,8 +1913,8 @@ end
 ---
 ---@param spec string|nil
 ---@param checkout string|nil The **checkout** to review, as a **switch** names one. nil
----       resolves it from the working directory, which is what `:CodeReview` does and what
----       every review did before a switch existed.
+---       asks which checkout the plugin is acting on, which is the open review's own and
+---       the working directory's with none open.
 ---@return boolean opened False has already said why: no repository, an unresolvable scope,
 ---        a failed diff, or a scope with nothing in it. A review that was already open is
 ---        still open in each of those cases -- nothing is closed until there is something
@@ -1807,7 +1923,14 @@ function M.open(spec, checkout)
   hl.setup()
   local cfg = config.get()
 
-  local root = checkout or git.root(vim.fn.getcwd())
+  -- Through the one question rather than around it. Resolving the working directory here
+  -- read `getcwd()` raw, which answers `""` in a tab whose own directory was deleted -- and
+  -- `vim.system` raises on an empty cwd rather than reporting a failure, so `:CodeReview`
+  -- was the second half of a stranding: neither a switch nor a reopen could get a reviewer
+  -- out of a review whose checkout had gone. `current_checkout` already carries the
+  -- fall-through that case needs, and a second copy of the resolution is a second chance to
+  -- answer it differently.
+  local root = checkout or require("codereview.state").current_checkout()
   if not root then
     warn("not inside a git repository")
     return false
@@ -1907,6 +2030,20 @@ function M.open(spec, checkout)
     callback = function()
       if M.current() and dimensions() ~= V.dims then
         M.paint()
+      end
+    end,
+  })
+
+  -- Nothing at all fires when a checkout is deleted (ADR-0008), so there is no moment to
+  -- announce it at except the two a reviewer makes for themselves: the operation they ask
+  -- for, which each refusal answers, and coming back to the review, which is this. It is the
+  -- only free moment there is -- a cursor move is on every keystroke and a paint is on every
+  -- resize, and neither may grow a syscall. One `fs_stat`, on entering this review's own tab.
+  vim.api.nvim_create_autocmd("TabEnter", {
+    group = V.augroup,
+    callback = function()
+      if M.current() and vim.api.nvim_get_current_tabpage() == V.tab and checkout_gone() then
+        tell_gone()
       end
     end,
   })

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,6 +83,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `checkout_restart_spec` | The same scoping across a genuine restart: what two checkouts worked in one session left on the disk, each store holding only what it is about, and the id a new annotation takes in a checkout whose **archive** the counter has never been seeded from |
 | `switch_spec` | Moving the review to another **checkout**: the listing it is chosen from — the three checkouts of one repository, each named as its own git names it, with a bare one and a deleted one left out — the picker the plugin ships and the `pick_checkout` adapter that replaces it, a switch with a review open and with none, the directories a switch must not move, the queue and the store and the id that follow the review rather than the working directory, and what belongs to no checkout riding along into one reached by switching — asked from a tab standing in another checkout — the tab a real file opens into, `:CodeReviewSwitch` and `gS` in the diff and the tree, and the checkout with nothing in scope that is declined rather than opened |
 | `count_spec` | The queued count a statusline asks for: which **checkout** it is about after a bare directory change, the bare note that is in the number everywhere, what a redraw costs in git processes cold and warm, the answer of "no checkout" that is deliberately not remembered so a `git init` is visible at once, the tab whose own directory was deleted underneath it, and the intersection with the **switch** — the number read from the tab the reviewer is standing in, about the checkout the review is on |
+| `frozen_spec` | A **checkout** deleted underneath an open review, which is the one place the review's root and the tab's working directory give different answers — so this is where ADR-0008 is proved and not merely restated. In two acts, because the two halves need different tab states: never having left the tab, where there is no working directory at all and the review has to stay readable through it; then having left and returned, where the tab has adopted a *live* sibling checkout and a working-directory read resolves, succeeds and is wrong. The paint, the cursor move and the file tree that all raised; the highlighting the diff keeps; the queue still readable; each operation needing the checkout refused by name rather than through git; the reviewer told on coming back; the store the annotation still reaches; the **switch** out that a deletion took away; `:CodeReview` from a tab with no directory of its own — and the executed mutation that replaces the review's root with a working-directory read and shows the review opening a file out of the wrong checkout |
 
 ## Fixtures
 
@@ -924,6 +925,42 @@ so the out-of-core language path is still checked locally without ever failing C
   dropping the backticks, say — silently yields no rows, and "no row names a module that is
   gone" then holds over nothing. It asserts both sides are non-empty before comparing them,
   which is the only reason that reformatting reds two cases instead of one.
+
+### A checkout deleted underneath a review
+
+This subsection is #177's and stands on its own.
+
+**A case about a deleted checkout has to say which act it is in.** `vim.uv.cwd()` is nil only
+while the reviewer stays in the tab; leaving it and coming back makes Neovim adopt the global
+directory. So a case that asserts the review is still readable must not have left the tab —
+the raise it guards against heals on re-entry — and a case that asserts *which* checkout the
+review resolves against must have left and returned, or a working-directory read answers `""`,
+fails loudly, and the case passes for the wrong reason. One `getcwd()` measurement answers
+neither question on its own. `frozen_spec` is in two acts for exactly this, and pins the
+environment at each boundary so a future Neovim that changes either answer fails here rather
+than somewhere confusing.
+
+**The checkout the reviewer stands in must be alive, and must not be the one under review.**
+The whole trap is that a working-directory read names something that *exists*. Stand the
+reviewer outside every checkout and every assertion naming the review's root passes under the
+implementation the file exists to catch.
+
+**Only a working-tree capture can be falsely staled.** A review annotation is judged against
+the blob its scope already holds in memory, which no deletion can move; a capture taken from
+the file carries a working-tree blob and is judged against the disk. So "reconciling is
+refused, and the queue's staleness is left alone" needs an entry captured from a buffer, or
+it is a rule with nothing to fail on.
+
+**A switch needs a target with something in scope.** The `mkcheckouts` fixture's `main` is the
+branch the other two are cut from, so its own branch review is empty and a switch to it is
+declined rather than opened — which `switch_spec` owns as a case in its own right. A file
+asserting that a reviewer can *get out* has to switch to `agent-a` or `agent-b`.
+
+**A mutation case asserts the broken behaviour, so it is green before and after.** The one at
+the end of `frozen_spec` replaces the review's root with a working-directory read and asserts
+the review opens a file out of an unrelated checkout. It is a sensitivity check on every case
+above it rather than a behaviour case, and reading it as a failing test to fix would delete
+the proof.
 
 ## Deliberately not covered
 

--- a/tests/codereview/frozen_spec.lua
+++ b/tests/codereview/frozen_spec.lua
@@ -1,0 +1,485 @@
+-- A **checkout** deleted underneath an open review.
+--
+-- **This file is where ADR-0008 is proved, and it is the only place it can be.** Inside a
+-- review tab `getcwd()` answers the `:tcd` the open just set, so an implementation that
+-- reads the tab's working directory instead of the review's root passes every case
+-- `switch_spec` is able to write. `switch_spec` says so itself and leaves the proof here.
+--
+-- The two answers come apart in one place: the review's checkout is deleted, and the tab
+-- silently adopts the global working directory. Measured on this platform, with the tab's
+-- own directory deleted:
+--
+--   * nothing at all fires at the moment of deletion;
+--   * while the reviewer stays in the tab, `getcwd()` is `""` and `vim.uv.cwd()` is nil;
+--   * leaving the tab fires `DirChanged` at *global* scope, describing the other tab;
+--   * coming back fires `DirChangedPre` at *tabpage* scope and **no** `DirChanged`, and
+--     from then on `getcwd()` answers the global directory while `getcwd(0, 0)` and
+--     `haslocaldir()` both still insist the deleted directory is the tab's.
+--
+-- Both halves are needed here and they need different tab states, which is why this file
+-- is in two acts.
+--
+-- **Act one, never having left the tab.** `vim.uv.cwd()` is nil, and that is what makes
+-- the review unreadable today: `syntax.lua` hands a *repository-relative* path to
+-- `vim.filetype.match`, which absolutises it through `vim.fs.abspath` -- an
+-- `assert(vim.uv.cwd())`. Every paint and every cursor move raises, and none of that path
+-- touches git. So "only what needs git is switched off" is not the rule; "the review
+-- remains usable" is, and switching git off is one part of it.
+--
+-- **Act two, having left the tab and come back.** `getcwd()` now answers `main`, which is
+-- a *live* checkout of the same repository: a working-directory read resolves, succeeds,
+-- and is wrong. That is the state the assertions about resolution are made in, and the
+-- state the mutation at the end of the file is run in. Asserted in act one instead, a
+-- working-directory read would answer `""` and fail loudly -- the mutation would die for
+-- the wrong reason and prove nothing about the review's root.
+--
+-- Single process, and one review throughout: what is being asserted is what one session
+-- can still do with a review whose checkout went out from under it.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+
+-- Three checkouts of one repository. Realpathed once: `git rev-parse --show-toplevel`
+-- answers resolved, and on macOS a temporary directory is a symlink into /private.
+local base = assert(vim.uv.fs_realpath(h.fixture("mkcheckouts")))
+local MAIN = vim.fs.joinpath(base, "main")
+local A = vim.fs.joinpath(base, "agent-a")
+local B = vim.fs.joinpath(base, "agent-b")
+
+local codereview = require("codereview")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+-- The checkout the reviewer is standing in, for the whole file, and never moved.
+--
+-- It has to be a checkout that is *alive* and is *not* the one being reviewed. That is the
+-- whole trap: once the review's tab falls back to this directory, a working-directory read
+-- names a real repository with a real `src/main.lua` in it, so it does not fail -- it
+-- answers about the wrong checkout. A reviewer standing outside every checkout would make
+-- every case below pass under a reading this file exists to catch.
+vim.cmd("cd " .. vim.fn.fnameescape(MAIN))
+local reviewer_tab = vim.api.nvim_get_current_tabpage()
+
+-- The sentence every door says. One fragment shared by the announcement and by each
+-- refusal, because it is one fact: a reviewer who meets it twice should recognise it, and
+-- a second phrasing would be a second rule to keep true.
+local GONE = "checkout under this review is gone"
+
+local note = "unset"
+local picked, offered = nil, nil
+
+-- **Syntax is left at its default, deliberately.** `switch_spec` turns it off; this file
+-- must not, because the pass that reads the working directory *is* the syntax pass. A spec
+-- asserting the review is still readable with the one thing that breaks it removed would
+-- assert nothing.
+codereview.setup({
+  compose = function(_, on_accept)
+    on_accept(nil, note)
+  end,
+  -- Stubbed exactly as the send, target and compose adapters are stubbed throughout the
+  -- suite. What it is *offered* is asserted too: the listing is the half of a switch that a
+  -- deleted checkout breaks, so a stub that only answered would hide it.
+  pick_checkout = function(checkouts, on_choice)
+    offered = checkouts
+    on_choice(picked)
+  end,
+})
+
+---@return CRView
+local function current()
+  return assert(view.current(), "no review view open")
+end
+
+---The notes the queue holds right now.
+---@return string[]
+local function queued_notes()
+  return vim.tbl_map(function(e)
+    return e.note
+  end, queue.all())
+end
+
+---The queued entry carrying a note, so a flag written onto it can be read back.
+---@param needle string
+---@return table
+local function entry_named(needle)
+  for _, e in ipairs(queue.all()) do
+    if e.note == needle then
+      return e
+    end
+  end
+  error("no queued entry says " .. needle .. ": " .. vim.inspect(queued_notes()))
+end
+
+---The notes a checkout's store holds, queued and archived alike.
+---@param checkout string
+---@return string[]
+local function stored_notes(checkout)
+  local doc = state.load(checkout)
+  local notes = {}
+  for _, entry in ipairs(doc.queue or {}) do
+    notes[#notes + 1] = entry.note
+  end
+  for _, batch in ipairs(doc.archive or {}) do
+    for _, entry in ipairs(batch.entries or {}) do
+      notes[#notes + 1] = entry.note
+    end
+  end
+  table.sort(notes)
+  return notes
+end
+
+---The paths a listing names, sorted so the assertion is about the set and not the order.
+---@param checkouts table[]
+---@return string[]
+local function paths_of(checkouts)
+  local paths = vim.tbl_map(function(c)
+    return c.path
+  end, checkouts or {})
+  table.sort(paths)
+  return paths
+end
+
+---Everything `vim.notify` was handed while `fn` ran.
+---@param fn fun()
+---@return string[]
+local function said(fn)
+  local msgs, restore = h.capture_notify()
+  local ok, err = pcall(fn)
+  restore()
+  assert(ok, tostring(err))
+  return msgs
+end
+
+---The review's whole after pane as one string.
+---@return string
+local function on_screen()
+  return table.concat(vim.api.nvim_buf_get_lines(current().buf, 0, -1, false), "\n")
+end
+
+--- The review, before anything happens to it -------------------------------------
+
+assert(view.open(nil, A), "the review did not open on agent-a")
+local review_tab = current().tab
+local painted_before = #h.syntax_marks(current())
+
+-- One annotation about a file of this checkout, captured the way a reviewer captures one --
+-- through the review's own key rather than written into the store. What is being asserted
+-- later is that the reviewer does not lose work they were in the middle of, so the work has
+-- to have been made the way they make it.
+local NOTE = "about agent-a, written while its checkout was still there"
+
+-- And one captured from the file itself rather than from the diff, because only that shape
+-- carries a **working-tree** blob. A diff annotation is judged against the blob the scope
+-- already holds in memory, which no deletion can move; a working-tree one is judged against
+-- the disk, and the disk is what goes. It is the only entry shape that a reconcile run
+-- against a checkout that is gone can be *falsely* judged -- so it is what gives the
+-- refusal below something to fail on.
+local WORKTREE_NOTE = "about a file of agent-a, captured from the file"
+
+describe("a review opened on a checkout that is about to go", function()
+  it("is on that checkout, with a diff drawn and highlighted", function()
+    assert.same(A, current().root)
+    assert.is_true(#current().files > 0, "the review has no files")
+    assert.is_true(painted_before > 0, "nothing was highlighted before the deletion")
+  end)
+
+  it("takes an annotation into that checkout's queue", function()
+    note = NOTE
+    local row = assert(h.line_row(current(), "src/main.lua"), "no diff row for src/main.lua")
+    vim.api.nvim_set_current_win(current().win)
+    vim.api.nvim_win_set_cursor(current().win, { row, 0 })
+    require("codereview.annotate").annotate("bug")
+    assert.is_true(vim.tbl_contains(queued_notes(), NOTE), vim.inspect(queued_notes()))
+  end)
+
+  -- In a tab of its own, because editing the file in the review tab would put it over the
+  -- diff. Dismissed again immediately: what this case is for is the entry, not the window.
+  it("takes an annotation captured from a file of it, carrying a working-tree blob", function()
+    note = WORKTREE_NOTE
+    vim.cmd("tabnew " .. vim.fn.fnameescape(vim.fs.joinpath(A, "src/config.lua")))
+    codereview.annotate("bug")
+    vim.cmd("tabclose")
+    vim.cmd("tabnext " .. vim.api.nvim_tabpage_get_number(review_tab))
+    assert.is_true(entry_named(WORKTREE_NOTE).worktree, "the capture carries no working-tree blob")
+  end)
+end)
+
+--- The checkout goes ------------------------------------------------------------
+
+-- Deleted with the review tab current, which is the reviewer's own position: an agent
+-- prunes its worktree while they are reading the diff of it. That is what leaves the
+-- *process* working directory inside a directory that no longer exists, and it is the
+-- state act one is about.
+vim.fn.delete(A, "rf")
+
+--- Act one: still standing in the tab ---------------------------------------------
+
+describe("the tab a deleted checkout leaves behind", function()
+  -- The guard that makes every case below what it claims to be. Not "the working directory
+  -- is different" -- there is no working directory at all, and every implicit
+  -- absolutisation Neovim does has nothing to work from.
+  it("has no working directory, and no process directory either", function()
+    assert.same("", vim.fn.getcwd())
+    assert.is_nil(vim.uv.cwd())
+  end)
+
+  -- Nothing announced it. This is the finding ADR-0008 rests on, asserted where the review
+  -- it happens to is on screen rather than only against a bare tab in `count_spec`.
+  it("still names the deleted checkout as its own", function()
+    assert.same(A, vim.fn.getcwd(0, 0))
+    assert.is_nil(vim.uv.fs_stat(A))
+  end)
+end)
+
+describe("a review whose checkout was deleted underneath it", function()
+  it("is still open", function()
+    assert.is_not_nil(view.current())
+  end)
+
+  -- The case the whole ticket turns on, and it has nothing to do with git. `syntax.lua`
+  -- hands `vim.filetype.match` a repository-relative path, which Neovim absolutises against
+  -- a working directory that is gone. **This reds the moment that path goes back to being
+  -- relative**, which is what it is here for.
+  it("repaints without raising", function()
+    local ok, err = pcall(view.paint)
+    assert.is_true(ok, tostring(err))
+  end)
+
+  -- A repaint runs on a resize; a cursor move runs on every keystroke a reviewer holds. If
+  -- either raises, the review is not readable in any sense a reviewer would accept.
+  it("takes a cursor move without raising", function()
+    local ok, err = pcall(view.cursor_moved)
+    assert.is_true(ok, tostring(err))
+  end)
+
+  -- A third gesture, and one a reviewer makes constantly. Summoned and dismissed in one
+  -- case because the pair is symmetric: the review is left exactly as it was found, so
+  -- nothing below reads a surface this case rearranged.
+  it("summons and dismisses the file tree without raising", function()
+    local first, err = pcall(view.toggle_panel)
+    local back, berr = pcall(view.toggle_panel)
+    assert.is_true(first, tostring(err))
+    assert.is_true(back, tostring(berr))
+  end)
+
+  -- Without this, "the review stayed open" is satisfied by a tab holding an empty buffer,
+  -- and the freeze behaviour is satisfied by the review having closed.
+  it("still draws its diff", function()
+    assert.is_truthy(on_screen():find("src/main.lua", 1, true), on_screen())
+  end)
+
+  -- The captures behind the highlighting were harvested before the deletion and are held in
+  -- memory, so a repaint replays them and needs no directory to do it. This reds both ways
+  -- that path can be got wrong: it reds on the raise, and it reds on a `pcall` that
+  -- swallows the raise and returns no language, which would leave the replay unreached.
+  it("still carries the syntax highlighting it was drawn with", function()
+    assert.is_true(#h.syntax_marks(current()) > 0, "the diff lost its highlighting")
+  end)
+
+  it("still draws the annotation queued before the deletion", function()
+    assert.is_true(#h.virt_marks(current()) > 0, "no annotation is drawn")
+  end)
+end)
+
+describe("the queue of a review whose checkout is gone", function()
+  it("still holds what was captured before the deletion", function()
+    assert.is_true(vim.tbl_contains(queued_notes(), NOTE), vim.inspect(queued_notes()))
+    assert.is_true(vim.tbl_contains(queued_notes(), WORKTREE_NOTE), vim.inspect(queued_notes()))
+    assert.same(2, codereview.count())
+  end)
+
+  it("can still be read", function()
+    view.review_queue()
+    local win = assert(current().queue_win, "no queue float opened")
+    local text = table.concat(vim.api.nvim_buf_get_lines(vim.api.nvim_win_get_buf(win), 0, -1, false), "\n")
+    vim.api.nvim_win_close(win, true)
+    assert.is_truthy(text:find(NOTE, 1, true), text)
+  end)
+end)
+
+--- What the review will not do without its checkout -------------------------------
+
+describe("the operations that need the checkout", function()
+  -- Refused rather than narrated, and this is the case that says why. `hash_worktree`
+  -- `fs_stat`s each path before it runs git; under a gone checkout every stat fails, it
+  -- returns nothing *without spawning git at all*, and every worktree-captured annotation
+  -- compares "no hash" against its capture blob and is flagged **stale**. The reviewer is
+  -- then told a number that is a lie, and `persist` writes the flag into the store. An
+  -- implementation that warns and reconciles anyway satisfies "refused with a clear reason"
+  -- and destroys information.
+  it("refuse to reconcile, and leave the queue's staleness alone", function()
+    local msgs = said(view.reconcile)
+    assert.is_true(h.notified(msgs, GONE), vim.inspect(msgs))
+    assert.is_false(h.notified(msgs, "stale"), vim.inspect(msgs))
+    assert.is_nil(entry_named(WORKTREE_NOTE).stale)
+  end)
+
+  it("refuse to change scope, and leave the review reading what it was reading", function()
+    local msgs = said(function()
+      view.set_scope("worktree")
+    end)
+    assert.is_true(h.notified(msgs, GONE), vim.inspect(msgs))
+    assert.same("branch", current().scope.name)
+  end)
+
+  it("refuse to re-read the diff", function()
+    local msgs = said(view.refresh)
+    assert.is_true(h.notified(msgs, GONE), vim.inspect(msgs))
+  end)
+
+  -- Said as a fact about the checkout and not about the file. "src/main.lua does not exist
+  -- in the working tree" is what this answers today, and it sends a reviewer looking for a
+  -- deleted file when what went is everything around it.
+  it("refuse to open the real file, and open no tab", function()
+    local row = assert(h.line_row(current(), "src/main.lua"), "no diff row for src/main.lua")
+    vim.api.nvim_set_current_win(current().win)
+    vim.api.nvim_win_set_cursor(current().win, { row, 0 })
+    local tabs = #vim.api.nvim_list_tabpages()
+    local msgs = said(view.open_file)
+    assert.is_true(h.notified(msgs, GONE), vim.inspect(msgs))
+    assert.same(tabs, #vim.api.nvim_list_tabpages())
+  end)
+
+  it("refuse to list the commits", function()
+    local msgs = said(view.commit_list)
+    assert.is_true(h.notified(msgs, GONE), vim.inspect(msgs))
+  end)
+end)
+
+--- Being told ---------------------------------------------------------------------
+
+-- Nothing fires when the directory dies, so there is no moment to announce it at except
+-- the two a reviewer makes themselves: the operation they ask for, and coming back to the
+-- review. The refusals above are the first door; this is the second, and it is the only
+-- free one that exists.
+--
+-- This is also the crossing into act two: entering the tab is what makes Neovim adopt the
+-- global directory, and every case after it is asserted in that state.
+describe("coming back to the review tab", function()
+  it("says the checkout is gone", function()
+    local msgs = said(function()
+      vim.cmd("tabnext " .. vim.api.nvim_tabpage_get_number(reviewer_tab))
+      vim.cmd("tabnext " .. vim.api.nvim_tabpage_get_number(review_tab))
+    end)
+    assert.is_true(h.notified(msgs, GONE), vim.inspect(msgs))
+  end)
+end)
+
+--- Act two: the tab has adopted a live checkout ------------------------------------
+
+describe("the working directory a returning review tab reads", function()
+  -- The trap this whole file exists for, pinned rather than assumed. Every assertion below
+  -- names `agent-a`, and `agent-a` is the one answer a working-directory read cannot give.
+  it("names a live sibling checkout, not the deleted one and not nothing", function()
+    assert.same(MAIN, vim.fn.getcwd())
+    assert.is_not_nil(vim.uv.fs_stat(MAIN))
+    assert.is_not_nil(vim.uv.fs_stat(vim.fs.joinpath(MAIN, "src/main.lua")))
+  end)
+
+  -- The other half of the trap: the tab-local read is no better. It answers the directory
+  -- that is gone, so an implementation reaching for `getcwd(0, 0)` to be careful is wrong
+  -- in the other direction.
+  it("keeps claiming the deleted checkout as the tab's own", function()
+    assert.same(A, vim.fn.getcwd(0, 0))
+    assert.same(1, vim.fn.haslocaldir(-1, 0))
+  end)
+end)
+
+describe("the checkout a review with no directory resolves against", function()
+  it("is the checkout it was opened on", function()
+    assert.same(A, current().root)
+  end)
+
+  -- ADR-0008 in one call. With a review open this answers the review's root, and the
+  -- working directory beside it now names something else that exists.
+  it("is what everything else resolves against too", function()
+    assert.same(A, state.current_checkout())
+  end)
+
+  it("is the store the annotation captured in it reaches", function()
+    view.persist()
+    assert.is_true(vim.tbl_contains(stored_notes(A), NOTE), vim.inspect(stored_notes(A)))
+    assert.is_false(vim.tbl_contains(stored_notes(MAIN), NOTE), vim.inspect(stored_notes(MAIN)))
+  end)
+
+  -- The same refusal as above, asked again in the state where the working directory has an
+  -- answer. A guard reading the working directory finds `main`, finds it alive, and refuses
+  -- nothing -- so this case reds under exactly the implementation act one cannot catch.
+  it("is what decides that the operations needing it are still refused", function()
+    local msgs = said(view.reconcile)
+    assert.is_true(h.notified(msgs, GONE), vim.inspect(msgs))
+  end)
+end)
+
+--- The mutation ------------------------------------------------------------------
+
+-- **The proof this file owes ADR-0008, executed rather than described.**
+--
+-- Every case above is satisfied by an implementation that reads the tab and happens to
+-- agree, unless the disagreement is demonstrated. So it is demonstrated: the review's root
+-- is replaced by a working-directory read, in the one state where the two differ, and the
+-- behaviour asserted above has to collapse.
+--
+-- What it collapses into is not a failure. It is the review quietly opening a file out of a
+-- live, unrelated checkout as though it were the file the diff is about -- which is the
+-- exact wrongness ADR-0008 was written to forbid, and the reason "it would have worked
+-- anyway" is not an argument.
+describe("the review's root replaced by a working-directory read", function()
+  local opened, msgs
+
+  it("stops refusing, and reaches into the wrong checkout", function()
+    local v = current()
+    local row = assert(h.line_row(v, "src/main.lua"), "no diff row for src/main.lua")
+    vim.api.nvim_set_current_win(v.win)
+    vim.api.nvim_win_set_cursor(v.win, { row, 0 })
+
+    v.root = vim.fn.getcwd() -- the mutation, and the whole of it
+    msgs = said(view.open_file)
+    opened = vim.api.nvim_buf_get_name(0)
+
+    -- Put it back before anything is asserted, so a failing assertion cannot leave the
+    -- rest of the file running against a mutated review.
+    vim.cmd("tabclose")
+    vim.cmd("tabnext " .. vim.api.nvim_tabpage_get_number(review_tab))
+    v.root = A
+
+    assert.is_false(h.notified(msgs, GONE), vim.inspect(msgs))
+    assert.is_truthy(opened:find(MAIN, 1, true), "opened " .. opened)
+  end)
+
+  it("leaves the review the review again once it is undone", function()
+    assert.same(A, current().root)
+    assert.same(A, state.current_checkout())
+  end)
+end)
+
+--- Leaving ------------------------------------------------------------------------
+
+-- A reviewer who cannot switch out of a review whose checkout is gone is stranded: the
+-- listing is built by asking git from the review's own checkout, and that is the directory
+-- that went. `:CodeReview` is no way out either -- it resolves the working directory, which
+-- is `""` for as long as the reviewer stays in the tab.
+--
+-- Last in the file because a switch rebuilds the review, and everything above is about the
+-- one that was open.
+describe("switching out of a review whose checkout is gone", function()
+  it("offers the checkouts that are still there", function()
+    picked = MAIN
+    local msgs = said(codereview.switch)
+    assert.is_false(h.notified(msgs, "no checkout of this repository can be opened"), vim.inspect(msgs))
+    assert.same({ B, MAIN }, paths_of(offered))
+  end)
+
+  it("opens the review on the one that was chosen", function()
+    assert.same(MAIN, current().root)
+  end)
+
+  -- The work left behind is the checkout's, not the reviewer's position's. It was written
+  -- to `agent-a`'s store while `agent-a` was already gone, and switching away does not move
+  -- it: sweeping orphaned state is #178's, and this slice must not do any of it.
+  it("leaves the annotation in the store of the checkout it was about", function()
+    assert.is_true(vim.tbl_contains(stored_notes(A), NOTE), vim.inspect(stored_notes(A)))
+    assert.is_false(vim.tbl_contains(stored_notes(MAIN), NOTE), vim.inspect(stored_notes(MAIN)))
+  end)
+end)

--- a/tests/codereview/frozen_spec.lua
+++ b/tests/codereview/frozen_spec.lua
@@ -53,6 +53,10 @@ local view = require("codereview.view")
 
 -- The checkout the reviewer is standing in, for the whole file, and never moved.
 --
+-- The last describe in this file leans on that directly rather than merely assuming it: a
+-- tab with no working directory of its own falls back to this one, and what `:CodeReview`
+-- resolves there is the whole of what that case is about.
+--
 -- It has to be a checkout that is *alive* and is *not* the one being reviewed. That is the
 -- whole trap: once the review's tab falls back to this directory, a working-directory read
 -- names a real repository with a real `src/main.lua` in it, so it does not fail -- it
@@ -486,5 +490,50 @@ describe("switching out of a review whose checkout is gone", function()
     assert.is_true(vim.tbl_contains(stored_notes(A), NOTE), vim.inspect(stored_notes(A)))
     assert.is_false(vim.tbl_contains(stored_notes(B), NOTE), vim.inspect(stored_notes(B)))
     assert.is_false(vim.tbl_contains(stored_notes(MAIN), NOTE), vim.inspect(stored_notes(MAIN)))
+  end)
+end)
+
+--- Opening from a tab that has lost its own directory --------------------------------
+
+-- The other half of the stranding, and the half a switch does not cover.
+--
+-- `open` resolved its checkout with a raw `getcwd()`, which answers `""` in a tab whose own
+-- directory was deleted -- and `vim.system` raises on an empty cwd rather than reporting a
+-- failure, so `:CodeReview` said "not inside a git repository" about a reviewer sitting
+-- inside one. Resolved through `current_checkout` instead, the fall-through #179 already
+-- shipped applies and the global directory answers.
+--
+-- **With no review open**, which is what makes this a different case from everything above
+-- rather than a second spelling of it. With a review open `current_checkout` answers that
+-- review's root, and if the review is the frozen one that root is the checkout that went --
+-- so a reopen cannot rescue it and a **switch** is the gesture that does. This is the tab a
+-- reviewer is left in afterwards, or one they never had a review in at all.
+--
+-- Last in the file: it closes the review and registers a checkout of its own, and nothing
+-- above should have to know either.
+describe("opening a review from a tab whose own directory is gone", function()
+  local doomed = vim.fs.joinpath(base, "doomed")
+  h.git_lines(MAIN, { "worktree", "add", "-q", "-b", "doomed", doomed })
+
+  codereview.close()
+  vim.cmd("tabnew")
+  vim.cmd("tcd " .. vim.fn.fnameescape(doomed))
+  vim.fn.delete(doomed, "rf")
+
+  it("stands in a tab with no working directory and no review", function()
+    assert.same("", vim.fn.getcwd())
+    assert.is_nil(view.current())
+  end)
+
+  -- Two assertions, because the negative alone would pass for a resolution that failed some
+  -- other way. What it resolved to is named by what it went on to say: `main` is the branch
+  -- every checkout here is cut from, so its own branch review is empty, and being *declined*
+  -- for having nothing in scope is proof it reached a checkout at all.
+  it("resolves the checkout the reviewer's own directory names", function()
+    local msgs = said(function()
+      codereview.open(nil)
+    end)
+    assert.is_false(h.notified(msgs, "not inside a git repository"), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, "No changes in scope"), vim.inspect(msgs))
   end)
 end)

--- a/tests/codereview/frozen_spec.lua
+++ b/tests/codereview/frozen_spec.lua
@@ -464,15 +464,19 @@ end)
 -- Last in the file because a switch rebuilds the review, and everything above is about the
 -- one that was open.
 describe("switching out of a review whose checkout is gone", function()
+  -- `agent-b` and not `main`: a switch opens nothing where nothing is in scope, and `main`
+  -- is the branch every other checkout here is cut from, so its own branch review is empty.
+  -- `switch_spec` owns that refusal; what is being asserted here is that the reviewer gets
+  -- out, so the checkout they get out to has to be one there is something to read in.
   it("offers the checkouts that are still there", function()
-    picked = MAIN
+    picked = B
     local msgs = said(codereview.switch)
     assert.is_false(h.notified(msgs, "no checkout of this repository can be opened"), vim.inspect(msgs))
     assert.same({ B, MAIN }, paths_of(offered))
   end)
 
   it("opens the review on the one that was chosen", function()
-    assert.same(MAIN, current().root)
+    assert.same(B, current().root)
   end)
 
   -- The work left behind is the checkout's, not the reviewer's position's. It was written
@@ -480,6 +484,7 @@ describe("switching out of a review whose checkout is gone", function()
   -- it: sweeping orphaned state is #178's, and this slice must not do any of it.
   it("leaves the annotation in the store of the checkout it was about", function()
     assert.is_true(vim.tbl_contains(stored_notes(A), NOTE), vim.inspect(stored_notes(A)))
+    assert.is_false(vim.tbl_contains(stored_notes(B), NOTE), vim.inspect(stored_notes(B)))
     assert.is_false(vim.tbl_contains(stored_notes(MAIN), NOTE), vim.inspect(stored_notes(MAIN)))
   end)
 end)


### PR DESCRIPTION
An agent prunes the worktree it worked in while the review of it is open. The diff and the
annotations on it are already in memory and need no directory, so the review stays open and
readable; what goes is only what genuinely needs the **checkout**, and it is refused by name
rather than left to fail through git. A **switch** away still works.

Closes #177. Parent spec #171.

## The ticket widened, and this is the reason

#177 said "only the operations that genuinely need git are switched off", which presumes
everything else already survives. It does not, and the failure has no git in it at all.

`syntax.lua` asked `vim.filetype.match` for a language by a *repository-relative* path.
That call absolutises a relative name through `vim.fs.abspath`, which is an
`assert(vim.uv.cwd())` — and `vim.uv.cwd()` is `nil` for as long as the tab sits in a
directory that is gone. So every paint and every cursor move **raised**:

```
[C]: in function 'assert'
vim/fs.lua: in function 'abspath'
vim/filetype.lua: in function 'match'
lua/codereview/syntax.lua:74: in function 'lang_for'
lua/codereview/view.lua (M.paint / M.cursor_moved)
```

An implementation that guarded every git operation would satisfy every acceptance criterion
on the issue and still leave the review erroring on every keystroke. So the rule this slice
implements is **"the review remains usable"**, and switching git off is one part of it
rather than the whole.

It is ADR-0008's own consequence — *every working-directory read inside a review is a bug,
including a convenient one* — with the read **implicit**, inside a Neovim library call. The
ADR's prose only warned about explicit reads, which is why this survived four slices. It
now names the shape. `syntax.lua` joins from `V.root`, which is the pattern the ADR already
pointed at.

## ADR-0008 is proved by a failing test here

This is the obligation the ticket carries and that #174 could not meet: inside a review tab
`getcwd()` returns the `:tcd` a switch just set, so an implementation reading the tab passes
everything that slice could write. A deleted checkout is the one place the two answers
differ.

`tests/codereview/frozen_spec.lua` is in two acts, because the two halves need different tab
states. Never having left the tab, `getcwd()` is `""` and `vim.uv.cwd()` is `nil` — that is
where readability is asserted. Having left and returned, the tab has adopted the **global**
directory, so a working-directory read names a *live sibling checkout*: it resolves,
succeeds, and is wrong. That is where resolution is asserted, and where the executed
mutation at the end of the file runs.

Mutating `state.current_checkout` to ignore the open review and read the working directory
reds **7 cases**, including:

```
the checkout a review with no directory resolves against
  is what everything else resolves against too
    got      '…/1-mkcheckouts/main'
    expected '…/1-mkcheckouts/agent-a'

  is the store the annotation captured in it reaches
    got {}
```

### The other three mutations, since this evidence does not survive in the diff

Run one at a time, reverted between each; two together mask each other.

| mutation | result | case that reds, and what it said |
| --- | --- | --- |
| syntax path back to `M.lang_for(file.path)` | 27 pass / 4 fail | `repaints without raising`, `takes a cursor move without raising`, `summons and dismisses the file tree without raising` — each `vim/fs.lua:0: assertion failed!`; and `still carries the syntax highlighting it was drawn with` — `the diff lost its highlighting` |
| listing fallback removed from `checkout.switch` | 29 pass / 2 fail | `offers the checkouts that are still there` — `{ "no checkout of this repository can be opened" }`; `opens the review on the one that was chosen` — got `…/agent-a`, expected `…/agent-b` |
| `M.open` back through `vim.fn.getcwd()` | **31 pass / 0 fail** | **nothing red — that fix had no test** |

The fourth found real coverage missing: every door reached `open` with an explicit checkout,
because a switch always hands it one, so the fallback branch was never taken. A case was
added, and the mutation then reds with `{ "not inside a git repository" }` — said to a
reviewer sitting inside one. The fourth mutation's own commit is separate for that reason.

Writing it narrowed what that fix is worth, which is worth stating: it does **not** rescue
`:CodeReview` while the frozen review is still open, because `current_checkout` then answers
that review's root — the checkout that went. The switch is the escape hatch for a frozen
review; this is for the tab afterwards.

## Reconciling is refused rather than narrated

`git.hash_worktree` stats each path before it runs git, so under a gone checkout `present`
is empty and it returns `{}` **without spawning git at all**. Every working-tree annotation
then compares "no hash" against its capture blob, is flagged **stale**, and `persist` writes
that flag to the store. Measured on the trunk: `1 annotation now stale`, about work the
reviewer still has to send.

So the obscure failure this ticket removes was not an error message — it was a plausible
number. An implementation that warns and reconciles anyway meets the criterion as written
and destroys information.

## Merge point with #178

**`checkout.switch()` — the listing fallback.** #178 is in `state.lua` and `checkout.lua`
off this same base and is at Phase 3, and its sweep hooks into this function.

The listing is built by asking git from the checkout the plugin is acting on, and that is
exactly the directory that went — `vim.system` raises on a cwd that is not there, so the
list comes back empty and the reviewer is told no checkout can be opened. With
`:CodeReview` resolving through the same question, the reviewer is stranded. The fallback
asks again from the global working directory, which is never moved, and is gated on the
checkout being **absent** rather than on the list being empty — an empty list from a
checkout that exists means git named nothing openable in *that* repository, and answering
that with another repository's checkouts is the cross-repository listing #171 rules out.

It is a self-contained block between the listing and the existing empty-list refusal.
Nothing else in this branch touches `checkout.lua`, and nothing here touches `state.lua`
beyond calling `current_checkout`. No document gains a field, and nothing is swept: this
slice owns the *live review*, #178 owns the *store*.

`docs/design-notes.md` and `tests/README.md` each get a section of their own rather than
additions woven into existing paragraphs, since both files conflicted on every merge in this
stack.

## Also here

- **The verdict is never latched.** A stat says "gone" for a directory that is briefly
  absent — an unmounted volume, an agent rebuilding a worktree at the same path. Stored
  state needs a grace period because nothing re-asks it; a live review is re-asked on every
  keypress, so it re-tests instead and works again at the next one. The announcement latch
  clears with it.
- **Told at the two moments a reviewer makes for themselves.** Nothing fires when a
  directory is deleted, so the doors are the operation they ask for and coming back to the
  review tab — one `fs_stat` on `TabEnter`, the only free moment there is.
- **`open_file` says what actually happened.** It answered "src/main.lua does not exist in
  the working tree", which is true and sends a reviewer looking for a deleted file when what
  went is everything around it.
- **ADR-0008's table was wrong in the direction that matters.** It said `DirChanged` never
  fires. Measured: a `DirChanged` *does* fire when you leave such a tab, at `global` scope,
  describing the other tab; the one that would say this tab's answer changed — `tabpage`
  scope, on re-entry — never arrives. As written it invited a reader who saw one
  `DirChanged` in a log to reopen a settled question.
- **`git.lua`'s memo docstring said `M.root` is left alone because opening a review asks
  it.** Opening a review no longer does, so it says what is true, including the cost: a
  `git init` *inside* an already-resolved checkout is not seen until the session ends. A
  repository appearing where there was none is unaffected — that answer was never
  remembered.

## Verification

`make all` — exit 0, 41 spec files, 1884 cases, 0 failures, 0 errors. `frozen_spec` 33/33.
