### PR TITLE
feat(state): sweep orphaned checkouts

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -500,6 +500,69 @@ gets them at all. Both halves of a restore therefore ask their own question, and
 is safe because every `queue.add` is followed by a write: a loose entry is on the disk
 before anything can read that store again.
 
+## Sweeping orphaned state
+
+**The seven-day window is seven days WITHOUT A WRITE, not seven days missing.** The stamp
+the age test reads is rewritten on every save, and only a mutation saves — opening a review
+does not, and closing one does not. So a checkout last written to nine days ago and deleted
+a minute ago has **no protection at all**: the next **switch** sweeps it, and whatever was
+unsent in it goes. The protection is proportional to how recently the document was written,
+which is not what a grace period against a directory that may come back would give you.
+This is a deliberate deviation from "kept for a while after its checkout disappears". The
+alternative — a stamp written the first time a sweep finds the directory gone, swept only
+once *that* is a week old — needs two sweeps seven days apart, and sweeps happen only on a
+switch, so a store could easily never shrink at all. The precedent settles it: the store
+that needs no root already deletes seven-day-old unsent annotations outright, with no
+directory test whatsoever, so this rule is strictly less aggressive than one the plugin has
+shipped for a long time.
+
+**The parent test buys less than "an unmounted volume is unsweepable at any age" claims.**
+It holds when the directory *above* the checkout was on the volume too, which is the
+motivating case: macOS removes `/Volumes/<name>` when a volume ejects, so a checkout under
+it has no parent and is never swept. It does not hold where a mount point survives as an
+empty directory, which is usual on Linux: a checkout at `/mnt/disk/repo` is gone, `/mnt/disk`
+is still there, and the sweep may take it. Keep the test — it is the only thing that
+separates an absent volume from a removed checkout, and no grace period of any length can —
+but do not read it as a guarantee.
+
+**A sweep can never reach the state anyone already has.** A document written before the
+checkout and the stamp existed carries neither, and the only way to gain them is to be saved
+again — which cannot happen once the directory is gone. Every orphan that exists today is
+therefore permanent. This is forced by the file name, which is a base name plus a hash of the
+full path and cannot be read backwards. It also means the sweep removes nothing on the day it
+ships, and can remove its first document no earlier than seven days later.
+
+**The commonest way checkouts disappear is the one shape the sweep cannot touch.** Deleting a
+whole project directory takes the repository and every checkout inside it, so every parent
+goes too and nothing qualifies. Worktrees kept at `.worktrees/agent-a` are the same case. What
+the sweep does reach is a checkout removed from *beside* a repository that stays — which is
+what `git worktree add ../agent-a` produces, and it is the shape agent tooling actually
+creates.
+
+**The age is the document's, not its entries'.** A document can hold nothing but reviewed
+marks and trims, and there is no entry in it to take an age from. The entries are stamped too,
+but for a different reason and read by nobody here: an entry with no repository behind it has
+carried a stamp since that store began ageing entries out, an owned one carried none, and
+which store an entry came from was therefore readable off the entry — which is ADR-0002's
+argument one field further along.
+
+**The stored checkout is checked against the file name, not trusted.** It is a second copy of
+what the file name already hashes, so a state directory carried between machines, or a file
+written half way, names a path that means nothing here. Sweeping on a path that does not hash
+back to its own file would remove a document belonging to something else entirely. That check
+is also why the sweep needs no list of files to leave alone: neither the store that needs no
+root nor the drafts beside it can pass it, and a list would be a third copy of where those two
+live. Both are refused *twice*, by that check and by the shape test above it, so
+`sweep_spec`'s case for a document carrying a checkout and no stamp exists to hold the stamp
+half on its own — a rule two guards defend can lose one of them silently.
+
+**A checkout this session has read back is never swept, and that is not an optimisation.**
+Its entries are in memory whether its directory is there or not, and the next write about it
+puts the document straight back. Sweeping it would report unsent work as destroyed while that
+work sits in the queue and in the number a statusline shows — a figure wrong in both
+directions at once. It is also what keeps a sweep away from the checkout under an open review,
+whose behaviour when its directory disappears belongs somewhere else entirely.
+
 ## The archive
 
 **The state document's `VERSION` must not be bumped to add a key.** A mismatched version

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -549,12 +549,22 @@ argument one field further along.
 **The stored checkout is checked against the file name, not trusted.** It is a second copy of
 what the file name already hashes, so a state directory carried between machines, or a file
 written half way, names a path that means nothing here. Sweeping on a path that does not hash
-back to its own file would remove a document belonging to something else entirely. That check
-is also why the sweep needs no list of files to leave alone: neither the store that needs no
-root nor the drafts beside it can pass it, and a list would be a third copy of where those two
-live. Both are refused *twice*, by that check and by the shape test above it, so
-`sweep_spec`'s case for a document carrying a checkout and no stamp exists to hold the stamp
-half on its own — a rule two guards defend can lose one of them silently.
+back to its own file would remove a document belonging to something else entirely. What that
+check refuses is a document filed under one checkout and naming another, and that is all it
+refuses.
+
+**What keeps the neighbouring stores out of a sweep is the shape test, not the file-name
+check.** The store that needs no root and the drafts beside it share the directory and are not
+checkout documents. Both are turned away for carrying neither the checkout nor the stamp,
+before the file-name check has seen them — so the sweep needs no list of files to leave alone,
+and the credit belongs to the shape test. The file-name check *would* refuse them, because
+`M.path(nil)` does not raise but answers `v:null-<hash>.json`, which no document is ever filed
+under; it simply never gets the chance. That was measured, after a comment here claimed
+otherwise. The shape test is load-bearing in a stronger way too: delete it and a document
+carrying a checkout with no stamp reaches the age test, where `now - nil` raises — an error on
+every switch, not a document wrongly swept. `sweep_spec` keeps a document of that shape
+because it is the only thing that holds the stamp half on its own; without it, reading a
+missing stamp as age zero passes the whole file.
 
 **A checkout this session has read back is never swept, and that is not an optimisation.**
 Its entries are in memory whether its directory is there or not, and the next write about it

--- a/lua/codereview/CLAUDE.md
+++ b/lua/codereview/CLAUDE.md
@@ -32,7 +32,7 @@ change there is felt through.
 | `queue.lua` | The queue itself — one per **checkout**, one more for what belongs to no checkout, and the single id counter they all draw from | stateful (memory) |
 | `queue_float.lua` | The float over the queue: an entry as a run of bar-marked rows, and the keys that drop, jump, copy and submit | stateful (float) |
 | `render.lua` | Parsed diff to buffer lines, extmarks and the anchor map; both panes from one walk; what a file is called wherever it is named, and how a winbar is assembled from typed segments | pure |
-| `state.lua` | Persisted review progress, filed under the **checkout** each entry is about, which checkout the plugin is acting on at all, the blob comparisons over it — staleness, and touchedness kept in a function of its own — and each branch's **trim**, checked against `HEAD` before it is handed back | stateful (disk) |
+| `state.lua` | Persisted review progress, filed under the **checkout** each entry is about, which checkout the plugin is acting on at all, the blob comparisons over it — staleness, and touchedness kept in a function of its own — each branch's **trim**, checked against `HEAD` before it is handed back, and the **sweep** that discards the state of checkouts that are gone | stateful (disk) |
 | `syntax.lua` | Treesitter harvest and replay onto the diff's rows, bounded by the viewport | stateful (extmarks) |
 | `trim_float.lua` | The float over the branch's commits: the first-parent listing from the base handed in, a checkbox and a size on every row, and the pick that applies the **trim** they add up to | stateful (float) |
 | `types.lua` | Annotation types: defaults, normalization, labels, and the directive that earns a type its keystroke | pure |

--- a/lua/codereview/checkout.lua
+++ b/lua/codereview/checkout.lua
@@ -99,6 +99,16 @@ function M.switch()
     -- one checkout need not exist in another, and `since-batch` names the archive of the
     -- checkout being left. Which scope a checkout was last reviewed at is #175's.
     require("codereview.view").open(nil, path)
+
+    -- The sweep of **orphaned** state, here and nowhere else. A switch is the moment a
+    -- checkout's existence is most likely to have just changed, it is rare, and it is
+    -- nowhere near a hot path -- so there is no startup scan and no timer.
+    --
+    -- After the open rather than before it, so a line reporting work destroyed is the last
+    -- thing said rather than the first thing buried under the review's own sentences. A
+    -- picker the reviewer dismissed never reaches this at all: declining a menu is not a
+    -- switch.
+    require("codereview.state").sweep_orphans()
   end)
 end
 

--- a/lua/codereview/queue.lua
+++ b/lua/codereview/queue.lua
@@ -36,6 +36,7 @@ local M = {}
 ---@field tag string|nil        "deleted"|"change"|"added"|hunk type
 ---@field note string
 ---@field stale boolean|nil
+---@field at integer           When it was captured
 
 ---The key a checkout's queue is held under. Outside every checkout there is still a queue
 ---to add to -- a **bare note** can be written anywhere -- and nil is not a table key.
@@ -88,6 +89,17 @@ end
 function M.add(item)
   item.id = next_id
   next_id = next_id + 1
+  -- Stamped where the id is issued, because this is the one seam every capture passes
+  -- through: the review path and the buffer path both end here. An entry with no
+  -- repository behind it has carried a stamp since the store that needs no root began
+  -- ageing entries out, and an owned one carried none -- so which store an entry came from
+  -- was readable off the entry. ADR-0002's argument against a consumer branching on where
+  -- an entry came from is the same argument, one field further along.
+  --
+  -- Not what the **sweep** reads. A document can hold nothing but reviewed marks and
+  -- trims, and there is no entry in it to take an age from, so the age of stored state is
+  -- the document's own stamp.
+  item.at = item.at or os.time()
   -- Filed by what the entry is, not by where the reviewer is: an entry with no
   -- repository-relative path has no checkout to belong to, wherever it was written.
   local list = item.path and list_for(current) or loose

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -99,6 +99,11 @@ function M.load(root)
   -- a key those files simply lack.
   decoded.archive = decoded.archive or {}
   decoded.trims = decoded.trims or {}
+  -- The **checkout** and the save stamp are deliberately *not* defaulted here, though they
+  -- arrived exactly as those two did. A document written before them has neither, and that
+  -- absence is the whole of what keeps it out of a **sweep**: defaulted, it would reach the
+  -- sweep either claiming to be about wherever it was loaded from or claiming an age of
+  -- 1970, and either answer removes a document nothing knows anything about.
   return decoded
 end
 
@@ -108,6 +113,17 @@ end
 function M.save(root, data)
   local file = M.path(root)
   vim.fn.mkdir(vim.fs.dirname(file), "p")
+  -- The two keys a **sweep** reads, written here rather than by each caller: every write of
+  -- a document comes through this function, and a key set anywhere else is a key some other
+  -- write silently drops.
+  --
+  -- The **checkout**, because the file name keeps a base name and a hash of the full path
+  -- and the path cannot be recovered from either. The stamp, because a document may hold
+  -- nothing but reviewed marks and trims, and the entries in it are not what a document's
+  -- age is. Neither is a reason to bump `VERSION`: an older document simply lacks both,
+  -- exactly as it lacks the archive and the trims.
+  data.checkout = root
+  data.saved = os.time()
   local ok, encoded = pcall(vim.json.encode, data)
   if not ok then
     return false
@@ -997,6 +1013,155 @@ function M.clear(root)
   -- The archive went with it, so anything holding a projection of it is holding entries
   -- that no longer exist -- and would go on drawing them until the next dispatch.
   archive_writes = archive_writes + 1
+end
+
+--- Sweeping orphaned state ------------------------------------------------------
+
+---How long the state of a checkout that is gone is kept before a sweep may take it.
+---
+---Seven days, which is the number the store that needs no root and the draft store both
+---carry -- and a different rule wearing it. Those two are lifetimes for stores nothing else
+---ever prunes: they age out on their own or they grow forever. This one is a grace period,
+---and it stands beside two other conditions rather than alone, so it gets a constant of its
+---own rather than borrowing one of theirs.
+---
+---**It measures time without a write, not time missing.** The stamp it reads is rewritten
+---on every save, and only a mutation saves -- opening a review does not, and closing one
+---does not -- so a checkout last written to nine days ago and deleted a minute ago has no
+---protection here at all. The design notes say what that costs and why the alternative was
+---refused.
+local ORPHAN_GRACE_SECONDS = 7 * 24 * 60 * 60
+
+---A document whose checkout is **orphaned** and whose state may be discarded, or nil.
+---
+---Every condition in one place, so nothing can hold three of them and forget the fourth.
+---@param file string The document being examined
+---@param now integer
+---@return table|nil doc The decoded document, when it may be swept
+local function sweepable(file, now)
+  local ok, doc = pcall(function()
+    return vim.json.decode(table.concat(vim.fn.readfile(file), "\n"), {
+      luanil = { object = true, array = true },
+    })
+  end)
+  if not ok or type(doc) ~= "table" or doc.version ~= VERSION then
+    return nil
+  end
+
+  -- Written before this file recorded either key. Such a document says neither which
+  -- checkout it is about nor when it was last written, so there is nothing here to test and
+  -- it is left alone -- for good, because the only way to gain the two keys is to be saved
+  -- again, and a checkout that is gone is never saved again.
+  if type(doc.checkout) ~= "string" or type(doc.saved) ~= "number" then
+    return nil
+  end
+
+  -- The stored path is a second copy of what the file name already hashes, so it is checked
+  -- against it rather than trusted. A state directory carried between machines names paths
+  -- that mean nothing here, and a file written half way names anything at all. This is also
+  -- what leaves the sweep needing no list of files to leave alone: neither the store that
+  -- needs no root nor the drafts beside it can pass it, and a list would be a third copy of
+  -- where those two live.
+  if M.path(doc.checkout) ~= file then
+    return nil
+  end
+
+  -- Already read back, and memory is the truth. A checkout this session has read keeps its
+  -- entries whether its directory is there or not, and the next write about it puts the
+  -- document straight back -- so taking it here would report unsent work as destroyed while
+  -- that work sits in the queue and in the number a statusline shows. It is also what keeps
+  -- a sweep away from the checkout under an open review.
+  if queue_restored[doc.checkout] then
+    return nil
+  end
+
+  -- The directory is gone. A path that is there but is not a directory is gone too: what
+  -- was a checkout is not one now.
+  if (vim.uv.fs_stat(doc.checkout) or {}).type == "directory" then
+    return nil
+  end
+
+  -- **Its parent is still there.** The condition that is easy to leave out, and the one
+  -- that keeps an absent volume out of this: a volume that is not mounted takes the
+  -- directory above the checkout with it, and a missing mount point is an absent volume
+  -- rather than a checkout somebody removed. No grace period of any length can tell those
+  -- two apart. The design notes say where this holds and where it does not.
+  if (vim.uv.fs_stat(vim.fs.dirname(doc.checkout)) or {}).type ~= "directory" then
+    return nil
+  end
+
+  -- Aged out, by the document's own stamp rather than by the entries in it: a document
+  -- holding only reviewed marks and trims has no entry to take an age from.
+  if (now - doc.saved) < ORPHAN_GRACE_SECONDS then
+    return nil
+  end
+
+  return doc
+end
+
+---How a reviewer is told what a sweep took.
+---
+---Two figures and never one. How many checkouts went is a fact about the state directory;
+---how many unsent annotations went with them is a fact about the reviewer's own work. A
+---sum answers neither, and the checkout count alone says nothing at all about the work.
+---@param checkouts integer
+---@param entries integer
+---@return string
+local function swept_phrase(checkouts, entries)
+  return ("Swept %d orphaned checkout%s — %d unsent annotation%s went with %s"):format(
+    checkouts,
+    checkouts == 1 and "" or "s",
+    entries,
+    entries == 1 and "" or "s",
+    checkouts == 1 and "it" or "them"
+  )
+end
+
+---Discard the stored state of checkouts that are gone.
+---
+---Run on a **switch** and on nothing else: that is the moment a checkout's existence is
+---most likely to have just changed, it is rare, and it is nowhere near a hot path. No
+---startup scan and no timer.
+---
+---The whole document goes rather than the queue inside it. An orphaned **archive** is
+---already unreadable, because an archive is opened through the checkout being reviewed, and
+---the reviewed marks and the **trim** beside it describe a diff that no longer exists.
+---
+---Says one line when it took something and nothing at all when it did not. It never asks:
+---a confirmation on an operation this guarded teaches distrust of it, which is the reason a
+---switch does not ask either.
+---
+---`archive_writes` is deliberately not moved. A projection of an archive is only ever the
+---open review's, and the checkout under an open review has been read back -- which is one
+---of the conditions above.
+---@return { checkouts: integer, entries: integer } What went, as two figures
+function M.sweep_orphans()
+  local dir = vim.fs.dirname(M.global_path())
+  local checkouts, entries = 0, 0
+  if vim.fn.isdirectory(dir) == 0 then
+    return { checkouts = checkouts, entries = entries }
+  end
+
+  local now = os.time()
+  for name, kind in vim.fs.dir(dir) do
+    if kind == "file" and name:sub(-5) == ".json" then
+      local file = vim.fs.joinpath(dir, name)
+      local doc = sweepable(file, now)
+      if doc then
+        checkouts = checkouts + 1
+        -- What was unsent, which is the queue and not everything the document held: an
+        -- archived entry has already reached an agent, and counting it would report work
+        -- as lost that was delivered.
+        entries = entries + #(doc.queue or {})
+        vim.fn.delete(file)
+      end
+    end
+  end
+
+  if checkouts > 0 then
+    info(swept_phrase(checkouts, entries))
+  end
+  return { checkouts = checkouts, entries = entries }
 end
 
 return M

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -1052,16 +1052,30 @@ local function sweepable(file, now)
   -- checkout it is about nor when it was last written, so there is nothing here to test and
   -- it is left alone -- for good, because the only way to gain the two keys is to be saved
   -- again, and a checkout that is gone is never saved again.
+  --
+  -- **This is also what leaves the sweep needing no list of files to leave alone.** The
+  -- store that needs no root and the drafts beside it share this directory and are not
+  -- checkout documents; both are turned away right here, before anything below has seen
+  -- them. A list would be a third copy of where those two live.
+  --
+  -- **And it stops a raise, not only a wrong sweep.** Delete it and a document carrying a
+  -- checkout with no stamp reaches the age test below, where `now - nil` raises: an error
+  -- outside an `it` in a spec, and an error on every **switch** in an editor. `sweep_spec`
+  -- keeps a document of exactly that shape, because that is the only way this half of the
+  -- test is held on its own.
   if type(doc.checkout) ~= "string" or type(doc.saved) ~= "number" then
     return nil
   end
 
   -- The stored path is a second copy of what the file name already hashes, so it is checked
-  -- against it rather than trusted. A state directory carried between machines names paths
-  -- that mean nothing here, and a file written half way names anything at all. This is also
-  -- what leaves the sweep needing no list of files to leave alone: neither the store that
-  -- needs no root nor the drafts beside it can pass it, and a list would be a third copy of
-  -- where those two live.
+  -- against it rather than trusted: a state directory carried between machines names paths
+  -- that mean nothing here, and a file written half way names anything at all.
+  --
+  -- What this refuses is a document filed under one checkout and naming another, and that
+  -- is all it refuses. It is **not** what keeps the two stores above out of a sweep -- they
+  -- are gone before this line runs. It would refuse them if they reached it, because
+  -- `M.path(nil)` does not raise but answers `v:null-<hash>.json`, which no document is
+  -- ever filed under -- and that is a true sentence about a path nothing ever takes.
   if M.path(doc.checkout) ~= file then
     return nil
   end

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,6 +83,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `checkout_restart_spec` | The same scoping across a genuine restart: what two checkouts worked in one session left on the disk, each store holding only what it is about, and the id a new annotation takes in a checkout whose **archive** the counter has never been seeded from |
 | `switch_spec` | Moving the review to another **checkout**: the listing it is chosen from — the three checkouts of one repository, each named as its own git names it, with a bare one and a deleted one left out — the picker the plugin ships and the `pick_checkout` adapter that replaces it, a switch with a review open and with none, the directories a switch must not move, the queue and the store and the id that follow the review rather than the working directory, and what belongs to no checkout riding along into one reached by switching — asked from a tab standing in another checkout — the tab a real file opens into, `:CodeReviewSwitch` and `gS` in the diff and the tree, and the checkout with nothing in scope that is declined rather than opened |
 | `count_spec` | The queued count a statusline asks for: which **checkout** it is about after a bare directory change, the bare note that is in the number everywhere, what a redraw costs in git processes cold and warm, the answer of "no checkout" that is deliberately not remembered so a `git init` is visible at once, the tab whose own directory was deleted underneath it, and the intersection with the **switch** — the number read from the tab the reviewer is standing in, about the checkout the review is on |
+| `sweep_spec` | Sweeping the stored state of **checkouts** that are gone: the checkout and the save stamp a document now records, the stamp every entry carries at capture, and the three conditions a sweep needs — the directory gone, its parent still there, and a document aged past seven days — each held by a case of its own, including the parent that is also gone which is never swept at any age; then the four documents a sweep must refuse to read as a checkout's, the whole document going rather than the queue inside it, the two figures it reports and the sum it must not report, the silence when it takes nothing, the absence of any prompt, and the **switch** it runs on — with nothing swept by setup or by a capture |
 
 ## Fixtures
 
@@ -139,7 +140,7 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mkcheckouts.sh`** — one repository in three **checkouts** of it, and the only fixture
   whose checkouts are the point: `main` on master, plus `agent-a` and `agent-b`, each a
   linked checkout on a branch of its own. Used by `checkout_spec`,
-  `checkout_restart_spec` and `switch_spec`. Unlike the other four it
+  `checkout_restart_spec`, `switch_spec` and `sweep_spec`. Unlike the other four it
   builds a plain directory holding the three rather than a repository at the path it is
   given, which keeps the whole fixture inside one `rm` — a checkout added beside the
   repository would be left behind — and leaves that path itself inside no repository. A

--- a/tests/codereview/since_batch_spec.lua
+++ b/tests/codereview/since_batch_spec.lua
@@ -232,9 +232,12 @@ describe("annotating inside it", function()
     })
   end)
 
-  -- Ids apart, because they are issued in order and nothing else about an entry is.
+  -- Ids apart, and the capture stamp with them: both are minted as an entry is made
+  -- rather than read off the line it is about, so two captures either side of a second
+  -- boundary differ in the stamp and in nothing else.
   it("produces the entry that line produces in any other scope", function()
     from_since.id, from_worktree.id = nil, nil
+    from_since.at, from_worktree.at = nil, nil
     assert.same(from_worktree, from_since)
   end)
 end)

--- a/tests/codereview/spans_spec.lua
+++ b/tests/codereview/spans_spec.lua
@@ -637,8 +637,9 @@ describe("what an annotation records", function()
     vim.api.nvim_win_set_cursor(V.win, { replacement_row(V), 0 })
     annotate.annotate("bug")
     local entry = vim.deepcopy(queue.all()[1])
-    -- The queue's own counter, which counts captures in this process and nothing else.
-    entry.id = nil
+    -- The queue's own counter, which counts captures in this process and nothing else,
+    -- and the capture stamp beside it, which is the clock and not the line.
+    entry.id, entry.at = nil, nil
     return entry, payload.render(queue.all(), V.root, { types = config.get().types })
   end
 

--- a/tests/codereview/sweep_spec.lua
+++ b/tests/codereview/sweep_spec.lua
@@ -215,6 +215,19 @@ store(BEFORE, {
 }, { checkout = false, saved = false })
 vim.fn.delete(BEFORE, "rf")
 
+-- Half of that schema: the checkout is on it and hashes back to its own file name, and the
+-- stamp is not. Gone, parent alive, and refused for want of an age.
+--
+-- Here because the document above is refused twice over -- it names no checkout, so both
+-- the shape test and the file-name test turn it away -- and a rule held by two guards can
+-- lose one of them silently. This one is refused by the stamp alone, so weakening the stamp
+-- test to "no stamp means old enough" is visible here and nowhere else.
+local HALF = checkout_dir("half")
+store(HALF, {
+  queue = { entry(HALF, 14, "unsent, in a document with a checkout and no stamp") },
+}, { checkout = HALF, saved = false })
+vim.fn.delete(HALF, "rf")
+
 -- A document whose stored checkout is not the checkout it is filed under. Reachable by a
 -- state directory carried between machines, and by a file written half way. All three
 -- conditions hold for the path it names -- gone, parent there, aged -- and it is still not
@@ -348,6 +361,10 @@ describe("what a sweep must not remove", function()
 
   it("leaves a document written before the checkout and the stamp existed", function()
     assert.is_true(stored(BEFORE), state.path(BEFORE))
+  end)
+
+  it("leaves a document that carries a checkout but no stamp", function()
+    assert.is_true(stored(HALF), state.path(HALF))
   end)
 
   it("leaves a document whose stored checkout is not the one it is filed under", function()

--- a/tests/codereview/sweep_spec.lua
+++ b/tests/codereview/sweep_spec.lua
@@ -1,0 +1,468 @@
+-- Sweeping the stored state of **checkouts** that are gone.
+--
+-- A checkout is **orphaned** when its document is still on disk and its directory is not.
+-- A sweep discards orphaned state under three conditions that must **all** hold: the
+-- directory is gone, **its parent still exists**, and the document has aged past seven
+-- days.
+--
+-- The parent test is the one that is easy to drop and the one that matters most, so the
+-- case holding it is here in full: state whose parent directory is also gone is never
+-- swept, at any age. Without that case the parent test can be deleted and everything else
+-- in this file still passes.
+--
+-- **Nothing here moves a clock and nothing waits.** An aged document is written by hand,
+-- with an old stamp in it, which is the only way to give a document an age in a spec that
+-- finishes in milliseconds.
+--
+-- Single process. Every claim is about what reached the disk, what stayed on it, and what
+-- the reviewer was told. Most of the orphans are plain directories rather than checkouts of
+-- the fixture, and deliberately so: the sweep never asks git anything -- it reads a stamp
+-- and stats two paths -- so a case that needed a repository would be testing something
+-- else. The one case that does need real checkouts is the last, where the sweep runs on a
+-- **switch** and git's own worktree listing is behind it.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+
+-- Three checkouts of one repository. Realpathed once: `git rev-parse --show-toplevel`
+-- answers resolved, and on macOS a temporary directory is a symlink into /private.
+local base = assert(vim.uv.fs_realpath(h.fixture("mkcheckouts")))
+local A = vim.fs.joinpath(base, "agent-a")
+local B = vim.fs.joinpath(base, "agent-b")
+
+local codereview = require("codereview")
+local drafts = require("codereview.drafts")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+-- The checkout the reviewer is standing in for the whole file, and one that is really
+-- there: a capture has to reach a live checkout's document.
+vim.cmd("cd " .. vim.fn.fnameescape(A))
+
+local note_text = "a note"
+local chosen = nil
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, note_text)
+  end,
+  -- The switch's own adapter, stubbed exactly as the send, target and compose adapters are
+  -- stubbed throughout the suite. No test-only seam is added for the sweep.
+  pick_checkout = function(_, on_choice)
+    on_choice(chosen)
+  end,
+})
+
+local WEEK = 7 * 24 * 60 * 60
+local NOW = os.time()
+local AGED = NOW - WEEK - 3600
+
+--- Building documents -----------------------------------------------------------
+
+-- A directory of its own for the orphans, so removing one says nothing about the fixture.
+local yard = vim.fn.tempname() .. "-orphans"
+vim.fn.mkdir(yard, "p")
+yard = assert(vim.uv.fs_realpath(yard))
+
+---A directory under the yard, resolved as a checkout's path always is.
+---@param name string
+---@return string
+local function checkout_dir(name)
+  local dir = vim.fs.joinpath(yard, name)
+  vim.fn.mkdir(dir, "p")
+  return assert(vim.uv.fs_realpath(dir))
+end
+
+---Give a checkout a document, and then force keys onto the encoded file.
+---
+---Built over `state.load` and written through `state.save`, so the document is one the
+---store itself would recognise -- version included -- rather than a shape this file would
+---have to keep in step with it by hand. Written any other way it decodes to nothing, and
+---every case below then passes while measuring an empty document.
+---
+---The stamp is patched into the encoded file afterwards, which is how a document gets an
+---age with no clock moved and nothing waited for. `false` removes a key, which is how a
+---document written before this ticket -- carrying neither the checkout nor the stamp --
+---is built.
+---@param checkout string The checkout the document is filed under
+---@param doc table Keys to put on the document the store would write
+---@param patch table Keys to force onto the encoded document; `false` removes one
+local function store(checkout, doc, patch)
+  local data = state.load(checkout)
+  for key, value in pairs(doc) do
+    data[key] = value
+  end
+  assert(state.save(checkout, data), "the document was not written: " .. checkout)
+  local file = state.path(checkout)
+  local raw = vim.json.decode(table.concat(vim.fn.readfile(file), "\n"))
+  for key, value in pairs(patch) do
+    raw[key] = value ~= false and value or nil
+  end
+  vim.fn.writefile({ vim.json.encode(raw) }, file)
+end
+
+---@param checkout string
+---@return boolean
+local function stored(checkout)
+  return vim.fn.filereadable(state.path(checkout)) == 1
+end
+
+---An entry as a document holds one: about a file in the checkout it is filed under.
+---@param checkout string
+---@param id integer
+---@param note string
+---@return CRAnnotation
+local function entry(checkout, id, note)
+  return {
+    id = id,
+    type = "bug",
+    kind = "file",
+    path = "src/main.lua",
+    abs_path = vim.fs.joinpath(checkout, "src/main.lua"),
+    key = "file:src/main.lua",
+    inline = false,
+    note = note,
+  }
+end
+
+---Sweep, catching a sweep that raises or does not exist.
+---
+---Caught rather than left to fail where it stands, because an error outside an `it` takes
+---the rest of the file down with it and every case below would then report nothing. It is
+---also a claim worth making on its own: the sweep walks a directory of files it did not
+---write, so it must not raise on any of them.
+---@return { checkouts: integer, entries: integer } counts, string[] said, string|nil err
+local function sweep()
+  local said, restore = h.capture_notify()
+  local ok, result = pcall(state.sweep_orphans)
+  restore()
+  if not ok or type(result) ~= "table" then
+    return { checkouts = -1, entries = -1 }, said, tostring(result)
+  end
+  return result, said, nil
+end
+
+---@param note string
+---@return CRAnnotation
+local function queued(note)
+  for _, item in ipairs(queue.all()) do
+    if item.note == note then
+      return item
+    end
+  end
+  error(("no entry noted %q is in the queue"):format(note))
+end
+
+--- The two stores that share the directory and are not checkout documents --------
+
+-- Neither can name a checkout that hashes back to its own file name, which is what leaves
+-- the sweep needing no list of files to leave alone. A list would be a second copy of
+-- where those two stores live, kept in a third place.
+state.save_global({
+  { id = 20, type = "issue", kind = "note", key = "note:0", note = "a thought with no repository behind it" },
+})
+drafts.set("/somewhere/else.lua", "half a note, abandoned")
+
+--- The cast --------------------------------------------------------------------
+
+-- Two checkouts that are gone, aged, and whose parent is still there. Two of them, holding
+-- three unsent entries between them, so the two figures a sweep reports are different
+-- numbers and neither can stand in for the other.
+local GONE_ONE = checkout_dir("gone-one")
+local GONE_TWO = checkout_dir("gone-two")
+store(GONE_ONE, {
+  queue = { entry(GONE_ONE, 1, "unsent, and about to go"), entry(GONE_ONE, 2, "so is this one") },
+  scopes = { branch = { reviewed = { ["src/main.lua"] = "0000000000000000000000000000000000000000" } } },
+  trims = { master = { "0123456789abcdef0123456789abcdef01234567" } },
+  -- Already dispatched, so it is not unsent work: the entry figure must not count it.
+  archive = { { at = AGED, target = "local", entries = { entry(GONE_ONE, 3, "already sent") } } },
+}, { checkout = GONE_ONE, saved = AGED })
+store(GONE_TWO, {
+  queue = { entry(GONE_TWO, 4, "the third unsent one") },
+}, { checkout = GONE_TWO, saved = AGED })
+vim.fn.delete(GONE_ONE, "rf")
+vim.fn.delete(GONE_TWO, "rf")
+
+-- The directory is still there, and the document is as old as anything here. Never swept:
+-- the age test on its own would take it.
+local LIVE = checkout_dir("live")
+store(LIVE, {
+  queue = { entry(LIVE, 5, "unsent, in a checkout that is still there") },
+}, { checkout = LIVE, saved = AGED })
+
+-- Gone, parent alive, and inside the window.
+local RECENT = checkout_dir("recent")
+store(RECENT, {
+  queue = { entry(RECENT, 6, "unsent, and gone an hour ago") },
+}, { checkout = RECENT, saved = NOW - 3600 })
+vim.fn.delete(RECENT, "rf")
+
+-- The volume that is not mounted: the checkout is gone and so is the directory it sat in.
+-- Aged by a year past the window, because "at any age" is the claim.
+local VOLUME = checkout_dir("volume/work")
+store(VOLUME, {
+  queue = { entry(VOLUME, 7, "unsent, on a disk that is not here") },
+}, { checkout = VOLUME, saved = AGED - 365 * 24 * 60 * 60 })
+vim.fn.delete(vim.fs.joinpath(yard, "volume"), "rf")
+
+-- Written before this ticket: no checkout on it, and no stamp. Gone, parent alive, and
+-- older than any window -- and unsweepable, because nothing in it says which checkout it
+-- is about or when it was last written.
+local BEFORE = checkout_dir("before")
+store(BEFORE, {
+  queue = { entry(BEFORE, 8, "unsent, from a session before this ticket") },
+}, { checkout = false, saved = false })
+vim.fn.delete(BEFORE, "rf")
+
+-- A document whose stored checkout is not the checkout it is filed under. Reachable by a
+-- state directory carried between machines, and by a file written half way. All three
+-- conditions hold for the path it names -- gone, parent there, aged -- and it is still not
+-- swept, because that path does not hash back to the file the document is in.
+local MISFILED = checkout_dir("misfiled")
+local IMPOSTOR = vim.fs.joinpath(yard, "impostor")
+store(MISFILED, {
+  queue = { entry(MISFILED, 9, "unsent, in a document naming somewhere else") },
+}, { checkout = IMPOSTOR, saved = AGED })
+vim.fn.delete(MISFILED, "rf")
+
+-- A checkout this session has already read back. Its entries are in memory, and memory is
+-- the truth: a sweep that took this document would report unsent work as destroyed while
+-- it sits in the queue, and the next write about this checkout would put it straight back.
+-- Four entries, so a figure that counted them is visibly wrong rather than plausibly so.
+--
+-- Read back last of everything built here, because the read-back points the queue at this
+-- checkout. The first capture below points it back, resolving the checkout for itself.
+local VISITED = checkout_dir("visited")
+store(VISITED, {
+  queue = {
+    entry(VISITED, 10, "read back, and still in memory"),
+    entry(VISITED, 11, "and so is this one"),
+    entry(VISITED, 12, "and this one"),
+    entry(VISITED, 13, "and this one too"),
+  },
+}, { checkout = VISITED, saved = AGED })
+state.ensure_queue_for(VISITED)
+vim.fn.delete(VISITED, "rf")
+
+--- The schema ------------------------------------------------------------------
+
+-- A capture in a checkout that is really there, which is what writes a document today.
+note_text = "about a file in this checkout"
+vim.cmd("edit " .. vim.fn.fnameescape(vim.fs.joinpath(A, "src", "main.lua")))
+codereview.annotate("bug")
+
+-- A **bare note**: an unnamed buffer has no file behind it, so the entry belongs to no
+-- checkout and goes to the store that needs no root.
+note_text = "with no file behind it"
+vim.cmd("enew")
+codereview.annotate("issue")
+
+describe("the document", function()
+  local doc = state.load(A)
+
+  it("records the checkout it belongs to", function()
+    assert.same(A, doc.checkout)
+  end)
+
+  it("carries a stamp written on the save", function()
+    assert.same("number", type(doc.saved))
+    -- Within the run rather than an exact second: what is asserted is that the stamp is of
+    -- this save and not of some fixed moment.
+    assert.is_true(doc.saved >= NOW and doc.saved <= os.time())
+  end)
+
+  it("keeps the queue it was written for", function()
+    assert.same(
+      { "about a file in this checkout" },
+      vim.tbl_map(function(e)
+        return e.note
+      end, doc.queue)
+    )
+  end)
+end)
+
+describe("an entry", function()
+  it("is stamped when it is captured, owned and loose alike", function()
+    local owned = queued("about a file in this checkout")
+    local loose = queued("with no file behind it")
+    assert.same({ "number", "number" }, { type(owned.at), type(loose.at) })
+  end)
+
+  it("is stamped at capture, not at the moment it happens to be written", function()
+    local owned = queued("about a file in this checkout")
+    assert.is_true(owned.at >= NOW and owned.at <= os.time())
+  end)
+end)
+
+describe("before any switch", function()
+  -- No startup scan and no timer: the orphans above were built before the capture, and a
+  -- capture writes a document without looking at any other.
+  it("sweeps nothing on setup or on a capture", function()
+    assert.same({ true, true }, { stored(GONE_ONE), stored(GONE_TWO) })
+  end)
+end)
+
+--- The sweep -------------------------------------------------------------------
+
+local swept, said, sweep_error = sweep()
+
+describe("a sweep", function()
+  it("does not raise on a directory of files it did not write", function()
+    assert.is_nil(sweep_error, tostring(sweep_error))
+  end)
+end)
+
+describe("what a sweep removes", function()
+  it("takes a checkout that is gone, whose parent is there, and that has aged out", function()
+    assert.is_false(stored(GONE_ONE), state.path(GONE_ONE))
+  end)
+
+  it("takes a second one in the same pass", function()
+    assert.is_false(stored(GONE_TWO), state.path(GONE_TWO))
+  end)
+
+  it("takes the whole document, not the queue inside it", function()
+    local left = state.load(GONE_ONE)
+    assert.same({ 0, 0, true, true }, {
+      #(left.queue or {}),
+      #(left.archive or {}),
+      vim.tbl_isempty(left.scopes or {}),
+      vim.tbl_isempty(left.trims or {}),
+    })
+  end)
+end)
+
+describe("what a sweep must not remove", function()
+  it("leaves a checkout that still exists, at any age", function()
+    assert.is_true(stored(LIVE), state.path(LIVE))
+  end)
+
+  it("leaves an orphan that is inside the window", function()
+    assert.is_true(stored(RECENT), state.path(RECENT))
+  end)
+
+  it("leaves an orphan whose parent directory is also gone, at any age", function()
+    assert.is_true(stored(VOLUME), state.path(VOLUME))
+  end)
+
+  it("leaves a document written before the checkout and the stamp existed", function()
+    assert.is_true(stored(BEFORE), state.path(BEFORE))
+  end)
+
+  it("leaves a document whose stored checkout is not the one it is filed under", function()
+    assert.is_true(stored(MISFILED), state.path(MISFILED))
+  end)
+
+  it("leaves a checkout this session has already read back", function()
+    assert.is_true(stored(VISITED), state.path(VISITED))
+  end)
+
+  it("leaves the store that needs no root, and the drafts beside it", function()
+    assert.same({ 1, "half a note, abandoned" }, {
+      vim.fn.filereadable(state.global_path()),
+      drafts.get("/somewhere/else.lua"),
+    })
+  end)
+end)
+
+describe("what a sweep reports", function()
+  it("says one line", function()
+    assert.same(1, #said, vim.inspect(said))
+  end)
+
+  it("answers with the two counts", function()
+    assert.same({ checkouts = 2, entries = 3 }, swept)
+  end)
+
+  it("gives the checkouts and the unsent annotations as separate figures", function()
+    local line = said[1] or ""
+    assert.is_truthy(line:find("2", 1, true), line)
+    assert.is_truthy(line:find("3", 1, true), line)
+    -- What this rules out is one figure standing for both: a sum reads 5, and a checkout
+    -- count on its own never mentions 3 at all.
+    assert.is_nil(line:find("5", 1, true), line)
+  end)
+
+  it("counts the unsent entries, and not everything the documents held", function()
+    -- Four entries were in those two documents; one of them had already been dispatched.
+    assert.same(3, swept.entries)
+  end)
+end)
+
+describe("a sweep with nothing to take", function()
+  local again, quiet = sweep()
+
+  it("removes nothing", function()
+    assert.same({ checkouts = 0, entries = 0 }, again)
+  end)
+
+  it("says nothing at all", function()
+    assert.same({}, quiet)
+  end)
+end)
+
+describe("a sweep that destroys work", function()
+  local UNASKED = checkout_dir("unasked")
+  store(UNASKED, {
+    queue = { entry(UNASKED, 30, "unsent, and taken without a question") },
+  }, { checkout = UNASKED, saved = AGED })
+  vim.fn.delete(UNASKED, "rf")
+
+  local asked = {}
+  local was = { select = vim.ui.select, input = vim.ui.input, confirm = vim.fn.confirm }
+  vim.ui.select = function()
+    asked[#asked + 1] = "select"
+  end
+  vim.ui.input = function()
+    asked[#asked + 1] = "input"
+  end
+  vim.fn.confirm = function()
+    asked[#asked + 1] = "confirm"
+    return 1
+  end
+  local taken = sweep()
+  vim.ui.select, vim.ui.input, vim.fn.confirm = was.select, was.input, was.confirm
+
+  it("takes it", function()
+    assert.same({ checkouts = 1, entries = 1 }, taken)
+  end)
+
+  it("never prompts", function()
+    assert.same({}, asked)
+  end)
+end)
+
+--- On a switch -----------------------------------------------------------------
+
+-- A checkout of the fixture, really removed. This is the shape the sweep is built for: a
+-- checkout taken out from beside a repository that stays, so the directory holding the
+-- three of them is still there as its parent.
+store(B, {
+  queue = { entry(B, 40, "left in a checkout that was then removed") },
+}, { checkout = B, saved = AGED })
+vim.fn.delete(B, "rf")
+
+local orphan_before_switch = stored(B)
+chosen = A
+local switch_said, restore_switch = h.capture_notify()
+codereview.switch()
+restore_switch()
+
+describe("a switch", function()
+  it("had the orphan on disk on the way in", function()
+    assert.is_true(orphan_before_switch)
+  end)
+
+  it("sweeps", function()
+    assert.is_false(stored(B), state.path(B))
+  end)
+
+  it("says what it took", function()
+    assert.is_true(h.notified(switch_said, "orphaned checkout"), vim.inspect(switch_said))
+  end)
+
+  it("still opens the review it was asked for", function()
+    assert.same(A, assert(view.current(), "no review view open").root)
+  end)
+end)

--- a/tests/codereview/sweep_spec.lua
+++ b/tests/codereview/sweep_spec.lua
@@ -156,9 +156,11 @@ end
 
 --- The two stores that share the directory and are not checkout documents --------
 
--- Neither can name a checkout that hashes back to its own file name, which is what leaves
--- the sweep needing no list of files to leave alone. A list would be a second copy of
--- where those two stores live, kept in a third place.
+-- Neither carries a checkout or a stamp, so the shape test turns both away before anything
+-- else has seen them -- which is what leaves the sweep needing no list of files to leave
+-- alone. A list would be a second copy of where those two stores live, kept in a third
+-- place. The file-name test below would refuse them too, and never gets the chance, so this
+-- case reds when the shape test goes and not when that one does.
 state.save_global({
   { id = 20, type = "issue", kind = "note", key = "note:0", note = "a thought with no repository behind it" },
 })
@@ -218,10 +220,11 @@ vim.fn.delete(BEFORE, "rf")
 -- Half of that schema: the checkout is on it and hashes back to its own file name, and the
 -- stamp is not. Gone, parent alive, and refused for want of an age.
 --
--- Here because the document above is refused twice over -- it names no checkout, so both
--- the shape test and the file-name test turn it away -- and a rule held by two guards can
--- lose one of them silently. This one is refused by the stamp alone, so weakening the stamp
--- test to "no stamp means old enough" is visible here and nowhere else.
+-- Here because the document above is refused by the shape test for naming no checkout, and
+-- never reaches anything below it -- so no case there can show what the *stamp* half of that
+-- test is doing. This one carries a checkout that hashes back to its own file name, so the
+-- stamp is the only thing left to refuse it: weakening that test to "no stamp means old
+-- enough" is visible here and nowhere else in the suite.
 local HALF = checkout_dir("half")
 store(HALF, {
   queue = { entry(HALF, 14, "unsent, in a document with a checkout and no stamp") },

--- a/tests/codereview/trim_spec.lua
+++ b/tests/codereview/trim_spec.lua
@@ -884,7 +884,9 @@ describe("annotating under a trim", function()
     vim.api.nvim_win_set_cursor(X.win, { X.render.file_rows[at], 0 })
     annotate.annotate("bug")
     local whole = vim.deepcopy(assert(queue.all()[1], "nothing was captured with the trim removed"))
+    -- Ids apart, and the capture stamp with them: neither is read off the line.
     trimmed.id, whole.id = nil, nil
+    trimmed.at, whole.at = nil, nil
     assert.same(whole, trimmed)
   end)
 end)


### PR DESCRIPTION
Closes #178. Parent spec #171.

Stored state for a **checkout** that has been deleted is **orphaned**: still on disk, and
reachable by nothing. It is now swept — under conditions strict enough that a briefly absent
directory does not cost a reviewer unsent work.

## What lands

**Two schema additions, because neither was derivable.** A document records the **checkout**
it belongs to — the file name keeps only a base name and a hash of the full path, so the path
cannot be read back out of it — and a stamp rewritten on every save, which is what the age
test reads. A stamp on entries alone gives no age to a document holding only reviewed marks
and trims. Neither key bumps `VERSION`: an older document simply lacks both, exactly as it
lacks the archive and the trims.

**Every entry is stamped at capture**, in `queue.add`, which is the one seam the review path
and the buffer path both pass through. Not for the sweep — an entry with no repository behind
it carried a stamp and an owned one did not, so which store an entry came from was readable
off the entry. ADR-0002's argument against a consumer branching on where an entry came from,
one field further along.

**The sweep runs on a switch and nowhere else.** No startup scan, no timer. It takes the whole
document — an orphaned **archive** is already unreadable, since an archive is opened through
the checkout being reviewed — and only when all three conditions hold: the directory is gone,
**its parent still exists**, and the document has aged past seven days. Afterwards it reports
one line giving the checkouts swept and the unsent annotations that went with them as separate
figures, and it never prompts.

Two further conditions keep it honest, neither of them in the original criteria:

- a stored path that does not hash back to its own file name is not believed — a state
  directory carried between machines, or a file written half way, names a path that means
  nothing here;
- a checkout this session has read back is left alone. Its entries are in memory, so taking
  its document would report unsent work as destroyed while that work sits in the queue and in
  the number a statusline shows, and the next write about that checkout would put it straight
  back. This is also what keeps the sweep away from the checkout under an open review.

## The grace period does not do what the parent spec's story 21 asks

Recorded in `docs/design-notes.md` rather than left for a reader to discover.

**The window is seven days WITHOUT A WRITE, not seven days missing.** The stamp is rewritten
on every save, and only a mutation saves — opening a review does not, and closing one does
not. **A checkout last written to nine days ago and deleted a minute ago has no protection at
all**: the next switch sweeps it and whatever was unsent in it goes. The protection is
proportional to how recently the document was written, which is not what a grace period
against a directory that may come back would give you.

The alternative — a stamp written the first time a sweep finds the directory gone, swept only
once *that* is a week old — was refused: it needs two sweeps seven days apart, and sweeps
happen only on a switch, so a store could easily never shrink at all. The precedent settles
it: the store that needs no root already deletes seven-day-old unsent annotations outright,
with no directory test whatsoever, so this rule is strictly less aggressive than one the
plugin has shipped for a long time.

The design notes also record that the parent test buys less than "unsweepable at any age"
claims — it holds where the mount point goes with the volume, as on macOS, and not where a
mount point survives as an empty directory, as is usual on Linux — that pre-existing orphans
are permanent, and that deleting a whole project directory is the one shape the sweep cannot
reach.

## Every guard has a case that names it

Each guard was deleted on the finished implementation, one at a time, and the spec re-run.
Reverted between each; two mutations at once mask each other.

| guard deleted | observed | case that reds |
| --- | --- | --- |
| parent-exists | 26 pass / 4 fail / 0 err, exit 2 | leaves an orphan whose parent directory is also gone, at any age |
| grace period | 26 / 4 / 0, exit 2 | leaves an orphan that is inside the window |
| directory-gone | 26 / 4 / 0, exit 2 | leaves a checkout that still exists, at any age |
| stored-path equality | 26 / 4 / 0, exit 2 | leaves a document whose stored checkout is not the one it is filed under |
| already-read-back skip | 26 / 4 / 0, exit 2 | leaves a checkout this session has already read back |
| schema-shape test | run aborts | a sweep does not raise on a directory of files it did not write |
| stamp read as age zero | 26 / 4 / 0, exit 2 | leaves a document that carries a checkout but no stamp |

Three things the matrix showed that the criteria did not predict:

**The three `what a sweep reports` cases red under every mutation.** They assert exact totals
(2 checkouts, 3 annotations), so any extra document swept moves them. Coupling, not masking —
the distinguishing case is unique in all seven runs — but they cannot localise a fault alone.

**Deleting the schema-shape test does not mis-sweep, it raises.** `state.lua: attempt to
perform arithmetic on field 'saved' (a nil value)`: a document carrying a checkout with no
stamp reaches the age test. In a spec that is an error outside an `it`, which aborts the file;
in an editor it is an error on every switch, for anyone holding a pre-existing document.

**The no-repository store and the drafts store are kept out by the schema-shape test, not by
the file-name check.** Deleting the file-name check leaves their case green — they never reach
it. `M.path(nil)` does not raise; it answers `v:null-<hash>.json`, which no document is ever
filed under, so that check *would* refuse them and simply never gets the chance. A comment
here originally credited the wrong guard and is corrected in its own commit.

**One guard had no test at all and now does.** Weakening the stamp half to `doc.saved or 0` —
a missing stamp reads as infinitely old, exactly what `state.load`'s comment warns about —
passed every case in the file. Nothing exercised a document carrying a checkout with no stamp,
because the pre-existing document lacks both keys and is turned away earlier. That fixture and
its case were added.

## Fallout outside the sweep

Stamping entries at capture broke three whole-entry comparisons that null the id and compare
everything else — `since_batch_spec`, `spans_spec`, `trim_spec`. They fail only when two
captures straddle a second boundary, so the first full run failed and the next passed. All
three now null the stamp beside the id, and the comment in each arguing "ids apart, because
they are issued in order and nothing else about an entry is" has moved with the rule; it is no
longer true. No assertion is weakened.

## Merge point with #177

`checkout.M.switch` is touched by both this branch and #184 (`fix/177-frozen-review`), which
owns the **listing fallback** — asking `git.checkouts` again from the global working directory
when the review's own checkout is gone, since `vim.system` raises on a cwd that is not there.

The two hunks are about 25 lines apart inside one function: #184 sits immediately after
`local checkouts = git.checkouts(root)`, and this branch adds one call at the end of the pick
callback, after `view.open`. Whichever lands second should confirm both are present rather
than trusting a clean automatic merge. `docs/design-notes.md` and `tests/README.md` are also
touched by both; this branch keeps its additions in a section of its own for that reason.

## Verification

`make all`: exit 0, 41 spec files, 1,881 cases, 0 failures, 0 errors, run three times
consecutively for the entry-stamp flakiness above. `sweep_spec` is 30 cases, single process,
about a second: no clock is moved and nothing waits — an aged document is written by hand onto
a file the store itself wrote.
