### PR TITLE
feat(state): remember the scope each checkout was last reviewed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ working directory never moves and the tab you started in keeps its own, so you c
 get back to where you started; only the review's own tab is pointed at the checkout, for
 your LSP, your diff signs and a relative `:e`.
 
+Returning also reopens the **scope** that checkout was last reviewed in — reviewed marks are
+kept per scope, so which scope opens decides which marks come back. A checkout you have
+never reviewed opens the branch review, and so does one whose remembered scope can no longer
+be shown: a revspec whose branch has gone, or a `staged` scope you have since committed. A
+restart is not a return, though — `:CodeReview` with no argument always means the branch
+review, wherever you are and whatever you last read.
+
 ### Trim a branch review
 
 A branch review can read any set of the branch's commits. Press `gc` to list them, newest

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -59,20 +59,31 @@ takes commits off the start of the branch included, works on any git.
 :CodeReviewSwitch
         Switch the review to another **checkout** of this repository -- the
         main clone, or any `git worktree` of it. Offers the checkouts git
-        itself lists, minus a bare repository and any whose directory is gone,
-        and opens the branch review in whichever you choose. Also bound to
-        `gS` in the diff and in the file tree.
+        itself lists, minus a bare repository and any whose directory is gone.
+        Also bound to `gS` in the diff and in the file tree.
+
+        Opens the **scope** that checkout was last reviewed in, so the reviewed
+        marks that come back are the ones you earned there -- they are kept per
+        scope, so which scope opens decides which marks you get. A checkout you
+        have never reviewed opens the branch review, and so does one whose
+        remembered scope cannot be shown: a revspec whose branch has since gone,
+        or a `staged` scope you have since committed. A remembered scope is a
+        default, and a default never refuses to open.
+
+        A restart is not a return. |:CodeReview| with no argument always means
+        the branch review, wherever you are and whatever you last read: only a
+        switch reopens the scope a checkout was left in.
 
         Needs no review open, which is how you open a review somewhere else in
         the first place: opening with nothing already open is simply the case
-        with nothing to close first. A checkout with nothing in its branch
-        scope says so and leaves the review you were reading exactly where it
+        with nothing to close first. A checkout with nothing in the scope it
+        opens at says so and leaves the review you were reading exactly where it
         was.
 
         Each checkout keeps its own queue, reviewed marks, trims and archive,
         and shares none of them -- so leaving one is lossless and returning
-        gives back what you left. Switching with annotations still queued is
-        therefore safe, and is not confirmed.
+        gives back what you left, in the scope you left it in. Switching with
+        annotations still queued is therefore safe, and is not confirmed.
 
         Your **global** working directory never moves and the tab you started
         in keeps its own, so you can always reach the checkout Neovim started

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -418,6 +418,64 @@ tree, and the whole batch silently degrades to absolute paths with pasted snippe
 resolves once per submit rather than per entry, and falls back to the string it was given:
 a routed agent can name a directory that does not exist on this machine at all.
 
+## The scope a checkout was last reviewed in
+
+**What is recorded is the spec that resolved the scope, and neither of the two things that
+look like it.** A progress key is `name:identity`, and an identity is a resolved sha for
+three of the five scopes, so nothing can resolve one again. A scope's own `name` is the spec
+for four of them and the literal `"revspec"` for the fifth — so a record spelled that way is
+right until a reviewer leaves a checkout on `HEAD~1`, which is one of the two cases the
+feature exists for. What a return needs is the string `git.resolve_scope` was handed, and
+both places that record it are already holding it. The pair of revspec cases in
+`last_scope_spec` is what stops the name passing: one says the return is not the default, the
+other says *which* revspec came back.
+
+**It is written when a scope is entered, because there is no leaving to hang it on.**
+`view.close` writes nothing, `state.persist` runs only from a mutation, and quitting runs
+neither. A reviewer who cycles `gs` onto another scope, reads it, marks nothing and switches
+away has still last reviewed that checkout in that scope — and a record hung on a mutation
+gives them back wherever they last happened to toggle something. That is not a hypothetical:
+it is the headline story of the ticket, and it is the only case in the spec that separates
+the two moments.
+
+**The consequence, which nothing else about opening a review ever had: an open now writes.**
+A checkout that has been reviewed and never annotated now has a document, where before it had
+none. It costs one file per checkout ever opened, and it moves the stamp the orphan sweep
+ages against — a checkout whose review was merely opened looks recently written. The sweep
+skips a checkout this session has read back anyway, so this makes it more conservative rather
+than less.
+
+**A remembered scope is a default, and a default must never turn an open into a refusal.**
+A revspec whose branch has gone stops resolving; a `staged` scope emptied by a commit resolves
+perfectly and holds nothing. Each of those hits one of `open`'s two early returns, and the
+reviewer who asked to move to a checkout is left with no review at all — where the same
+gesture, before any of this existed, always opened. Both fall back to the branch scope,
+silently, and what actually opened is what gets recorded, so a return never reopens a scope
+the reviewer was declined.
+
+**That is not the rule an empty scope is otherwise declined under, and the two look
+identical.** A switch to a checkout with nothing in its branch scope still says so and leaves
+the review where it was (`switch_spec` owns that). There the reviewer named the scope and the
+honest answer is to say so; here nobody named it in this session at all. The difference is
+where the spec came from and not what it found, which is why it is decided at the point the
+remembered spec is chosen rather than at the point the diff comes back empty. Deleting the
+fall-back reds `last_scope_spec` and leaves `switch_spec` green, which is the shape of the
+distinction.
+
+**Only a switch consults it, and a restart is therefore not a return.** `:CodeReview` with
+no argument still means the branch review. Reading the memory on every argument-less open is
+one rule instead of two and was rejected: the front door's answer would drift with whatever
+was read through it days ago, and a reviewer who looked at `HEAD~1` once would get it every
+morning until they said `branch` out loud. It is held by a test rather than by this
+paragraph — consulting the memory with no checkout named reds `trim_float_spec`, where a
+review opened on `HEAD~1` is followed by argument-less opens whose `gc` then has no branch
+review to list.
+
+**A trim needs nothing here, and the reason is worth keeping.** A branch review's identity is
+the merge base and does not move when a **trim** moves the pre-image, so a remembered
+`"branch"` reads the same marks back under every trim — including one applied while the
+reviewer was in another checkout.
+
 ## The queue and its checkout
 
 **One id counter for every checkout, and seeding it per checkout is not the same thing.**

--- a/lua/codereview/state.lua
+++ b/lua/codereview/state.lua
@@ -624,6 +624,59 @@ function M.persist_queue(root)
   M.save(root, data)
 end
 
+--- The scope a checkout was last reviewed in --------------------------------------
+
+---The **scope** a review was last opened at in a **checkout**, as the spec that resolved it.
+---
+---**The spec, and not the scope's own name, and not the key its reviewed marks are filed
+---under.** A key is `name:identity`, and an identity is a resolved sha for three of the five
+---scopes, so nothing can ever resolve one again. A name is the spec for four of them and the
+---literal `"revspec"` for the fifth, which resolves to nothing at all -- so a record spelled
+---that way is right until a reviewer leaves a checkout on `HEAD~1`, which is one of the two
+---cases this exists for. What a return needs is the string `git.resolve_scope` was given,
+---and both of the places that record it are already holding it.
+---
+---Beside the reviewed marks it decides, in the same document, rather than in a store of its
+---own: it is one string about one checkout, it is written by whatever wrote those marks, and
+---a document swept for a checkout that has gone takes it with it.
+---
+---An absent key is a checkout no review has ever been opened in, and it reads as the
+---default. A document written before this key existed is exactly that case, which is the
+---whole of what it takes to read one -- the same way the **archive** and the **trims**
+---arrived, and for the reason recorded there: a `VERSION` bump would throw away every
+---reviewed mark in the file to add a key those files simply lack.
+---@param root string
+---@return string|nil spec nil for a checkout nothing has been reviewed in
+function M.last_scope(root)
+  return M.load(root).last_scope
+end
+
+---Record the scope a review has just opened at.
+---
+---**Written when a scope is entered, and never when one is left**, because there is no
+---leaving to hang it on: `view.close` writes nothing, `persist` runs only from a mutation,
+---and quitting runs neither of them. A reviewer who cycles `gs` onto another scope, marks
+---nothing and switches away has still last reviewed this checkout in that scope, and a
+---record hung on a mutation loses precisely that reviewer.
+---
+---Merged over the stored document rather than written beside it, for the reason `persist`
+---is: everything else in there belongs to somebody. Skipped when nothing moved, because
+---`gs` is a key held down.
+---
+---**Opening a review now creates a document for a checkout that had none.** Nothing about
+---opening one ever wrote before. It costs a file per checkout ever reviewed, and it moves
+---the stamp an orphan sweep ages against -- see `docs/design-notes.md`.
+---@param root string
+---@param spec string What resolved the scope, as `git.resolve_scope` was handed it
+function M.set_last_scope(root, spec)
+  local data = M.load(root)
+  if data.last_scope == spec then
+    return
+  end
+  data.last_scope = spec
+  M.save(root, data)
+end
+
 ---Load the queue from disk when nothing has been captured in this session yet.
 ---
 ---Separate from `restore`, which needs a view and a scope to put reviewed marks back.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1274,6 +1274,10 @@ function M.set_scope(spec)
   V.reviewed = V.per_scope[key].reviewed
   V.expanded = V.per_scope[key].expanded
   require("codereview.state").restore(V, key)
+  -- Entered rather than left, which is the only moment there is: nothing runs when a review
+  -- is closed or when Neovim quits, and a reviewer who cycles here and marks nothing has
+  -- still last reviewed this checkout in this scope.
+  require("codereview.state").set_last_scope(V.root, spec)
   M.reconcile()
 
   if #files == 0 then
@@ -1813,15 +1817,53 @@ function M.open(spec, checkout)
     return false
   end
 
-  local scope, err = git.resolve_scope(spec or "branch", root)
-  if not scope then
-    warn(err or "could not resolve the review scope")
-    return false
+  local state = require("codereview.state")
+
+  -- The **scope** this checkout was last reviewed in, which is what a return to it reopens
+  -- so that the reviewed marks coming back are the ones the reviewer earned.
+  --
+  -- Only where a checkout was named and a scope was not. Naming a checkout is what a
+  -- **switch** does, and a return is a switch. `:CodeReview` with no argument is the front
+  -- door and still means the branch review: a command whose answer drifts with what was read
+  -- through it days ago is a worse trade than a restart not counting as a return.
+  local remembered = (checkout and not spec) and state.last_scope(root) or nil
+
+  ---Resolve a scope and read the diff for it, which the fall-back below does a second time.
+  ---@param name string
+  ---@return CRScope|nil, CRFile[]|nil, string|nil err
+  local function read(name)
+    local resolved, rerr = git.resolve_scope(name, root)
+    if not resolved then
+      return nil, nil, rerr or "could not resolve the review scope"
+    end
+    local drawn, derr =
+      git.collect(resolved, root, { context = cfg.context, untracked = cfg.untracked, spans = cfg.spans })
+    if not drawn then
+      return nil, nil, "git: " .. (derr or "diff failed")
+    end
+    return resolved, drawn
   end
 
-  local files, derr = git.collect(scope, root, { context = cfg.context, untracked = cfg.untracked, spans = cfg.spans })
-  if not files then
-    warn("git: " .. (derr or "diff failed"))
+  local opened_as = remembered or spec or "branch"
+  local scope, files, err = read(opened_as)
+
+  -- **A remembered scope is a default, and a default must never turn an open into a
+  -- refusal.** A revspec whose branch has gone stops resolving, and a `staged` scope emptied
+  -- by a commit resolves perfectly and holds nothing -- and each of those refuses below,
+  -- leaving a reviewer who asked to move somewhere with no review at all. What they asked
+  -- for is the checkout, so they get the review they would have got before any of this
+  -- existed.
+  --
+  -- Deliberately not the rule an empty scope is otherwise declined under. There the scope is
+  -- the one the reviewer named, and saying so is the honest answer -- a checkout with nothing
+  -- in its branch scope is still declined rather than opened. The two look alike, so this one
+  -- is decided on where the spec came from rather than on what it found.
+  if remembered and (not scope or #files == 0) then
+    opened_as = "branch"
+    scope, files, err = read(opened_as)
+  end
+  if not scope then
+    warn(err)
     return false
   end
   if #files == 0 then
@@ -1872,7 +1914,10 @@ function M.open(spec, checkout)
   }
   V.reviewed = V.per_scope[key].reviewed
   V.expanded = V.per_scope[key].expanded
-  require("codereview.state").restore(V, key)
+  state.restore(V, key)
+  -- What actually opened, which after a fall-back is not what was remembered. A return finds
+  -- the review the reviewer was last shown here, and never one they were declined.
+  state.set_last_scope(V.root, opened_as)
   M.reconcile()
 
   -- Before the windows below it: every one of them takes focus while it is being built, and

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/*_spec.lua` | The suite. Only `*_spec.lua` is collected. |
 | `codereview/state_child.lua` | Spawned by `state_spec` — deliberately not a spec. |
 | `codereview/checkout_child.lua` | Spawned by `checkout_restart_spec` to work in two **checkouts** and dispatch from each — deliberately not a spec. |
+| `codereview/last_scope_child.lua` | Spawned by `last_scope_spec` to leave a checkout reviewed at a scope of its own and exit — deliberately not a spec. |
 | `codereview/layout_child.lua` | Spawned by `layout_spec` — deliberately not a spec. |
 | `codereview/archived_child.lua` | Spawned by `render_spec` to archive a batch and turn archived entries off — deliberately not a spec. |
 | `codereview/viewless_child.lua` | Spawned by `viewless_spec` — deliberately not a spec. |
@@ -82,6 +83,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `checkout_spec` | The queue scoped to its **checkout**: two checkouts of one repository in one session — what each store receives, the queue left in the second read back rather than hidden, the return to the first, the annotation about a checkout you are not in that is filed nowhere and says so, and the loose entry whose id one counter keeps clear of |
 | `checkout_restart_spec` | The same scoping across a genuine restart: what two checkouts worked in one session left on the disk, each store holding only what it is about, and the id a new annotation takes in a checkout whose **archive** the counter has never been seeded from |
 | `switch_spec` | Moving the review to another **checkout**: the listing it is chosen from — the three checkouts of one repository, each named as its own git names it, with a bare one and a deleted one left out — the picker the plugin ships and the `pick_checkout` adapter that replaces it, a switch with a review open and with none, the directories a switch must not move, the queue and the store and the id that follow the review rather than the working directory, and what belongs to no checkout riding along into one reached by switching — asked from a tab standing in another checkout — the tab a real file opens into, `:CodeReviewSwitch` and `gS` in the diff and the tree, and the checkout with nothing in scope that is declined rather than opened |
+| `last_scope_spec` | The **scope** a **checkout** was last reviewed in, and the return that reopens it: the marks that come back being that scope's rather than the branch scope's, the revspec whose own name resolves to nothing, the scope reached with `gs` and left with nothing marked in it, the two remembered scopes that must fall back rather than refuse — one that stopped resolving and one that emptied — the document written before the key existed, the argument-less `:CodeReview` that still means the branch review, the staleness a return reports in the queue's own wording, and the scope a previous process left behind |
 | `count_spec` | The queued count a statusline asks for: which **checkout** it is about after a bare directory change, the bare note that is in the number everywhere, what a redraw costs in git processes cold and warm, the answer of "no checkout" that is deliberately not remembered so a `git init` is visible at once, the tab whose own directory was deleted underneath it, and the intersection with the **switch** — the number read from the tab the reviewer is standing in, about the checkout the review is on |
 
 ## Fixtures
@@ -139,7 +141,7 @@ interchangeable, and the assertions know which one they are looking at.
 - **`mkcheckouts.sh`** — one repository in three **checkouts** of it, and the only fixture
   whose checkouts are the point: `main` on master, plus `agent-a` and `agent-b`, each a
   linked checkout on a branch of its own. Used by `checkout_spec`,
-  `checkout_restart_spec` and `switch_spec`. Unlike the other four it
+  `checkout_restart_spec`, `switch_spec` and `last_scope_spec`. Unlike the other four it
   builds a plain directory holding the three rather than a repository at the path it is
   given, which keeps the whole fixture inside one `rm` — a checkout added beside the
   repository would be left behind — and leaves that path itself inside no repository. A
@@ -919,6 +921,16 @@ so the out-of-core language path is still checked locally without ever failing C
   from `view.lua`'s `follow_file` when `V.panel_win` is nil must red the tree-dismissed case
   in `render_spec` — it freezes on the file that was being read when the tree went away —
   and one case in `panel_spec`. That is the whole reason #103 moved the latch.
+- **A fall-back case is green before the thing it falls back from exists.** Every rule about
+  a *remembered* scope failing — one that stopped resolving, one that emptied — is satisfied
+  on a trunk with no memory at all, because opening the branch scope is what already happens.
+  `last_scope_spec`'s two fall-back blocks passed before a line of `state.lua` was written,
+  and green there said nothing whatsoever. What pins them is deleting each half of the
+  fall-back on the finished implementation: the unresolvable one must red as a **refusal**,
+  with the review still on the checkout it was leaving and `not a valid revision` on screen,
+  and the emptied one must red with `No changes in scope 'staged'` — while `switch_spec`
+  stays green, because the empty scope a reviewer *asked* for is still declined. Same shape
+  as the sweep guards in `sweep_spec`.
 - **A set comparison passes when one set was never read.** `map_spec` matches the module
   map's rows with a pattern over the table's first column, so reformatting that column —
   dropping the backticks, say — silently yields no rows, and "no row names a module that is

--- a/tests/codereview/last_scope_child.lua
+++ b/tests/codereview/last_scope_child.lua
@@ -1,0 +1,50 @@
+-- The writing half of last_scope_spec, in its own process.
+--
+-- Deliberately a separate process. "The scope is recorded in the checkout's *document*" is
+-- only meaningfully tested across a genuine restart: a module-level table keyed on the
+-- checkout passes every single-process case in that file and nothing in one session can
+-- tell the two apart, because a checkout's entries and marks never leave memory once it has
+-- been visited. A second session is the only reader that has to have got it off the disk.
+--
+-- What it leaves behind: one checkout last reviewed at the `worktree` scope, with the file
+-- in that scope marked reviewed. The mark is there so the session after this one can prove
+-- the channel between the two is live before concluding anything about the scope -- without
+-- it, "the scope did not come back" would be satisfied by there being no store at all.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned with
+-- XDG_STATE_HOME and FIXTURE in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+
+local base = assert(vim.env.FIXTURE, "FIXTURE is not set")
+local A = vim.fs.joinpath(base, "agent-a")
+vim.cmd("cd " .. vim.fn.fnameescape(A))
+
+require("codereview").setup({ syntax = false })
+
+local view = require("codereview.view")
+
+-- Named rather than defaulted, and `worktree` rather than any other: an argument-less open
+-- answers with the branch scope, so a scope a return could reach by accident would leave
+-- the next session unable to say what it was reading.
+view.open("worktree")
+local V = assert(view.current(), "no review view opened")
+assert(V.scope.name == "worktree", "the child did not open the scope it asked for")
+assert(#V.files > 0, "the worktree scope of this checkout has nothing in it")
+
+vim.api.nvim_set_current_win(V.win)
+vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[1], 0 })
+view.toggle_reviewed()
+
+-- Printed so a failing spec can show what the writing process believed it left behind.
+-- `nvim -l` sends this to stderr, not stdout.
+print(
+  ("reviewed %s in the %s scope; state file: %s"):format(
+    V.files[1].path,
+    V.scope.name,
+    require("codereview.state").path(V.root)
+  )
+)
+vim.cmd("qa!")

--- a/tests/codereview/last_scope_spec.lua
+++ b/tests/codereview/last_scope_spec.lua
@@ -1,0 +1,442 @@
+-- Returning to a **checkout** reopens the **scope** it was last reviewed in.
+--
+-- The reviewed marks a reviewer earns are kept per scope, so which scope a return opens
+-- decides which marks come back. A return that always opened the branch scope left the marks
+-- made anywhere else sitting in the document, unused and invisible.
+--
+-- What is asserted here is what a reviewer can see: which scope the review is on, which
+-- files it draws, which marks came back, what was said on the way, and -- across a genuine
+-- restart -- that the answer was on the disk rather than in this process's memory.
+--
+-- Three rules are pinned that the acceptance criteria did not carry, and each of them is a
+-- refusal this feature could introduce rather than a behaviour it adds:
+--
+--   * **What is recorded is the spec that resolved the scope, not the scope's name.** A
+--     revspec's name is the literal string "revspec", which resolves to nothing, so an
+--     implementation recording `scope.name` fails exactly the case the ticket names.
+--   * **A remembered scope is a default, and a default must never turn an open into a
+--     refusal.** One that no longer resolves, and one that resolves to nothing, both fall
+--     back to the branch scope rather than leaving the reviewer with no review at all.
+--     That is a different rule from the one `switch_spec` pins, where a checkout whose
+--     *branch* scope is empty is declined rather than opened: there the reviewer asked for
+--     that scope, here nobody did.
+--   * **A return is a switch, and not every open.** `:CodeReview` with no argument still
+--     means the branch review, because the front door's meaning must not drift across
+--     sessions.
+--
+-- Single process, except for the last block. Leaving a checkout and coming back is one
+-- session moving between checkouts; what needs a genuine restart is that the scope reached
+-- the document, and that has a child of its own.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+
+-- Three checkouts of one repository. Realpathed once: `git rev-parse --show-toplevel`
+-- answers resolved, and on macOS a temporary directory is a symlink into /private.
+local base = assert(vim.uv.fs_realpath(h.fixture("mkcheckouts")))
+local A = vim.fs.joinpath(base, "agent-a")
+local B = vim.fs.joinpath(base, "agent-b")
+
+local codereview = require("codereview")
+local git = require("codereview.git")
+local queue = require("codereview.queue")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+-- The checkout the reviewer is standing in. Nothing below moves it until the last block,
+-- which reaches a second repository entirely.
+vim.cmd("cd " .. vim.fn.fnameescape(A))
+
+---Run git somewhere, for the histories this file builds on top of the shared fixture.
+---@param cwd string
+---@param args string[]
+local function git_at(cwd, args)
+  local res = vim.system(vim.list_extend({ "git" }, args), { cwd = cwd, text = true }):wait(60000)
+  assert(res.code == 0, table.concat(args, " ") .. ": " .. (res.stderr or ""))
+end
+
+---@return CRView
+local function current()
+  return assert(view.current(), "no review view open")
+end
+
+---The files the review is drawing, in the order it drew them.
+---@return string[]
+local function drawn()
+  return vim.tbl_map(function(f)
+    return f.path
+  end, current().files)
+end
+
+---The paths marked reviewed in the scope the review is on.
+---@return string[]
+local function marked()
+  local paths = vim.tbl_keys(current().reviewed)
+  table.sort(paths)
+  return paths
+end
+
+---Mark a file reviewed in the open view, in whichever scope it is on.
+---@param path string
+local function mark_reviewed(path)
+  local V = current()
+  local index = assert(h.file_index(V, path), path .. " is not in this scope")
+  vim.api.nvim_set_current_win(V.win)
+  vim.api.nvim_win_set_cursor(V.win, { V.render.file_rows[index], 0 })
+  view.toggle_reviewed()
+end
+
+--- The switch, through the adapter -----------------------------------------------
+
+-- Stubbed exactly as `switch_spec` stubs it, and for the same reason: the **switch** is the
+-- public entry point every case here drives through, and the adapter is the seam that makes
+-- it answerable without a picker. No test-only door is opened anywhere below.
+local note, chosen = "unset", nil
+codereview.setup({
+  syntax = false,
+  compose = function(_, on_accept)
+    on_accept(nil, note)
+  end,
+  pick_checkout = function(_, cb)
+    cb(chosen)
+  end,
+})
+
+---Switch the review to a checkout, through the public entry point.
+---@param path string
+local function switch_to(path)
+  chosen = path
+  codereview.switch()
+end
+
+--- A checkout no review has ever been opened in ----------------------------------
+
+-- The floor this whole feature stands on: with nothing recorded there is nothing to reopen,
+-- and the answer is the one every review has always opened with.
+describe("a switch to a checkout nothing has ever been reviewed in", function()
+  -- Read before the switch, because the switch is what creates the document.
+  local had_store = vim.fn.filereadable(state.path(B))
+
+  switch_to(B)
+
+  it("really is a checkout with nothing stored, so the case is not vacuous", function()
+    assert.same(0, had_store)
+  end)
+
+  it("opens at the default scope", function()
+    assert.same("branch", current().scope.name)
+  end)
+end)
+
+--- Leaving a checkout in a scope, and coming back to it ---------------------------
+
+-- The headline. The marks belong to the scope and not to the checkout, so a return that
+-- opens the wrong scope hands back the wrong marks -- or, as here, none at all.
+describe("a return to a checkout left in a scope of its own", function()
+  switch_to(A)
+
+  -- A mark in the scope the checkout is *not* left in, so "the marks that came back" cannot
+  -- be satisfied by handing back whatever the document holds.
+  mark_reviewed("src/main.lua")
+  local at_branch = marked()
+
+  view.set_scope("worktree")
+  mark_reviewed("src/config.lua")
+  local at_worktree = marked()
+
+  it("really is two scopes with different marks and different diffs", function()
+    assert.same({ "src/main.lua" }, at_branch)
+    assert.same({ "src/config.lua" }, at_worktree)
+    assert.same({ "src/config.lua" }, drawn())
+  end)
+
+  switch_to(B)
+
+  it("leaves for a checkout that is genuinely somewhere else", function()
+    assert.same(B, current().root)
+    assert.same("branch", current().scope.name)
+  end)
+
+  switch_to(A)
+
+  it("reopens the scope that checkout was last reviewed in", function()
+    assert.same(A, current().root)
+    assert.same("worktree", current().scope.name)
+  end)
+
+  -- Without this, "the review is on that scope" is satisfied by a name on a field. The two
+  -- scopes of this checkout draw different files, and only one of them is what was read.
+  it("draws that scope's diff and not the default's", function()
+    assert.same({ "src/config.lua" }, drawn())
+  end)
+
+  it("gives back the marks that belong to that scope", function()
+    assert.same({ "src/config.lua" }, marked())
+  end)
+end)
+
+--- A scope whose name is not a spec ----------------------------------------------
+
+-- The case the naive implementation fails. Every named scope is its own spec, so recording
+-- `scope.name` is right for four scopes out of five and resolves to nothing for the fifth --
+-- and a reviewer who left a checkout on a revspec is exactly who the ticket describes.
+describe("a return to a checkout left on a revspec", function()
+  view.set_scope("HEAD~1")
+
+  it("really is a scope whose own name resolves to nothing", function()
+    assert.same("revspec", current().scope.name)
+    local resolved = git.resolve_scope(current().scope.name, A)
+    assert.is_nil(resolved)
+  end)
+
+  switch_to(B)
+  switch_to(A)
+
+  it("comes back on the revspec, and not on the default", function()
+    assert.same("revspec", current().scope.name)
+  end)
+
+  -- Which revspec, and not merely that one was resolved: the label is the only thing on the
+  -- view that names the spec the reviewer typed.
+  it("comes back on the revspec it was left on", function()
+    assert.same("vs HEAD~1", current().scope.label)
+  end)
+end)
+
+--- The door the memory is behind -------------------------------------------------
+
+-- A **return** is a switch. `:CodeReview` with no argument is the front door and it still
+-- means the branch review: a command whose meaning drifts across sessions is a worse trade
+-- than a restart not being a return.
+describe("an argument-less open in a checkout that remembers a scope", function()
+  codereview.open()
+
+  it("opens the branch review, not the scope the checkout was left in", function()
+    assert.same(A, current().root)
+    assert.same("branch", current().scope.name)
+  end)
+
+  switch_to(B)
+  switch_to(A)
+
+  it("records what it opened, so a return then finds that", function()
+    assert.same("branch", current().scope.name)
+  end)
+end)
+
+--- A remembered scope that no longer resolves -------------------------------------
+
+-- A revspec is resolved against the repository as it stands, and a branch can go while the
+-- reviewer is away. Implemented as the criteria are written, the return warns and opens
+-- nothing at all -- where the same gesture, before this feature existed, always opened.
+describe("a return to a checkout left on a scope that no longer resolves", function()
+  git_at(A, { "branch", "scratch", "HEAD~1" })
+  view.set_scope("scratch")
+
+  it("really is a review on that scope, with something in it", function()
+    assert.same("revspec", current().scope.name)
+    assert.is_true(#current().files > 0)
+  end)
+
+  switch_to(B)
+  git_at(A, { "branch", "-D", "scratch" })
+
+  local msgs, restore = h.capture_notify()
+  switch_to(A)
+  restore()
+
+  it("opens the review all the same", function()
+    assert.same(A, current().root)
+  end)
+
+  it("opens it at the default", function()
+    assert.same("branch", current().scope.name)
+    assert.same({ "src/config.lua", "src/main.lua" }, vim.fn.sort(drawn()))
+  end)
+
+  -- A default that fell back is not an error a reviewer did anything about. What they would
+  -- see is a branch review, which is what they would have seen before this feature existed.
+  it("says nothing about the scope it could not resolve", function()
+    assert.is_false(h.notified(msgs, "not a valid revision"), vim.inspect(msgs))
+  end)
+end)
+
+--- A remembered scope that resolves and is empty -----------------------------------
+
+-- The same refusal through the other door. A reviewer who left a checkout on `staged` and
+-- then committed the index comes back to a scope that resolves perfectly and holds nothing,
+-- and an open with nothing in scope declines.
+--
+-- Not the rule `switch_spec` pins on a checkout whose branch scope is empty. There the
+-- scope is the one the reviewer asked for and the honest answer is to say so; here nobody
+-- asked for it in this session at all.
+describe("a return to a checkout left on a scope that has since emptied", function()
+  git_at(B, { "add", "src/config.lua" })
+  switch_to(B)
+  view.set_scope("staged")
+
+  it("really is a review on that scope, with something in it", function()
+    assert.same("staged", current().scope.name)
+    assert.same({ "src/config.lua" }, drawn())
+  end)
+
+  switch_to(A)
+  git_at(B, { "reset", "-q" })
+
+  it("really has emptied that scope while the reviewer was away", function()
+    assert.same({}, h.git_lines(B, { "diff", "--cached", "--name-only" }))
+  end)
+
+  local msgs, restore = h.capture_notify()
+  switch_to(B)
+  restore()
+
+  it("opens the review at the default rather than declining to move", function()
+    assert.same(B, current().root)
+    assert.same("branch", current().scope.name)
+  end)
+
+  it("does not report an empty scope nobody asked for", function()
+    assert.is_false(h.notified(msgs, "No changes in scope"), vim.inspect(msgs))
+  end)
+end)
+
+--- A document written before any of this ------------------------------------------
+
+-- Every reviewer already has one. It carries reviewed marks and a queue and no record of a
+-- scope, and it has to go on opening -- at the default, with everything else in it intact.
+describe("a return to a checkout whose document predates the recorded scope", function()
+  mark_reviewed("src/main.lua")
+
+  -- The document as an earlier version of the plugin left it: whatever is in there now,
+  -- minus the one key this ticket adds.
+  local doc = state.load(B)
+  doc.last_scope = nil
+  state.save(B, doc)
+
+  it("really is a document with marks in it and no scope recorded", function()
+    local written = state.load(B)
+    assert.is_nil(written.last_scope)
+    assert.is_truthy(next(written.scopes), "nothing was stored to come back")
+  end)
+
+  switch_to(A)
+  switch_to(B)
+
+  it("still opens", function()
+    assert.same(B, current().root)
+  end)
+
+  it("opens at the default", function()
+    assert.same("branch", current().scope.name)
+  end)
+
+  -- Without this, "it still opens" is satisfied by a document that was discarded on the way
+  -- past. What predates the key has to be read, not merely survived.
+  it("gives back what that document already held", function()
+    assert.same({ "src/main.lua" }, marked())
+  end)
+end)
+
+--- What a return reports ------------------------------------------------------------
+
+-- Returning to a checkout is the widest staleness window there is: nothing was watching the
+-- files while the reviewer was somewhere else. It is reported in the wording the queue
+-- already has, by the reconciliation every read-back goes through, and it adds no sentence
+-- of its own.
+describe("a return holding an annotation whose file moved while the reviewer was away", function()
+  switch_to(A)
+
+  -- Captured from an ordinary buffer, in a tab of its own so the review window keeps the
+  -- diff it is drawing. A capture-path entry is judged against the file on disk at any
+  -- scope, which is the comparison this window is about.
+  note = "about a file that is about to move"
+  vim.cmd("tabnew " .. vim.fn.fnameescape(vim.fs.joinpath(A, "src/config.lua")))
+  codereview.annotate("bug")
+  vim.cmd("tabclose")
+
+  it("really has one annotation queued for that checkout", function()
+    assert.same(1, #queue.all())
+    assert.same("about a file that is about to move", queue.all()[1].note)
+  end)
+
+  switch_to(B)
+  vim.fn.writefile({ 'return { port = 9090, agent = "agent-a" }' }, vim.fs.joinpath(A, "src/config.lua"))
+
+  local msgs, restore = h.capture_notify()
+  switch_to(A)
+  restore()
+
+  it("reports it in the queue's own wording", function()
+    assert.is_true(h.notified(msgs, queue.stale_phrase(1)), vim.inspect(msgs))
+  end)
+
+  it("says it once, and adds no sentence of its own", function()
+    local said = 0
+    for _, m in ipairs(msgs) do
+      if type(m) == "string" and m:find("stale", 1, true) then
+        said = said + 1
+      end
+    end
+    assert.same(1, said, vim.inspect(msgs))
+  end)
+end)
+
+--- Across a genuine restart ---------------------------------------------------------
+
+-- The claim no single-process case can make. Every case above is green against an
+-- implementation that keeps the answer in a module-level table, because a checkout's state
+-- never leaves memory once this session has visited it. A second session is the only reader
+-- that has to have got it off the disk.
+describe("a checkout last reviewed by the session before this one", function()
+  -- A repository of its own: this process has opened a review in both checkouts of the
+  -- shared fixture, and its own record would be what a return found there.
+  local second = assert(vim.uv.fs_realpath(h.fixture("mkcheckouts")))
+  local A2 = vim.fs.joinpath(second, "agent-a")
+
+  -- The child shares this process's throwaway XDG_STATE_HOME and nothing else. It runs with
+  -- `--clean` so no user config, and no minimal_init, can hand it a different one.
+  local cmd = {
+    vim.v.progpath,
+    "--clean",
+    "-l",
+    vim.fs.joinpath(h.root, "tests", "codereview", "last_scope_child.lua"),
+  }
+  local proc = vim.system(cmd, {
+    cwd = second,
+    text = true,
+    env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = second },
+  })
+  local child = proc:wait(60000)
+
+  it("exits cleanly", function()
+    assert.same(0, child.code, (child.stderr or "") .. (child.stdout or ""))
+  end)
+
+  -- Without this the case below is vacuous: "the scope did not come back" would be satisfied
+  -- by there being no channel between the two sessions at all.
+  it("leaves a store behind, so the two sessions really do share one", function()
+    assert.same(1, vim.fn.filereadable(state.path(A2)), "no state at " .. state.path(A2) .. (child.stderr or ""))
+  end)
+
+  -- Reached with no review open and from the checkout itself, so the listing this switch is
+  -- offered is that repository's rather than the shared fixture's.
+  codereview.close()
+  vim.cmd("cd " .. vim.fn.fnameescape(A2))
+  switch_to(A2)
+
+  it("reopens the scope that session was reviewing", function()
+    assert.same(A2, current().root)
+    assert.same("worktree", current().scope.name)
+  end)
+
+  it("draws that scope's diff", function()
+    assert.same({ "src/config.lua" }, drawn())
+  end)
+
+  -- The whole point of reopening it: the marks earned in that scope are the ones that come
+  -- back, and they were earned in another process.
+  it("gives back the marks that session earned in it", function()
+    assert.same({ "src/config.lua" }, marked())
+  end)
+end)

--- a/tests/codereview/last_scope_spec.lua
+++ b/tests/codereview/last_scope_spec.lua
@@ -175,6 +175,38 @@ describe("a return to a checkout left in a scope of its own", function()
   end)
 end)
 
+--- A scope nothing was marked in --------------------------------------------------
+
+-- The headline story of the ticket, and the case that says *when* the record is written. A
+-- reviewer holds `gs` down, lands somewhere, reads it and switches away having marked
+-- nothing at all -- and that is still the scope this checkout was last reviewed in.
+--
+-- Nothing runs when a review is closed and nothing runs when Neovim quits, so a record
+-- hung on a mutation is a record this reviewer never makes: what they would come back to is
+-- wherever they last happened to toggle something.
+describe("a scope reached with `gs` and left with nothing marked in it", function()
+  vim.api.nvim_set_current_win(current().win)
+  -- Through the key, and three presses, because the cycle from here passes through the
+  -- branch scope -- which is the default, and would be reached by a return that remembered
+  -- nothing at all -- and through the staged scope, which is empty in this checkout.
+  h.feed("gs")
+  h.feed("gs")
+  h.feed("gs")
+
+  it("really is a scope this reviewer only looked at", function()
+    assert.same("unstaged", current().scope.name)
+    assert.is_true(#current().files > 0)
+    assert.same({}, marked())
+  end)
+
+  switch_to(B)
+  switch_to(A)
+
+  it("is the scope the return opens", function()
+    assert.same("unstaged", current().scope.name)
+  end)
+end)
+
 --- A scope whose name is not a spec ----------------------------------------------
 
 -- The case the naive implementation fails. Every named scope is its own spec, so recording


### PR DESCRIPTION
Returning to a **checkout** reopens the **scope** it was last reviewed in, so the reviewed
marks that come back are the ones the reviewer earned rather than a default's. Marks are kept
per scope, so which scope opens decides which marks you get — a return that always opened the
branch scope left everything earned anywhere else in the document, unread.

Closes #175. Parent spec #171.

## What lands

One document key, `last_scope`, beside the `scopes` it decides, and an accessor pair in the
shape `trim`/`set_trim` already has. `VERSION` is not bumped and `state.load` is not touched:
an absent scalar needs no defaulting, which is the whole of what it takes to read a document
written before this existed. A switch consults it; `view.open`'s scope-resolution step reads
it, falls back where it must, and records what actually opened.

## Three rules the acceptance criteria did not carry

**What is recorded is the spec that resolved the scope, and neither of the two things that
look like it.** A progress key is `name:identity` and an identity is a resolved sha for three
of the five scopes, so nothing can resolve one again. A scope's own `name` is the spec for
four of them and the literal `"revspec"` for the fifth, which resolves to nothing — so the
obvious implementation is right until a reviewer leaves a checkout on `HEAD~1`, which is one
of the two cases the ticket's own problem statement names.

**A remembered scope is a default, and a default must never turn an open into a refusal.** A
revspec whose branch has gone stops resolving; a `staged` scope emptied by a commit resolves
perfectly and holds nothing. Each hits one of `open`'s early returns, and the reviewer who
asked to move to a checkout is left with no review at all — where the same gesture, before
any of this existed, always opened. Both fall back to the branch scope, silently.

This is deliberately **not** the rule an empty scope is otherwise declined under. A switch to
a checkout with nothing in its branch scope still says so and leaves the review where it was
(`switch_spec` owns that): there the reviewer named the scope and the honest answer is to say
so, here nobody named it in this session. The difference is where the spec came from and not
what it found, so it is decided where the remembered spec is chosen rather than where the
diff comes back empty.

**It is written when a scope is entered, because there is no leaving to hang it on.**
`view.close` writes nothing, `state.persist` runs only from a mutation, and quitting runs
neither. A reviewer who cycles `gs` onto another scope, reads it, marks nothing and switches
away has still last reviewed that checkout in that scope — and a record hung on a mutation
gives them back wherever they last happened to toggle something.

## Every rule has a case that names it

Each mutation applied alone on the finished implementation and reverted before the next; two
together mask each other.

| mutation | result | case that reds, and what it said |
| --- | --- | --- |
| unresolvable remembered scope reaches `open` unguarded | 30 pass / 4 fail | `opens the review all the same` — got `…/1-mkcheckouts/agent-b`, expected `…/agent-a`; `says nothing about the scope it could not resolve` — got `true`, notified `{ "not a valid revision: scratch" }` |
| emptied remembered scope reaches `open` unguarded | 30 / 4, and **`switch_spec` 40 / 0** | `opens the review at the default rather than declining to move` — got `…/agent-a`, expected `…/agent-b`; `does not report an empty scope nobody asked for` — got `true`, notified `{ "No changes in scope 'staged'" }` |
| record `scope.name` instead of the spec | 32 / 2 | `comes back on the revspec, and not on the default` — got `'branch'`, expected `'revspec'`; `comes back on the revspec it was left on` — got `'branch vs master'`, expected `'vs HEAD~1'` |
| record from a mutation instead of at scope entry | 29 / 5 | `a scope reached with gs and left with nothing marked in it is the scope the return opens` — got `'worktree'`, the scope of the last toggle, expected `'unstaged'` |
| consult the memory on an argument-less open too | `trim_float_spec` 173 / 2 fail / 2 err | `the default branch moving under an open review` and `a float too narrow for the rows to fit whole` both error with `gc opened no window of its own`; `draws a row for every one of them` — got `63`, expected `65` |

Three things the matrix showed that the criteria did not predict:

**The first mutation reds as a refusal, which is the defect** — the review is still on the
checkout the reviewer was leaving, with `not a valid revision: scratch` on screen. Its
companion case `opens it at the default` does **not** red, because the stale review left
behind is also a branch review drawing the same two file names. The root assertion is what
catches this; a case asserting the scope name alone would have let the mutation live.

**The second leaves `switch_spec` at 40 / 0.** The two rules look identical and are now
separated by evidence rather than by prose.

**Both fall-back cases were green before a line of `state.lua` was written**, because with no
memory at all everything already falls back to the branch scope. Green there said nothing
whatsoever, which is why each half is pinned by deleting it rather than by the run. Same shape
as the sweep guards in #178, and it is recorded in `tests/README.md`.

## An open now writes a state document

Nothing about opening a review ever wrote before. A checkout that has been reviewed and never
annotated now has a document — one file per checkout ever opened.

**This meets #178, and the stamp is the seam.** That sweep ages against a stamp rewritten on
every save, and it landed saying its window is *seven days without a write* — with "only a
mutation saves, opening a review does not" as the reason. This slice makes that reason
untrue. **The sentence in `docs/design-notes.md` is corrected here, as part of the merge**:
the window is *seven days without a write or an open*. The direction is conservative — it
makes a document harder to sweep, never easier, and that sweep already skips any checkout the
session has read back — but the window is what a reviewer is promised, so it has to say what
it is. This slice's own section points at that correction rather than restating it.

## A restart is not a return

Only a switch consults the memory. `:CodeReview` with no argument still means the branch
review, wherever you are and whatever you last read. Reading the memory on every argument-less
open is one rule instead of two and was rejected: the front door's answer would drift with
whatever was read through it days ago, and a reviewer who looked at `HEAD~1` once would get it
every morning until they said `branch` out loud. The last row of the matrix is that rejection
held by a test — `trim_float_spec` opens `HEAD~1` and then opens argument-less three times,
and `gc` has no branch review to list.

The asymmetry is real, so it is documented where a reviewer meets it: `:CodeReviewSwitch`'s
own help in `doc/codereview.txt`, and the README section beside it — not only in the design
notes.

## Merged with master, which now holds #176, #177 and #178

`tests/README.md` conflicted three times — the child row, the spec row and the fixture's user
list — all squash artifacts where neither side had seen the other's rows. Both sets are kept,
and the `mkcheckouts` list now names every spec that builds it, `trail_spec` included, which
it did not.

`docs/design-notes.md` merged clean: this slice's section sits at line 420, before "The queue
and its checkout", and #178's sweep section at 500.

**`view.lua` merged clean and was read rather than trusted, because both changes had to
survive.** #177 resolves the review's checkout through `current_checkout` — which is what
stops a deleted checkout stranding a reopen — and this decides which scope is read for that
checkout, immediately below it. They are independent, and the module they both reach for is
now required once instead of twice. One consequence worth naming: #177 made `set_scope` refuse
outright in a checkout that is gone, and that refusal comes before the scope is recorded,
which is right — a checkout nothing can be read from was not reviewed in that scope.

#176's go-back calls `view.open` with a checkout and no spec, so it inherits the return
behaviour with no change of its own. `trail_spec` is green, unmodified.

**Every mutation was re-run on the merged tree**, since #177 changed the open path this
depends on: identical results, including the last row — reading (a) still reds
`trim_float_spec` with the same two errors at the same two blocks.

## Verification

`make all` on the merged tree: exit 0, 44 spec files, 1,985 cases, 0 failures, 0 errors. `last_scope_spec` is 34
cases, single process apart from one child, and builds two `mkcheckouts` fixtures — the second
because this process reviews in both checkouts of the first, so its own record would be what a
return found there. No existing spec is modified.
