### PR TITLE
feat(view): go back along the checkout trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,19 @@ It works with no review open, which is how you open a review somewhere else in t
 place. The list is built from git's own worktree listing; replace the chooser with
 [`pick_checkout`](#adapters) to get it in the picker your config already uses.
 
+`:CodeReviewBack` goes back to the checkout you came from. It is the same journey, with the
+destination taken from where you have been rather than asked for — and the checkout you came
+from is also the **first entry the picker offers**, so going back is the gesture you already
+have. There is no forward and none is needed: after going back, going forward again is that
+same first entry.
+
+The checkouts you have been in are held one each, most recent first, so moving back and forth
+between two does not fill the list with repeats. One whose directory is gone is walked over
+and named, so a pruned agent worktree is visible rather than silent; one that is still there
+with nothing in its branch scope says so and is kept, so you have not lost it. The trail lives
+for the session and is never written to disk — it is where you have been, not what you were
+reviewing.
+
 Each checkout keeps its own queue, its own reviewed marks, its own trims and its own
 archive. Leaving one is lossless and returning gives back exactly what you left, so
 switching with annotations still queued is safe and is not confirmed. Your **global**

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -81,6 +81,33 @@ takes commits off the start of the branch included, works on any git.
         nothing in the plugin reads it back. Replace the chooser with
         |codereview-opt-pick_checkout|.
 
+                                                            *:CodeReviewBack*
+:CodeReviewBack
+        Go back to the **checkout** the review came from. The same journey
+        |:CodeReviewSwitch| makes, with the destination taken from where you
+        have been rather than asked for.
+
+        There is no forward, and none is needed: the checkout you just left is
+        the first entry |:CodeReviewSwitch| offers, so going forward again is
+        the same single keystroke as going back. That is also why there is no
+        key of its own -- the picker's first row already is one.
+
+        The checkouts you have been in are held one each, most recent first,
+        and that order is the order the picker offers them in. Moving back and
+        forth between two does not fill it with repeats.
+
+        A checkout whose directory is gone is walked over and named, so a
+        pruned agent worktree is visible rather than silent, and the walk
+        carries on to the one underneath it. A checkout that is still there and
+        has nothing in its branch scope says so and is kept, so you have not
+        lost it -- press again once there is something to review in it. With
+        nothing left to go back to it says that too.
+
+        Lives for the session only, and is never written to disk: it is where
+        you have been, not what you were reviewing, and restoring it would
+        offer a path through checkouts that may no longer exist. Needs no
+        review open.
+
                                                        *:CodeReviewLastBatch*
 :CodeReviewLastBatch
         Read the last dispatched batch back: its annotations, grouped by type

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -500,6 +500,49 @@ gets them at all. Both halves of a restore therefore ask their own question, and
 is safe because every `queue.add` is followed by a write: a loose entry is on the disk
 before anything can read that store again.
 
+## The checkout trail
+
+A section of its own, because `docs/design-notes.md` has conflicted on every merge in this
+stack.
+
+**Only a successful open is a journey.** `view.open` declines an empty scope, an
+unresolvable one and a failed diff, and it declines each of them *before* it closes
+anything — the review the reviewer was reading is still on screen. A push made on the switch
+rather than on the open therefore records a departure that never happened, and the checkout
+it records is the one the reviewer is standing in. The picker then offers the row marked
+`(current)` first and going back goes nowhere, which is two of this feature's rules broken
+by a keystroke that told the reviewer only "No changes in scope".
+
+**Arriving removes; leaving pushes. De-duplicating the push is not the same rule.** The
+parent spec's wording — "pushing a checkout removes any earlier occurrence of it first" —
+holds each checkout once and still leaves the checkout the reviewer is *standing in* on the
+trail, ranked above one they have never opened. Removing the checkout being arrived at is
+what makes the trail "where I have been" rather than "where I have been, plus here". It also
+makes a duplicate push impossible without a second rule: a checkout can only be pushed by
+being left, and can only be left after being entered, which removed it. Two checkouts cannot
+tell the two rules apart at any step — `trail_spec` needs the fixture's third for it, and
+deleting the removal reds the ordering case with `agent-a` ranked above `main`.
+
+**A checkout that is gone and a checkout that refuses are opposite cases.** Gone: walk over
+it, name it, carry on — consuming the entry is the point. There and refusing: consume
+nothing. An agent worktree whose branch has been merged has an empty branch scope, so
+refusing is the *ordinary* end state rather than an exotic one, and a trail entry once spent
+cannot be got back — there is no forward, by design. An implementation that pops before it
+opens loses that checkout permanently and says nothing about it.
+
+**Skipping terminates because the trail is finite, not because anything is protected.** The
+parent spec said it terminates because the checkout Neovim started in is never switched away
+from and stays reachable. The first half is true — the global working directory never moves.
+The second does not follow: that checkout reaches the trail by being left, like any other,
+and its directory can be deleted, like any other. Every skip takes one entry off a finite
+list, which is the real reason, and it means the bottom of the trail is reachable and has to
+say so rather than be a press that does nothing.
+
+**The trail is never persisted, and the only way to test that is a process that did not
+build it.** `trail_child.lua` is inverted from every other child in the suite: it builds a
+trail so the parent can find one absent, and it shares the parent's state directory so the
+parent looks for one with that session's stores on the disk in front of it.
+
 ## The archive
 
 **The state document's `VERSION` must not be bumped to add a key.** A mismatched version

--- a/lua/codereview/checkout.lua
+++ b/lua/codereview/checkout.lua
@@ -26,6 +26,118 @@ local function warn(msg)
   vim.notify(msg, vim.log.levels.WARN, { title = "Code review" })
 end
 
+---@param msg string
+local function info(msg)
+  vim.notify(msg, vim.log.levels.INFO, { title = "Code review" })
+end
+
+--- The trail back ---------------------------------------------------------------
+
+---The **checkouts** the reviewer has been in, most recent first, and never the one they
+---are in now.
+---
+---Module-level, and that is the whole of its lifetime: it is navigation history rather than
+---review state, and persisting it would resurrect a path through checkouts that may no
+---longer exist. Nothing writes it to disk and nothing reads it back.
+---
+---It has no term in the glossary and no surface of its own, deliberately -- a reviewer
+---never handles it. What they see of it is the order the picker offers, which is this
+---order: going back is then the first entry of the list they already know rather than a
+---second gesture to learn, and going forward again is the same single keystroke, which is
+---why there is no forward.
+---@type string[]
+local trail = {}
+
+---Take a checkout out of the trail, wherever it is.
+---@param path string
+local function forget(path)
+  for i = #trail, 1, -1 do
+    if trail[i] == path then
+      table.remove(trail, i)
+    end
+  end
+end
+
+---Open the review on a checkout, and record the journey only if it opened.
+---
+---Both halves are load-bearing and neither is obvious.
+---
+---**Only if it opened.** `view.open` declines an empty scope, an unresolvable one and a
+---failed diff, and it declines each of them *before* it closes anything -- the review the
+---reviewer was reading is still on screen. A push made on the switch rather than on the
+---open would then name a checkout they never left, which is the one they are standing in:
+---the picker would offer the row marked `(current)` first and going back would go nowhere.
+---
+---**The checkout arrived at leaves the trail.** Removing it here rather than
+---de-duplicating the push is what keeps the trail to where the reviewer has *been*. De-
+---duplicating alone holds each checkout once as well, and still leaves the checkout they
+---are standing in in the trail, ranked above one they have never opened. It also makes a
+---push impossible to duplicate, since a checkout can only be pushed by being left and can
+---only be left after being entered here.
+---
+---Reopening the checkout the review is already on is a legitimate thing to ask the picker
+---for, and it must leave the trail alone: it is not a journey.
+---@param path string
+---@return boolean opened `view.open` has already said why it did not
+local function enter(path)
+  -- Before the open, which replaces the review this reads from.
+  local from = require("codereview.state").current_checkout()
+  if not require("codereview.view").open(nil, path) then
+    return false
+  end
+  forget(path)
+  if from and from ~= path then
+    table.insert(trail, 1, from)
+  end
+  return true
+end
+
+---The listing, ordered by the trail: where the reviewer has been, most recent first, then
+---everything else in the order git named it.
+---
+---A permutation of what it was handed and never an addition to it. A checkout offered twice
+---would answer with a row the reviewer did not believe they were choosing.
+---@param checkouts CRCheckout[]
+---@return CRCheckout[]
+local function in_trail_order(checkouts)
+  local rank = {}
+  for i, path in ipairs(trail) do
+    rank[path] = i
+  end
+
+  local been, rest = {}, {}
+  for _, checkout in ipairs(checkouts) do
+    if rank[checkout.path] then
+      been[#been + 1] = checkout
+    else
+      rest[#rest + 1] = checkout
+    end
+  end
+  table.sort(been, function(a, b)
+    return rank[a.path] < rank[b.path]
+  end)
+  return vim.list_extend(been, rest)
+end
+
+---What was walked over on the way back, named.
+---
+---By full path rather than by the directory name the picker leads with. The picker can
+---afford the short name because it draws the branch beside it and the reviewer is choosing
+---from a list they can see; a line about a checkout that is gone has neither, and two
+---worktrees under different parents can share a name.
+---
+---One line rather than one notification per checkout: going back over three pruned agent
+---worktrees would otherwise be three warnings in a row, which is a worse answer than the
+---silence the naming exists to prevent.
+---@param paths string[]
+---@return string
+local function skipped_line(paths)
+  if #paths == 1 then
+    return ("Skipped a checkout that no longer exists: %s"):format(paths[1])
+  end
+  return ("Skipped %d checkouts that no longer exist: %s"):format(#paths, table.concat(paths, ", "))
+end
+
 ---One row of the picker, as the reviewer reads it.
 ---
 ---The directory's own name first, because that is what a reviewer named the checkout when
@@ -85,6 +197,11 @@ function M.switch()
     return
   end
 
+  -- Ordered here, as a step of its own after the listing has been settled: the checkout
+  -- the reviewer came from is the first row, which is what makes going back the gesture
+  -- they already have.
+  checkouts = in_trail_order(checkouts)
+
   -- The shipped picker is the *default implementation* of the adapter, not a lesser path
   -- beside it (ADR-0003): both are handed the same list and both answer the same way.
   local pick = config.get().pick_checkout or M.pick
@@ -98,8 +215,51 @@ function M.switch()
     -- review's scope across would be wrong rather than convenient: a revspec resolved in
     -- one checkout need not exist in another, and `since-batch` names the archive of the
     -- checkout being left. Which scope a checkout was last reviewed at is #175's.
-    require("codereview.view").open(nil, path)
+    enter(path)
   end)
+end
+
+---Go back along the trail, to the **checkout** the reviewer came from.
+---
+---The same journey a switch makes, with the destination chosen for them instead of asked
+---for -- so there is nothing here that a switch does not also do, and nothing to learn
+---beyond which key it is on.
+---
+---A checkout whose directory is gone is walked over and named. A checkout that is *there*
+---and declines to open is not: it is left exactly where it is on the trail, because the
+---reviewer has not been anywhere and a trail entry once consumed cannot be got back --
+---there is no forward. An agent worktree whose branch has been merged has an empty branch
+---scope and declines, which makes this the ordinary case rather than the exotic one.
+---
+---Walking over entries always terminates, because the trail is finite and every skip takes
+---one entry off it. Not because the checkout Neovim started in is protected: it reaches the
+---trail by being left, like any other, and its directory can be deleted like any other. So
+---the bottom of the trail is reachable, and being there is said rather than left as a press
+---that does nothing.
+function M.back()
+  local skipped, landed = {}, false
+
+  while #trail > 0 do
+    local path = trail[1]
+    if (vim.uv.fs_stat(path) or {}).type ~= "directory" then
+      table.remove(trail, 1)
+      skipped[#skipped + 1] = path
+    else
+      -- `enter` takes it off the trail itself, and only once the open has succeeded.
+      landed = enter(path)
+      break
+    end
+  end
+
+  if #skipped > 0 then
+    warn(skipped_line(skipped))
+  end
+  -- Nothing was refused and there is nothing left: said, for the reason an empty listing is
+  -- said rather than opened as an empty picker. A refusal has already spoken for itself and
+  -- has left its checkout on the trail, so it is not this.
+  if not landed and #trail == 0 then
+    info("No checkout to go back to")
+  end
 end
 
 return M

--- a/lua/codereview/init.lua
+++ b/lua/codereview/init.lua
@@ -40,6 +40,14 @@ function M.setup(opts)
     desc = "Switch the review to another checkout of this repository",
   })
 
+  -- No key of its own, and that is the design rather than an omission: the previous
+  -- **checkout** is the first entry |:CodeReviewSwitch| offers, so going back already has a
+  -- gesture. A command, for the reason the switch is one -- it has to work with no review
+  -- open.
+  vim.api.nvim_create_user_command("CodeReviewBack", M.back, {
+    desc = "Go back to the checkout the review came from",
+  })
+
   -- Takes no arguments and needs no review open, for the reason the copy above does not:
   -- the batch it reads back has already gone, so nothing about the current window could
   -- change which one went last.
@@ -90,6 +98,22 @@ end
 ---`pick_checkout` adapter, whose default the plugin ships (ADR-0007).
 function M.switch()
   require("codereview.checkout").switch()
+end
+
+---Go back to the **checkout** the review came from.
+---
+---The same journey a **switch** makes, with the destination taken from where the reviewer
+---has been rather than asked for. There is no forward beside it: the checkout just left is
+---the first entry the picker offers, so going forward again is the same single keystroke.
+---
+---Checkouts that no longer exist are walked over and named. One that is still there and
+---declines to open -- an agent worktree whose branch has been merged has an empty branch
+---scope -- is left on the trail rather than spent, because nothing here could give it back.
+---
+---The trail lives for the session and is never written to disk. It is navigation history,
+---not review state.
+function M.back()
+  require("codereview.checkout").back()
 end
 
 ---Annotate the file in the current buffer, from anywhere.

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
 | `codereview/checkout_child.lua` | Spawned by `checkout_restart_spec` to work in two **checkouts** and dispatch from each — deliberately not a spec. |
+| `codereview/trail_child.lua` | Spawned by `trail_spec` to build a **checkout** trail and go back along it, so the parent can find one absent after a restart — deliberately not a spec. |
 | `codereview/layout_child.lua` | Spawned by `layout_spec` — deliberately not a spec. |
 | `codereview/archived_child.lua` | Spawned by `render_spec` to archive a batch and turn archived entries off — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
@@ -82,6 +83,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `checkout_spec` | The queue scoped to its **checkout**: two checkouts of one repository in one session — what each store receives, the queue left in the second read back rather than hidden, the return to the first, the annotation about a checkout you are not in that is filed nowhere and says so, and the loose entry whose id one counter keeps clear of |
 | `checkout_restart_spec` | The same scoping across a genuine restart: what two checkouts worked in one session left on the disk, each store holding only what it is about, and the id a new annotation takes in a checkout whose **archive** the counter has never been seeded from |
 | `switch_spec` | Moving the review to another **checkout**: the listing it is chosen from — the three checkouts of one repository, each named as its own git names it, with a bare one and a deleted one left out — the picker the plugin ships and the `pick_checkout` adapter that replaces it, a switch with a review open and with none, the directories a switch must not move, the queue and the store and the id that follow the review rather than the working directory, and what belongs to no checkout riding along into one reached by switching — asked from a tab standing in another checkout — the tab a real file opens into, `:CodeReviewSwitch` and `gS` in the diff and the tree, and the checkout with nothing in scope that is declined rather than opened |
+| `trail_spec` | Going back along the **checkout** trail: the return and the previous checkout offered first, the eight switches between two that leave the trail holding each once, the third checkout the ordering cannot be seen without, the reopen and the declined switch that put nothing on it, the checkout that is there and refuses being kept rather than spent, the ones that are gone being named and walked over, the landing in the checkout Neovim started in, the bottom of the trail said rather than silent, and the trail absent in the session after the one that built it |
 | `count_spec` | The queued count a statusline asks for: which **checkout** it is about after a bare directory change, the bare note that is in the number everywhere, what a redraw costs in git processes cold and warm, the answer of "no checkout" that is deliberately not remembered so a `git init` is visible at once, the tab whose own directory was deleted underneath it, and the intersection with the **switch** — the number read from the tab the reviewer is standing in, about the checkout the review is on |
 
 ## Fixtures
@@ -924,6 +926,34 @@ so the out-of-core language path is still checked locally without ever failing C
   dropping the backticks, say — silently yields no rows, and "no row names a module that is
   gone" then holds over nothing. It asserts both sides are non-empty before comparing them,
   which is the only reason that reformatting reds two cases instead of one.
+
+## The checkout trail
+
+A section of its own, because `tests/README.md` has conflicted on every merge in this stack.
+
+- **The trail has no surface, so every claim about it is read through the picker's
+  ordering.** That is where the rule was written — the trail's order *is* the picker's — and
+  it is the only place a reviewer sees it. Nothing in `trail_spec` asserts how it is stored,
+  and the spec would survive the storage being replaced.
+- **Two checkouts cannot tell the ordering rules apart.** A trail that removes the checkout
+  being arrived at and one that merely de-duplicates its pushes agree at every step of an
+  A↔B dance, head included. The fixture's third checkout is what separates them: with three,
+  the wrong rule ranks the checkout you are standing in above one you have never opened. A
+  case written against two checkouts is a case that cannot fail.
+- **A refused open and a deleted directory are opposite cases and need separate fixtures.**
+  Deleting a directory is easy; making a checkout *refuse* takes `git reset --hard master`,
+  which empties its branch scope while leaving it listed. Without the second one, the rule
+  that a refusal costs the reviewer nothing has no case at all.
+- **The restart child is inverted.** Every other child in this suite writes something for
+  the parent to read; `trail_child.lua` builds a trail so the parent can find one *absent*.
+  It shares the parent's `XDG_STATE_HOME`, so the parent looks for a trail with that
+  session's stores in front of it, and it asserts its own half — that it switched and got
+  back — so the case cannot pass by asserting nothing came back from nothing.
+- **The block order in `trail_spec` is load-bearing twice.** The restart case is first,
+  because it is about a process that has not switched anything and every block below
+  switches. The exhausted-trail case is last, because it deletes checkouts the blocks above
+  need — the trail holds every checkout visited except the current one, so emptying it means
+  deleting all of them.
 
 ## Deliberately not covered
 

--- a/tests/codereview/trail_child.lua
+++ b/tests/codereview/trail_child.lua
@@ -1,0 +1,48 @@
+-- The switching half of `trail_spec`'s restart case, in its own process.
+--
+-- Inverted from every other child in this suite. The others write something and let the
+-- parent read it back; this one exists so that the parent can find something **absent**.
+-- The trail is navigation history and is never persisted, so the only way to see that it
+-- did not survive a process is to have a process build one first -- and the process that
+-- builds it cannot be the one that observes the absence.
+--
+-- It shares the parent's `XDG_STATE_HOME`, which is the whole point of sharing it: the
+-- parent looks for its trail with this session's stores sitting on the disk in front of it.
+-- If a trail were ever written, that is where it would be.
+--
+-- It asserts its own half rather than printing it, so the case cannot go vacuous. A child
+-- that never reached the second checkout, or that could not go back, exits non-zero and the
+-- parent says so instead of quietly asserting that nothing came back from nothing.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+
+local base = assert(vim.env.FIXTURE, "FIXTURE is not set")
+local A = vim.fs.joinpath(base, "agent-a")
+local B = vim.fs.joinpath(base, "agent-b")
+
+vim.cmd("cd " .. vim.fn.fnameescape(A))
+
+local chosen = nil
+require("codereview").setup({
+  syntax = false,
+  pick_checkout = function(_, cb)
+    cb(chosen)
+  end,
+})
+
+local codereview = require("codereview")
+local view = require("codereview.view")
+
+chosen = B
+codereview.switch()
+assert(view.current() and view.current().root == B, "the child never reached the second checkout")
+
+codereview.back()
+assert(view.current() and view.current().root == A, "the child could not go back to the first checkout")
+
+print("went " .. A .. " -> " .. B .. " -> back")
+vim.cmd("qa!")

--- a/tests/codereview/trail_spec.lua
+++ b/tests/codereview/trail_spec.lua
@@ -1,0 +1,452 @@
+-- Going back along the **checkout** trail.
+--
+-- A **switch** is not a one-way trip. What this file pins is the history behind it: the
+-- checkout the reviewer came from, ordered first in the list they are offered, so going
+-- back is the gesture they already know rather than a second one to learn.
+--
+-- The trail has no surface of its own, deliberately -- a reviewer never handles it, which
+-- is why the parent spec gave it no term. So every claim about it here is read through the
+-- **picker's ordering**, which is the one place it is visible and is where the rule was
+-- written: the trail holds each checkout once, most recent first, and that ordering is the
+-- picker's. Nothing below asserts how the trail is stored.
+--
+-- Two rules in one function, and they are not the same rule, which is the trap this file is
+-- shaped around:
+--
+--   * a checkout whose **directory is gone** is skipped, named, and the walk continues --
+--     skipping consumes the entry on purpose;
+--   * a checkout that is **there and refuses to open** -- an empty branch scope, which is
+--     the ordinary end state of an agent worktree once its branch is merged -- consumes
+--     nothing. The reviewer stays where they are and the entry is still there to try again.
+--     An implementation that pops before it opens loses that checkout permanently, and no
+--     gesture in the plugin restores it: there is no forward, by design.
+--
+-- Single process, except for the one claim a single process cannot make. Every switch here
+-- is one session moving between checkouts, which is what a switch is.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+
+-- Three checkouts of one repository. Realpathed once: `git rev-parse --show-toplevel`
+-- answers resolved, and on macOS a temporary directory is a symlink into /private.
+local base = assert(vim.uv.fs_realpath(h.fixture("mkcheckouts")))
+local MAIN = vim.fs.joinpath(base, "main")
+local A = vim.fs.joinpath(base, "agent-a")
+local B = vim.fs.joinpath(base, "agent-b")
+
+-- Checkouts this file adds to the fixture, each for one rule and each named for what it is
+-- for. Built inside the cases that need them rather than by the fixture script, so the
+-- ordering asserted before they exist is asserted against a listing that has only ever held
+-- real ones.
+local THIRD = vim.fs.joinpath(base, "third") -- a third openable checkout; later made to refuse
+local PRUNED = vim.fs.joinpath(base, "pruned") -- deleted under one entry of the trail
+local PRUNED_A = vim.fs.joinpath(base, "pruned-a") -- and two of them, above the start
+local PRUNED_B = vim.fs.joinpath(base, "pruned-b")
+
+local codereview = require("codereview")
+local git = require("codereview.git")
+local view = require("codereview.view")
+
+-- The checkout Neovim started in, for the whole file. Nothing below ever changes it: it is
+-- what `back` has to be able to reach at the bottom of everything, and a case that moved it
+-- would be asserting that guarantee against a directory it had arranged.
+vim.cmd("cd " .. vim.fn.fnameescape(A))
+
+---Run git somewhere, for the checkouts this file builds on top of the shared fixture.
+---@param cwd string
+---@param args string[]
+local function git_at(cwd, args)
+  local res = vim.system(vim.list_extend({ "git" }, args), { cwd = cwd, text = true }):wait(60000)
+  assert(res.code == 0, table.concat(args, " ") .. ": " .. (res.stderr or ""))
+end
+
+---Add a linked checkout of the fixture repository, on a branch of its own.
+---
+---Branched from `agent-a`'s HEAD, so it carries that checkout's commit over master and its
+---branch scope has something in it -- a checkout with an empty branch scope cannot be
+---opened at all, so it could never be entered and could never reach the trail.
+---@param path string
+local function add_checkout(path)
+  git_at(A, { "worktree", "add", "-q", "-b", vim.fn.fnamemodify(path, ":t"), path })
+end
+
+---@return CRView
+local function current()
+  return assert(view.current(), "no review view open")
+end
+
+--- The seam ---------------------------------------------------------------------
+
+-- The `pick_checkout` adapter, stubbed exactly as the send, target and compose adapters are
+-- stubbed throughout this suite. It is the one seam this work has, it is the same one
+-- `switch_spec` drives, and no test-only door is opened anywhere below.
+local offered, chosen = nil, nil
+codereview.setup({
+  syntax = false,
+  pick_checkout = function(checkouts, cb)
+    offered = checkouts
+    cb(chosen)
+  end,
+})
+
+---Switch the review to a checkout, through the public entry point and the adapter.
+---@param path string|nil
+local function switch_to(path)
+  chosen = path
+  codereview.switch()
+end
+
+---The order the picker offers, read by opening it and declining.
+---
+---Declining moves nothing and pushes nothing, so this can be asked between any two cases
+---without disturbing what they are about. It is the only reading of the trail there is.
+---@return string[]
+local function offered_order()
+  offered, chosen = nil, nil
+  codereview.switch()
+  return vim.tbl_map(function(c)
+    return c.path
+  end, assert(offered, "the picker was never offered a list"))
+end
+
+---Every checkout git still lists, sorted -- the set the picker's order must be a permutation
+---of. Sorted because this one is about the set and not the order.
+---@return string[]
+local function listed()
+  local paths = vim.tbl_map(function(c)
+    return c.path
+  end, git.checkouts(A))
+  table.sort(paths)
+  return paths
+end
+
+---@param paths string[]
+---@return string[] sorted copy
+local function sorted(paths)
+  local copy = vim.deepcopy(paths)
+  table.sort(copy)
+  return copy
+end
+
+--- The trail does not survive the process ------------------------------------------
+
+-- First in the file, and it has to be: the claim is about a process that has not switched
+-- anything, and every block below switches. The child does the switching, in a session of
+-- its own that shares this one's state directory -- so this process looks for its trail with
+-- that session's stores sitting on the disk in front of it. If a trail were ever written,
+-- that is where it would be.
+describe("a session after the one that switched", function()
+  local cmd = {
+    vim.v.progpath,
+    "--clean",
+    "-l",
+    vim.fs.joinpath(h.root, "tests", "codereview", "trail_child.lua"),
+  }
+  local proc = vim.system(cmd, {
+    cwd = base,
+    text = true,
+    env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = base },
+  })
+  local child = proc:wait(60000)
+
+  -- The guard. The child asserts its own half -- that it reached the second checkout and
+  -- that it got back -- so a child that never built a trail cannot leave this block
+  -- asserting that nothing came back from nothing.
+  it("built a trail and went back along it before it exited", function()
+    assert.same(0, child.code, (child.stderr or "") .. (child.stdout or ""))
+  end)
+
+  it("has no trail of its own, and says so rather than going nowhere quietly", function()
+    local msgs, restore = h.capture_notify()
+    codereview.back()
+    restore()
+    assert.is_true(h.notified(msgs, "No checkout to go back to"), vim.inspect(msgs))
+  end)
+
+  it("opens nothing on its way to saying it", function()
+    assert.is_nil(view.current())
+  end)
+end)
+
+--- Going back ---------------------------------------------------------------------
+
+describe("going back after one switch", function()
+  it("arrives in the checkout that was chosen", function()
+    switch_to(B)
+    assert.same(B, current().root)
+  end)
+
+  it("returns to the checkout the reviewer came from", function()
+    codereview.back()
+    assert.same(A, current().root)
+  end)
+
+  -- The whole of criterion 2, and the reason there is no key for going back: the gesture is
+  -- the one the reviewer already used to leave.
+  it("puts the checkout it came from first in the list it offers next", function()
+    assert.same({ B, MAIN, A }, offered_order())
+  end)
+end)
+
+-- "There is no forward" is a negative over the whole surface and no case can assert it.
+-- What can be asserted is the thing that makes a forward gesture unnecessary, which is what
+-- the parent spec actually argues: after going back, going forward again is the same single
+-- keystroke, because the checkout just left is the first entry the picker offers.
+describe("going back again, which is what stands in for a forward", function()
+  it("returns to the checkout that was just left", function()
+    codereview.back()
+    assert.same(B, current().root)
+  end)
+
+  it("offers the checkout it just left first, so forward costs one keystroke", function()
+    assert.same({ A, MAIN, B }, offered_order())
+  end)
+end)
+
+--- The trail holds each checkout once ------------------------------------------------
+
+-- The case the issue says is easy to omit, and it is easy to omit because the reading that
+-- catches it is not the obvious one. After eight switches between two checkouts, "the
+-- previous checkout is first" is true of a trail that appended blindly as well -- the head
+-- is the checkout just left either way. What separates them is everything below the head: a
+-- trail that kept every visit holds the checkout the reviewer is standing in, and orders it
+-- above a checkout they have never been to.
+describe("switching between two checkouts, over and over", function()
+  it("moves between them eight times and lands back where it began", function()
+    for _ = 1, 4 do
+      switch_to(A)
+      switch_to(B)
+    end
+    switch_to(A)
+    assert.same(A, current().root)
+  end)
+
+  it("offers exactly what one switch would have left, and in the same order", function()
+    assert.same({ B, MAIN, A }, offered_order())
+  end)
+end)
+
+--- Three checkouts, which is the fewest that can show the ordering ----------------------
+
+-- Two cannot. With two, a trail that removes the checkout being arrived at and one that
+-- merely de-duplicates its pushes produce the same list at every step. The third is what
+-- makes "most recent first" a claim with an order in it, and it is why the fixture builds
+-- three rather than two.
+describe("the order a third checkout puts the list in", function()
+  it("walks the three of them and comes back to the first", function()
+    add_checkout(THIRD)
+    switch_to(B)
+    switch_to(THIRD)
+    switch_to(A)
+    assert.same(A, current().root)
+  end)
+
+  it("offers the two it has been to, most recent first", function()
+    assert.same({ THIRD, B, MAIN, A }, offered_order())
+  end)
+
+  -- Stated on its own because it is the half the de-duplication rule is really about. The
+  -- checkout the reviewer is standing in is not somewhere they have been, so it cannot
+  -- outrank a checkout they have never opened.
+  it("does not rank the checkout it is standing in above one never visited", function()
+    local order = offered_order()
+    local at = {}
+    for i, path in ipairs(order) do
+      at[path] = i
+    end
+    assert.is_true(at[MAIN] < at[A], vim.inspect(order))
+  end)
+
+  -- An ordering is a permutation. Prepending the trail to the list it was ordering would
+  -- offer a checkout twice, and the picker would answer with a row the reviewer did not
+  -- believe they were choosing.
+  it("offers every checkout git lists, each exactly once", function()
+    assert.same(listed(), sorted(offered_order()))
+  end)
+end)
+
+--- A destination that is where you already are -------------------------------------------
+
+-- The picker offers the current checkout on purpose, marked, and reopening it is a
+-- legitimate thing to ask for. What it must not do is make the reviewer's own position the
+-- checkout they came from: the picker's first entry would then be the row marked
+-- `(current)`, and going back would go nowhere.
+describe("reopening the checkout the review is already on", function()
+  it("reopens it", function()
+    switch_to(A)
+    assert.same(A, current().root)
+  end)
+
+  it("leaves the trail exactly as it was", function()
+    assert.same({ THIRD, B, MAIN, A }, offered_order())
+  end)
+end)
+
+--- A switch that is refused ------------------------------------------------------------
+
+-- `main` is the branch every other checkout here is reviewed against, so its branch scope is
+-- empty and opening it is declined -- the review the reviewer was reading stays where it
+-- was. A push that happens on the switch rather than on the open leaves the trail naming a
+-- checkout that was never left, which is the checkout they are standing in.
+describe("a switch to a checkout that declines to open", function()
+  local msgs, restore
+
+  it("says so, and leaves the review where it was", function()
+    msgs, restore = h.capture_notify()
+    switch_to(MAIN)
+    restore()
+    assert.is_true(h.notified(msgs, "No changes in scope"), vim.inspect(msgs))
+    assert.same(A, current().root)
+  end)
+
+  it("puts nothing on the trail on its way to saying nothing happened", function()
+    assert.same({ THIRD, B, MAIN, A }, offered_order())
+  end)
+end)
+
+--- Going back onto a checkout that is there and declines ----------------------------------
+
+-- The asymmetry. A checkout whose branch was merged has an empty branch scope and will not
+-- open, and it is still there -- so there is nothing to skip and nothing to name. Going back
+-- onto it must cost the reviewer nothing at all, because a pop that has already happened
+-- cannot be undone by any gesture the plugin has.
+describe("going back onto a checkout whose scope has emptied", function()
+  local msgs, restore
+
+  it("is declined in the wording an ordinary open uses", function()
+    git_at(THIRD, { "reset", "--hard", "master" })
+    msgs, restore = h.capture_notify()
+    codereview.back()
+    restore()
+    assert.is_true(h.notified(msgs, "No changes in scope"), vim.inspect(msgs))
+  end)
+
+  it("leaves the review where it was", function()
+    assert.same(A, current().root)
+  end)
+
+  it("keeps it on the trail, so the reviewer has not lost it", function()
+    assert.same({ THIRD, B, MAIN, A }, offered_order())
+  end)
+
+  -- Asked twice, because "the entry survives" and "the entry survives once" are different
+  -- claims and only the second one is worth anything.
+  it("says the same thing the second time, and still has not moved", function()
+    local again, stop = h.capture_notify()
+    codereview.back()
+    stop()
+    assert.is_true(h.notified(again, "No changes in scope"), vim.inspect(again))
+    assert.same(A, current().root)
+    assert.same({ THIRD, B, MAIN, A }, offered_order())
+  end)
+end)
+
+--- Going back over a checkout that is gone -------------------------------------------------
+
+describe("going back over one checkout whose directory is gone", function()
+  local msgs, restore
+
+  it("walks through it and deletes it underneath the trail", function()
+    add_checkout(PRUNED)
+    switch_to(PRUNED)
+    switch_to(B)
+    assert.same(B, current().root)
+    vim.fn.delete(PRUNED, "rf")
+  end)
+
+  it("names the checkout it skipped", function()
+    msgs, restore = h.capture_notify()
+    codereview.back()
+    restore()
+    assert.is_true(h.notified(msgs, "no longer exist"), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, PRUNED), vim.inspect(msgs))
+  end)
+
+  -- Skipping is not stopping. Without this the case is satisfied by a `back` that names what
+  -- it found and gives up on the spot.
+  it("carries on to the one underneath it", function()
+    assert.same(A, current().root)
+  end)
+end)
+
+describe("going back with every checkout above the start gone", function()
+  local msgs, restore
+
+  it("walks through two of them and deletes them both", function()
+    add_checkout(PRUNED_A)
+    add_checkout(PRUNED_B)
+    switch_to(PRUNED_A)
+    switch_to(PRUNED_B)
+    switch_to(B)
+    assert.same(B, current().root)
+    vim.fn.delete(PRUNED_A, "rf")
+    vim.fn.delete(PRUNED_B, "rf")
+  end)
+
+  it("names both of them, in the order it walked over them", function()
+    msgs, restore = h.capture_notify()
+    codereview.back()
+    restore()
+    assert.is_true(h.notified(msgs, PRUNED_B), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, PRUNED_A), vim.inspect(msgs))
+  end)
+
+  -- Criterion 5, stated the way the guarantee is stated rather than as a path: the reviewer
+  -- lands in the checkout Neovim started in, which is the one a switch never moves.
+  it("still lands in the checkout Neovim started in", function()
+    assert.same(vim.fn.getcwd(-1, -1), current().root)
+  end)
+end)
+
+--- The surface -------------------------------------------------------------------------
+
+describe("the surface going back is reached through", function()
+  it("is a command, because going back has to work with no review open", function()
+    assert.is_true(vim.tbl_contains(vim.fn.getcompletion("CodeReviewBack", "cmdline"), "CodeReviewBack"))
+  end)
+
+  -- The other half of "there is no forward", and the half a future contributor would trip
+  -- over rather than argue with.
+  it("has no forward beside it", function()
+    assert.same(
+      {},
+      vim.tbl_filter(function(name)
+        return name:find("Forward", 1, true) ~= nil
+      end, vim.fn.getcompletion("CodeReview", "cmdline"))
+    )
+  end)
+end)
+
+--- A trail that empties while it is being walked --------------------------------------------
+
+-- Last, because it deletes checkouts the blocks above need.
+--
+-- The parent spec says skipping always terminates because the checkout Neovim started in is
+-- never switched away from and stays reachable. The first half is true and the second does
+-- not follow: that checkout is an ordinary entry, pushed because it was left, with nothing
+-- keeping its directory alive. Skipping terminates because the trail is finite and every
+-- skip consumes an entry -- so the bottom of it is reachable, and what happens there has to
+-- be said rather than left as a press that does nothing.
+describe("going back with nothing left on the trail that still exists", function()
+  local msgs, restore
+
+  it("is standing in the checkout Neovim started in, with two live checkouts behind it", function()
+    assert.same(A, current().root)
+    assert.same({ B, THIRD, MAIN, A }, offered_order())
+  end)
+
+  it("names both of them once they are gone, and says there is nowhere left to go", function()
+    vim.fn.delete(B, "rf")
+    vim.fn.delete(THIRD, "rf")
+    msgs, restore = h.capture_notify()
+    codereview.back()
+    restore()
+    assert.is_true(h.notified(msgs, B), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, THIRD), vim.inspect(msgs))
+    assert.is_true(h.notified(msgs, "No checkout to go back to"), vim.inspect(msgs))
+  end)
+
+  it("leaves the reviewer where they were rather than moving them nowhere", function()
+    assert.same(A, current().root)
+  end)
+end)


### PR DESCRIPTION
A **switch** is not a one-way trip. `:CodeReviewBack` returns to the **checkout** the
reviewer came from, and that checkout is the first entry the picker offers — so going back is
the gesture they already have rather than a second one to learn, and going forward again is
the same single keystroke. That is why there is no forward.

Closes #176. Parent spec #171.

## The trail

Module-level, never written to disk. It is navigation history, not review state: persisting
it would resurrect a path through checkouts that may no longer exist. It has no glossary term
and no surface of its own, deliberately — a reviewer never handles it, which is the same
argument that declined a term for the checkout Neovim started in. What they see of it is the
picker's order.

Both doors go through one `enter(path)`, eleven lines, and four of its rulings are not what
the criteria on the issue asked for. Each was raised before any code was written and each has
a case that names it.

**Only a successful open is a journey.** `view.open` declines an empty scope, an unresolvable
one and a failed diff, and it declines each of them *before* it closes anything — the review
the reviewer was reading is still on screen, which `switch_spec` already pins. A push made on
the switch rather than on the open therefore records a departure that never happened, and the
checkout it records is the one they are standing in. The picker would then offer the row
marked `(current)` first and going back would go nowhere — two of this feature's rules broken
by a keystroke whose only message was `No changes in scope`.

**A checkout that is gone and a checkout that refuses are opposite cases.** Gone: walk over
it, name it, carry on — consuming the entry is the point. There and refusing: consume
nothing. An agent worktree whose branch has been merged has an empty branch scope, so
refusing is the *ordinary* end state rather than an exotic one, and a trail entry once spent
cannot be got back. An implementation that pops before it opens loses that checkout
permanently and says nothing about it.

**Arriving removes; leaving pushes.** The parent spec's wording — "pushing a checkout removes
any earlier occurrence of it first" — holds each checkout once and still leaves the checkout
the reviewer is *standing in* on the trail, ranked above one they have never opened. Removing
the checkout being arrived at is what makes the trail "where I have been" rather than "where
I have been, plus here". It also makes a duplicate push impossible without a second rule: a
checkout can only be pushed by being left, and can only be left after being entered, which
removed it.

**Reopening the checkout the review is already on leaves the trail alone.** The picker offers
that row on purpose and reopening it is a supported gesture; it is not a journey.

## The stated reason for termination was wrong

The parent spec said skipping always terminates because the checkout Neovim started in is
never switched away from and stays reachable. The first half is true — the global working
directory never moves, and three cases in `switch_spec` say so. The second does not follow:
that checkout reaches the trail by being *left*, like any other entry, and its directory can
be deleted like any other. ADR-0008 is about exactly that directory going away.

**Termination is on the trail being finite and every skip taking one entry off it.** That
makes the bottom of the trail reachable, so being there has to be said rather than left as a
press that does nothing — which the criteria did not cover and `trail_spec`'s last block now
does. #171 has been corrected; this is where a reader of the code will look.

## Every ruling has a mutation that reds it

Six, run one at a time on the finished implementation and reverted between each; two together
mask one another. Baseline `trail_spec` is 33 cases.

| mutation | result | distinguishing case, and what it observed |
| --- | --- | --- |
| push unconditionally, not on a true return | 28 / 5 | `a switch to a checkout that declines to open puts nothing on the trail` — offered `{agent-a, third, agent-b, main}`, expected `{third, agent-b, main, agent-a}`. The checkout being stood in is offered **first**. |
| commit the pop before the open succeeds | 29 / 4 | `keeps it on the trail, so the reviewer has not lost it` — offered `{agent-b, main, agent-a, third}`. `third` fell off the head into the never-visited remainder: gone, with no gesture that restores it. |
| push when destination equals departure | 28 / 5 | `reopening the checkout the review is already on leaves the trail exactly as it was` — offered `{agent-a, third, agent-b, main}`. Reopening where you are makes you the checkout you came from. |
| de-duplicate on push, do not remove on arrival | 22 / 11 | `offers the two it has been to, most recent first` — offered `{third, agent-b, agent-a, main}`, expected `{third, agent-b, main, agent-a}`. Head and second correct; `agent-a`, stood in, ranks above `main`, never opened. |
| skip without naming | 30 / 3 | `names the checkout it skipped` — captured notifications `{}`. Nothing said at all. |
| return silently on an empty trail | 31 / 2 | `a session after the one that switched … says so rather than going nowhere quietly` — `{}`. |

Each signature is unique, so the matrix localises a fault rather than only detecting one.

Two things the matrix showed that the criteria did not predict:

**The exhausted-trail block reds under three of the six.** Its cases assert a full picker
order and both messages, so any trail defect surviving to the end of the file moves them.
Coupling, not masking — the distinguishing case in each run is still unique — but they cannot
localise a fault alone.

**One case is a guard no mutation here violates.** `offers every checkout git lists, each
exactly once` stayed green in all six. It fails only if the ordering is written as a prepend
onto the list rather than a partition of it. It is not claimed as coverage for anything above.

## Two checkouts cannot test the ordering, and that is why the fixture has three

A trail that removes the checkout being arrived at and one that merely de-duplicates its
pushes agree at every step of an A↔B dance, head included. With three, the wrong rule ranks
the checkout you are standing in above one you have never opened. `mkcheckouts.sh` already
built three and says three is the point; this is the first slice that needs the third.

`tests/codereview/trail_spec.lua` is 33 cases, single process except for one claim. The block
order is load-bearing at both ends: the restart case is **first**, because it is about a
process that has not switched anything and every block below switches; the exhausted-trail
case is **last**, because it deletes checkouts the blocks above need — the trail holds every
checkout visited except the current one, so emptying it means deleting all of them.

`trail_child.lua` is inverted from every other child in the suite: it builds a trail so the
parent can find one **absent**. It shares the parent's state directory, so the parent looks
for a trail with that session's stores on the disk in front of it, and it asserts its own
half — that it switched and got back — so the case cannot pass by asserting that nothing came
back from nothing.

Making a checkout *refuse* rather than disappear takes `git reset --hard master`, which
empties its branch scope while leaving it listed. Without that fixture the rule that a
refusal costs the reviewer nothing has no case at all.

## Merge points

**#177 (PR #184) — the listing fallback.** It sits immediately after
`local checkouts = git.checkouts(root)`, for the case where the review's own checkout is gone
and `git worktree list` with a dead cwd returns nothing. This branch does not reimplement or
move it. The trail's ordering is a step of its own **after** the existing empty-list refusal,
about ten lines below, and I expect to meet that fallback there.

**#178 (PR #185) — the sweep hook belongs in `enter()`.** Their hook is one call at the end
of the pick callback, after `view.open`. Going back *is* a switch — CONTEXT.md's **Switch**
has no clause about which door was used — and it is the gesture most likely to meet a
checkout that has just stopped existing, since it is the only one that already tests for a
gone directory. Left where it is, back would be the one switch that never sweeps. This branch
keeps the trail's push inside `enter()` and touches nothing at the end of that callback, so
the two hunks are independent; once both land the hook moves into `enter()`, and the case to
add there is that **going back sweeps**, which reds against a hook left in the pick callback.
Recorded on #185.

**#175 (parallel, same base)** is in `state.lua`'s document and `view.lua`'s open path. This
branch touches neither.

`docs/design-notes.md` and `tests/README.md` each get a section of their own rather than
additions woven into existing paragraphs, since both files have conflicted on every merge in
this stack.

## Also here

- **No key for going back**, as #171 decided. The picker's first entry already is one.
- **"There is no forward" is not asserted as a universal negative**, which no case could do.
  What is asserted is the consequence that makes a forward gesture unnecessary: after going
  back, the checkout just left is the first entry the picker offers, so forward costs one
  keystroke. The cheap half — no `CodeReviewForward` in command completion — is there beside
  it for the contributor who would add one.
- **Skipped checkouts are named by full path, one line for however many.** The picker can
  afford a short name because it draws the branch beside it and the reviewer can see the
  list; a line about something that is gone has neither, and two worktrees under different
  parents can share a directory name. One notification per skip would make going back over
  three pruned worktrees three warnings in a row.

## Verification

`make all` — exit 0, 41 spec files, 1,884 cases, 0 failures, 0 errors. No pre-existing spec
file is touched, so no assertion anywhere else could have been loosened to get here.
