### PR TITLE
perf(git): fetch whole-file content in one batch per pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,8 +895,10 @@ chose. Both last for the session and no longer.
 
 ```sh
 make deps    # clone plenary into .tests/
-make test    # the suite: one Neovim per spec file, ~5s
+make all     # lint and the whole suite, ~5s. Run this before every commit
+make test    # the suite alone: one Neovim per spec file
 make lint    # stylua --check
+make perf    # the timing report. Never part of `make test`
 ```
 
 Tests are plenary/busted specs under `tests/codereview/`, and each one builds its own
@@ -906,6 +908,14 @@ Markdown and those parsers ship with Neovim.
 
 See [`tests/README.md`](tests/README.md) for the layout, what is deliberately not covered,
 and the traps worth knowing before you change a fixture.
+
+`make perf` is a report you read, not a gate: it opens a review on three generated
+repositories — 60 files, 300 files, and 300 files of two changed lines each — and prints what
+opening, scrolling, a keystroke and a repaint cost on each. Only the 60-file open is
+budgeted, because wall-clock numbers belong to the machine that produced them. The third tier
+is a different *shape* rather than a smaller size: it is the one where a file is twenty rows
+instead of three hundred, so a screenful holds a dozen files, which is the only place work
+done per file can be told apart from work done for every file in view at once.
 
 ## Contributing
 

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -177,6 +177,60 @@ files and `git cat-file --batch-check` for everything behind a ref. One process 
 was, measurably, more expensive than all the treesitter work combined — on a 60-file diff
 it was over half the open time.
 
+**Whole-file content is fetched for everything one pass brings into view, in one
+`cat-file --batch`.** The syntax pass needs the file behind a diff, and it needs it only as
+that file comes near the window, so the fetch cannot be hoisted to open the way the blob
+hashing is. What it can be is *widened*: `apply` decides which files are due before it paints
+any of them, and the sides all of those need go out together. Measured on 300 files with two
+changed lines each — the shape of a wide change, and the one `mkbig` grew a fourth argument
+to build — opening the review fetched seventeen sides in one process instead of seventeen,
+and reading it through cost seventy-one processes instead of two hundred and eighty-three.
+Wall clock: open 316 ms → 198 ms, read-through 2.0 s → 0.9 s.
+
+**The same change does nothing on a review of tall diffs, and that is not a bug in it.** A
+file whose diff is three hundred rows is the only file near the window, so the batch holds
+one spec and buys one process’s worth of nothing — measured, and a batch of one is not
+slower than the `git show` it replaced. This is why `perf.lua` has a third tier: on the two
+deep tiers the `file content` line reads the same whether content is fetched per file or for
+all of them at once, so a regression that put the work back would be invisible there.
+
+**`cat-file` runs no textconv filter and has no option to**, so a path with one attached
+cannot be answered out of the batch — it would come back as exactly the bytes the filter
+exists to hide. Such paths are left out and fetched by `git show --textconv` as before. The
+rule is per path rather than per repository because one `*.png diff=exif` line in
+`.gitattributes` should not cost a repository the batch for its source files. Finding them
+starts from config, not from attributes: `textconv` is a config key (`diff.<driver>.textconv`)
+while the driver is attached by `.gitattributes`, so a repository configuring none can have
+no such path — which is nearly every repository, and it is what lets the common case skip
+`check-attr` entirely. Both answers are memoised per checkout, because this is the scroll
+path and a process per pass to learn "no filters here" costs more than the batch saves.
+
+**The batch is a pre-warm, not a substitution, and that is what bounds its failure mode.**
+Three kinds of side are simply absent from its answer — a working-tree side, a textconv
+path, and anything a batch that died never reached — and the caller fetches those one at a
+time exactly as it always did. So a batch that dies costs a pass its head start, not its
+content: with every batch stubbed to return nothing, a 300-file review renders a
+byte-identical set of syntax extmarks, from 300 single-file processes. That is what answers
+the objection the change was raised with, that one process failing would take every file’s
+content with it.
+
+**Absent and `false` are different answers and the caller must keep them apart.** `false` is
+git saying there is no blob on that side — an added or deleted file, or a rename read at its
+post-image name — which is a real answer the single-file fetch spells `nil`; asking again
+would buy the same nothing for a whole process. Absent is the batch not having covered the
+side at all. Collapsing the two costs a process per added file per review, which is most of
+what the batch was for on a change that adds a lot of files.
+
+**The batch reads bytes, never text.** `vim.system`’s `text = true` replaces CRLF with LF,
+and every `cat-file --batch` record declares its length in *bytes* with the next record
+starting right after them — so that flag shortens a body mid-stream and hands every
+following file the wrong content. Silently: the output still parses, and the highlighting is
+still well-formed, on the wrong code. The translation is done per body afterwards instead,
+where it cannot move a boundary, which is also what keeps the answer identical to the one
+`git show` gives through `run`. For the same reason a record header it cannot measure stops
+the walk rather than guessing a length — everything after it is left absent and fetched the
+old way.
+
 **Progress is written on mutation, not on paint.** `paint` also runs on window resize, and
 persisting there turns dragging a split into a stream of file writes.
 
@@ -705,7 +759,8 @@ checkout" for what a counter per checkout costs.
 temptation is a marker — a scope that says "the archive" and is special-cased downstream —
 and it fails in three places at once: the diff parser is handed `git diff <before>`, the
 blob hashing resolves `<before>:<path>` through `cat-file`, and the syntax highlighter
-fetches whole-file content with `git show <before>:<path>`. Every one of them needs
+fetches whole-file content for the same spec — through `cat-file` too, and through
+`git show <before>:<path>` for a path a batch cannot take. Every one of them needs
 `before` to be something git can resolve, which is why the archive stores a commit object
 rather than a set of blobs, and why resolution reads that sha and returns an ordinary
 scope. If a new scope ever appears to need a case in the render or the view, it is not

--- a/lua/codereview/git.lua
+++ b/lua/codereview/git.lua
@@ -857,7 +857,24 @@ local function read_worktree(root, path)
   return content
 end
 
+---The `<ref>:<path>` spelling git reads a blob by.
+---
+---One function rather than the same concatenation at every call site, because two of them
+---now have to agree exactly: the batch keys what it fetched by this string, and the caller
+---looks its answer up by it. A second spelling anywhere is a lookup that silently misses
+---and quietly pays for a process per file again.
+---@param ref string Ref for one side; ":0" is the index, and needs no case of its own --
+---                  the index's `:0:<path>` is what this concatenation already produces
+---@param path string Relative to root
+---@return string
+function M.spec(ref, path)
+  return ref .. ":" .. path
+end
+
 ---Whole-file content on one side of the diff, for syntax highlighting.
+---
+---One process per call. `file_contents` answers many at once and is what the render path
+---uses; this stays the single-file answer, and the fallback for a path a batch cannot take.
 ---@param path string Relative to root
 ---@param ref string|nil nil = working tree, ":0" = index, otherwise a commit-ish
 ---@param root string
@@ -866,12 +883,232 @@ function M.file_content(path, ref, root)
   if ref == nil then
     return read_worktree(root, path)
   end
-  local spec = ref == ":0" and (":0:" .. path) or (ref .. ":" .. path)
   -- Exit 128 is the normal answer for "this path does not exist at that ref" (an added or
   -- deleted file), not a failure worth reporting.
-  local out = run({ "show", "--textconv", spec }, { cwd = root, timeout = DIFF_TIMEOUT_MS })
+  local out = run({ "show", "--textconv", M.spec(ref, path) }, { cwd = root, timeout = DIFF_TIMEOUT_MS })
   return out
 end
+
+--- Batched file content ---------------------------------------------------------
+
+---Which diff drivers this repository gives a `textconv`, remembered per checkout.
+---
+---`cat-file` does not run textconv filters and has no option to, so a path whose content
+---only becomes readable through one cannot come out of a batch. Finding those paths starts
+---here because the filter is a *config* key (`diff.<driver>.textconv`) while the driver is
+---attached to paths by `.gitattributes` -- so a repository that configures no textconv at
+---all can have no textconv path, which is very nearly every repository, and that single
+---answer is what lets the batch skip asking about paths entirely.
+---
+---Remembered rather than asked per pass: this is on the scroll path, where a process per
+---pass to learn "no filters here" would cost more than the batch saves. The price is that
+---editing the config mid-session does not take effect until the next one, which is the same
+---bargain `roots` already makes.
+local textconv_drivers = {}
+
+---@param root string
+---@return table<string, true>|nil Driver names; empty when the repository configures none,
+---        and nil when the question could not be answered at all
+local function drivers_with_textconv(root)
+  local hit = textconv_drivers[root]
+  if hit then
+    return hit
+  end
+  local out = {}
+  -- ERE, not a Lua pattern -- git reads this one. `--get-regexp` searches every config
+  -- level, so a filter set in the user's global config counts exactly as a repository's
+  -- own does; exit 1 is its answer for "nothing matched", not a failure.
+  local res = run({ "config", "--get-regexp", "^diff\\..*\\.textconv$" }, { cwd = root, ok_codes = { 0, 1 } })
+  -- nil rather than the empty table, and nothing memoised: a read that failed is not the
+  -- same answer as a repository with no filters, and recording it as one is how a textconv
+  -- path ends up in a batch and comes back as the bytes the filter exists to hide -- for the
+  -- rest of the session, since the wrong answer would be the memoised one.
+  if not res then
+    return nil
+  end
+  for _, ln in ipairs(vim.split(res, "\n", { trimempty = true })) do
+    -- `key value`, and a driver name may itself contain dots, so the name is what lies
+    -- between the two fixed ends of the key rather than the second dotted field.
+    local name = (ln:match("^(%S+)") or ""):match("^diff%.(.+)%.textconv$")
+    if name then
+      out[name] = true
+    end
+  end
+  textconv_drivers[root] = out
+  return out
+end
+
+---Diff attributes already looked up, keyed by root and then by path.
+---
+---Only ever consulted in a repository that configures a textconv, and a path's attribute
+---is as fixed within a session as the config behind it, so the same bargain applies.
+local path_drivers = {}
+
+---Which of `paths` git would run a textconv filter over.
+---@param paths string[]
+---@param root string
+---@return table<string, true>
+local function textconv_paths(paths, root)
+  local out = {}
+  local drivers = drivers_with_textconv(root)
+  if not drivers then
+    -- Unanswerable, so every path stays out of the batch and is fetched the old way. That
+    -- is slow, which is the right way for this to fail.
+    for _, p in ipairs(paths) do
+      out[p] = true
+    end
+    return out
+  end
+  if vim.tbl_isempty(drivers) then
+    return out
+  end
+
+  local known = path_drivers[root]
+  if not known then
+    known = {}
+    path_drivers[root] = known
+  end
+  local ask = {}
+  for _, p in ipairs(paths) do
+    if known[p] == nil then
+      ask[#ask + 1] = p
+    end
+  end
+
+  if #ask > 0 then
+    -- `-z` rather than the readable format: the default prints `<path>: diff: <value>`,
+    -- which a path containing `: ` splits wrongly. With `-z` the input is NUL-separated too.
+    local ok, res = pcall(function()
+      return vim
+        .system({ "git", "check-attr", "diff", "-z", "--stdin" }, {
+          cwd = root,
+          stdin = table.concat(ask, "\0") .. "\0",
+        })
+        :wait(DIFF_TIMEOUT_MS)
+    end)
+    -- A failure leaves nothing memoised, so the next pass asks again rather than deciding
+    -- from an answer it never got. Every path stays out of the batch until it does.
+    if ok and res.code == 0 then
+      -- Triples: path, attribute, value.
+      local fields = vim.split(res.stdout or "", "\0", { plain = true })
+      for i = 1, #fields - 2, 3 do
+        known[fields[i]] = drivers[fields[i + 2]] or false
+      end
+    end
+  end
+
+  for _, p in ipairs(paths) do
+    -- `false` is the only answer that lets a path into the batch. nil is "we could not find
+    -- out", which in a repository that configures filters is not a licence to guess: an
+    -- unanswered path stays out until `check-attr` has answered for it.
+    if known[p] ~= false then
+      out[p] = true
+    end
+  end
+  return out
+end
+
+---Whole-file content for many sides of a diff, in one process.
+---
+---`git cat-file --batch` takes `<ref>:<path>` specs on stdin and answers them all from one
+---invocation, which is the same shape the blob hashing beside it already uses. It exists
+---because the syntax pass fetches content as files come near the window, and a scroll that
+---brings a screenful of small files into view otherwise pays a process for every one.
+---
+---**This is a pre-warm, not a substitution.** Three kinds of side are simply absent from the
+---answer -- a working-tree side, a path a textconv filter applies to, and anything a batch
+---that failed never reached -- and the caller fetches those the single-file way. That is
+---what keeps the failure mode no worse than one process per file: a batch that dies costs a
+---pass its head start, not its content.
+---
+---@param items { path: string, ref: string|nil }[] A nil ref is the working tree, which no
+---                                                 batch can answer; it is skipped here
+---@param root string
+---@return table<string, string|false> Keyed by `M.spec`. `false` means git answered "no such
+---        blob" -- an added or deleted file -- and is a real answer, not a gap. Absent means
+---        the batch did not cover it, and the caller must ask the old way.
+function M.file_contents(items, root)
+  local out = {}
+
+  -- Deduplicated: a modified file is two sides of one path, and the textconv question is
+  -- about the path.
+  local paths, asked = {}, {}
+  for _, it in ipairs(items) do
+    if it.ref and not asked[it.path] then
+      asked[it.path] = true
+      paths[#paths + 1] = it.path
+    end
+  end
+  if #paths == 0 then
+    return out
+  end
+  local skip = textconv_paths(paths, root)
+
+  local specs, seen = {}, {}
+  for _, it in ipairs(items) do
+    if it.ref and not skip[it.path] then
+      local spec = M.spec(it.ref, it.path)
+      if not seen[spec] then
+        seen[spec] = true
+        specs[#specs + 1] = spec
+      end
+    end
+  end
+  if #specs == 0 then
+    return out
+  end
+
+  -- Deliberately not `text = true`. Every record declares its length in *bytes* and the
+  -- next record starts right after them, so the CRLF translation that flag performs would
+  -- shorten a body mid-stream and hand every following file the wrong content. The
+  -- translation is done below instead, on each body, where it cannot move a boundary.
+  local ok, res = pcall(function()
+    return vim
+      .system({ "git", "cat-file", "--batch" }, {
+        cwd = root,
+        stdin = table.concat(specs, "\n") .. "\n",
+      })
+      :wait(DIFF_TIMEOUT_MS)
+  end)
+  if not ok or res.code ~= 0 then
+    return out
+  end
+
+  -- `<sha> SP <type> SP <size> LF <contents> LF` per spec, in the order they were asked,
+  -- or `<spec> SP missing LF` for a path that does not exist at that ref.
+  local data = res.stdout or ""
+  local pos = 1
+  for _, spec in ipairs(specs) do
+    local eol = data:find("\n", pos, true)
+    if not eol then
+      break
+    end
+    local header = data:sub(pos, eol - 1)
+    local kind, size = header:match("^%x+ (%S+) (%d+)$")
+    if kind then
+      size = tonumber(size)
+      if kind == "blob" then
+        -- Parenthesised: gsub answers with a count as well, and a bare call would return it
+        -- as the table's second value.
+        out[spec] = (data:sub(eol + 1, eol + size):gsub("\r\n", "\n"))
+      end
+      pos = eol + 1 + size + 1
+    elseif header:find(" missing$") or header:find(" ambiguous$") then
+      out[spec] = false
+      pos = eol + 1
+    else
+      -- A header shape we cannot measure is a stream we can no longer walk, and guessing
+      -- its length would hand some later file another file's content -- highlighting on the
+      -- wrong code, which is worse than none. Everything from here is left absent, and the
+      -- caller fetches it one at a time.
+      break
+    end
+  end
+
+  return out
+end
+
+--- Blob hashes ------------------------------------------------------------------
 
 ---Content hash of one side of a file -- the invalidation key for reviewed marks and
 ---queued annotations. A file whose blob still matches is a file you really did review.
@@ -883,8 +1120,7 @@ function M.blob(path, ref, root)
   if ref == nil then
     return line({ "hash-object", "--", path }, root)
   end
-  local spec = ref == ":0" and (":0:" .. path) or (ref .. ":" .. path)
-  return line({ "rev-parse", "--quiet", "--verify", spec }, root)
+  return line({ "rev-parse", "--quiet", "--verify", M.spec(ref, path) }, root)
 end
 
 ---Hash many working-tree files in one process.
@@ -1006,7 +1242,7 @@ function M.collect(scope, root, opts)
     if ref == nil then
       worktree_paths[#worktree_paths + 1] = file.path
     else
-      ref_specs[#ref_specs + 1] = (ref == ":0" and ":0:" or (ref .. ":")) .. file.path
+      ref_specs[#ref_specs + 1] = M.spec(ref, file.path)
     end
   end
 
@@ -1018,7 +1254,7 @@ function M.collect(scope, root, opts)
     if ref == nil then
       file.blob = from_worktree[file.path]
     else
-      file.blob = from_refs[(ref == ":0" and ":0:" or (ref .. ":")) .. file.path]
+      file.blob = from_refs[M.spec(ref, file.path)]
     end
   end
 

--- a/lua/codereview/syntax.lua
+++ b/lua/codereview/syntax.lua
@@ -150,6 +150,37 @@ local function harvest(content, lang, wanted)
   return walked and out or false
 end
 
+---Where a side's captures are memoised on the view.
+---@param file CRFile
+---@param side "before"|"after"
+---@return string
+local function cache_key(file, side)
+  return file.path .. "|" .. side
+end
+
+---The spec a side would be fetched by, or nil when it would not be fetched at all.
+---
+---Asked before anything is painted, so that every side coming into view this pass can be
+---fetched in one process. It must answer exactly what `apply_side` decides for itself a
+---moment later: a side missing from the batch costs the process the batch was for, and a
+---side in it that nothing reads is a blob fetched for nothing.
+---@param view CRView
+---@param file CRFile
+---@param side "before"|"after"
+---@param map table<integer, { row: integer, col: integer }>
+---@param ref string|nil
+---@return string|nil
+local function fetch_spec(view, file, side, map, ref)
+  -- A nil ref is the working tree, which is read from disk and costs no process at all.
+  if ref == nil or vim.tbl_isempty(map) then
+    return nil
+  end
+  if view.syntax_cache[cache_key(file, side)] ~= nil then
+    return nil
+  end
+  return git.spec(ref, file.path)
+end
+
 ---@param view CRView
 ---@param ns integer
 ---@param buf integer Buffer the rows in `map` are rows of
@@ -159,17 +190,29 @@ end
 ---@param ref string|nil
 ---@param lang string
 ---@param group_of (fun(group: string): string)|nil What the caller wants a token drawn in
-local function apply_side(view, ns, buf, file, side, map, ref, lang, group_of)
+---@param fetched table<string, string|false> What the pass already fetched in one process
+local function apply_side(view, ns, buf, file, side, map, ref, lang, group_of, fetched)
   if vim.tbl_isempty(map) then
     return
   end
 
   local cfg = config.get()
-  local key = file.path .. "|" .. side
+  local key = cache_key(file, side)
   local caps = view.syntax_cache[key]
 
   if caps == nil then
-    local content = git.file_content(file.path, ref, view.root)
+    -- Three answers, not two. A string is the content. `false` is git saying there is no
+    -- blob on this side -- an added or deleted file -- and asking again buys the same
+    -- nothing for a whole process. nil is a side the batch did not cover: a working-tree
+    -- side, a textconv path, or a batch that failed, all of which the single-file fetch is
+    -- still here for.
+    local hit = ref and fetched[git.spec(ref, file.path)]
+    local content
+    if hit == nil then
+      content = git.file_content(file.path, ref, view.root)
+    elseif hit then
+      content = hit
+    end
     -- `false` is the memo for "do not try this file again": a missing side (added or
     -- deleted file), an oversized file, or a parse that failed.
     if not content or #content > cfg.max_syntax_bytes or git.looks_binary(content) then
@@ -315,6 +358,11 @@ function M.apply(view, ns, group_for)
   local lo, hi = M.viewport(view)
   local split = view.before_render ~= nil
 
+  -- Which files come into view this pass, decided before any of them is painted. The two
+  -- halves used to be one loop, and the split is what lets every side one scroll brings
+  -- into view be fetched together: one file at a time, each one's content was a `git show`
+  -- of its own, so a jump onto a screenful of small files paid a process for every one.
+  local due, wanted = {}, {}
   for fi, maps in pairs(view.syntax_rows) do
     local file = view.files[fi]
     -- A file is parsed whole once any part of it is near the window: parsing only the
@@ -328,17 +376,43 @@ function M.apply(view, ns, group_for)
       -- the same authority, which is the pattern ADR-0008 names.
       local lang = M.lang_for(vim.fs.joinpath(view.root, file.path))
       if lang then
-        local group_of = group_for and group_for(fi) or nil
         -- An untracked file has no committed pre-image; its "after" is the working tree.
-        local after_ref = file.status == "U" and nil or view.scope.after
-        apply_side(view, ns, view.buf, file, "after", maps.after, after_ref, lang, group_of)
-        -- Each image paints onto the pane that shows it. With one pane, that is the same
-        -- buffer twice, which is what the unified layout has always done.
-        local before_buf = split and view.before_buf or view.buf
-        apply_side(view, ns, before_buf, file, "before", maps.before, view.scope.before, lang, group_of)
+        local work = {
+          fi = fi,
+          file = file,
+          lang = lang,
+          maps = maps,
+          after = file.status == "U" and nil or view.scope.after,
+          before = view.scope.before,
+        }
+        due[#due + 1] = work
+        for _, side in ipairs({ "after", "before" }) do
+          if fetch_spec(view, file, side, maps[side], work[side]) then
+            wanted[#wanted + 1] = { path = file.path, ref = work[side] }
+          end
+        end
       end
+      -- Set here rather than after the paint, and for a file with no parser too: the
+      -- question this answers is "has this file had its chance", which a file treesitter
+      -- cannot read has had.
       view.syntax_painted[file.path] = true
     end
+  end
+  if #due == 0 then
+    return
+  end
+
+  -- Empty when there was nothing a batch could take, which costs nothing: each side then
+  -- falls through to the single-file fetch exactly as it always did.
+  local fetched = #wanted > 0 and git.file_contents(wanted, view.root) or {}
+
+  for _, work in ipairs(due) do
+    local group_of = group_for and group_for(work.fi) or nil
+    apply_side(view, ns, view.buf, work.file, "after", work.maps.after, work.after, work.lang, group_of, fetched)
+    -- Each image paints onto the pane that shows it. With one pane, that is the same
+    -- buffer twice, which is what the unified layout has always done.
+    local before_buf = split and view.before_buf or view.buf
+    apply_side(view, ns, before_buf, work.file, "before", work.maps.before, work.before, work.lang, group_of, fetched)
   end
 end
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -92,7 +92,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 
 ## Fixtures
 
-Five repositories, each rebuilt from scratch by its script. They are not
+Six repositories, each rebuilt from scratch by its script. They are not
 interchangeable, and the assertions know which one they are looking at.
 
 - **`mkfixture.sh`** — flat `src/`-only repo covering every file status at once:
@@ -162,13 +162,29 @@ interchangeable, and the assertions know which one they are looking at.
   for "a **switch** to somewhere with nothing to review", which `switch_spec` needs and
   which no other fixture offers.
 - **`mkbig.sh`** — files of a given size, half of every file rewritten. It takes counts as
-  well as a path (`mkbig.sh <path> <files> <lines>`, defaulting to 60 and 200), so a caller
-  asks for the height it needs rather than for a second script. `perf.lua` builds a 60-file,
-  12k-line repository and a 300-file, 60k-line one per run; `bounded_spec` and `faded_spec`
-  each build a 6-file one, about 1,800 rendered rows, which is the only fixture in the suite
-  taller than a window and the margin around it. Nothing built from it is committed. It costs about a
-  third of a second, which is why it is no longer kept out of `make test` — what is slow is
-  opening a review on it at the sizes the report uses, not building it.
+  well as a path (`mkbig.sh <path> <files> <lines> [changed]`, defaulting to 60 and 200), so
+  a caller asks for the height it needs rather than for a second script. `perf.lua` builds a
+  60-file, 12k-line repository and a 300-file, 60k-line one per run; `bounded_spec` and
+  `faded_spec` each build a 6-file one, about 1,800 rendered rows, which is the only fixture
+  in the suite taller than a window and the margin around it. Nothing built from it is
+  committed. It costs about a third of a second, which is why it is no longer kept out of
+  `make test` — what is slow is opening a review on it at the sizes the report uses, not
+  building it.
+
+  The fourth count is a *shape*, not a size: it rewrites that many lines per file instead of
+  half of each, so a file is twenty rendered rows rather than three hundred and a screenful
+  holds a dozen files instead of one. That is the only shape in which per-file work in the
+  render path can be told from work done for every file in view at once, which is why
+  `perf.lua`'s third tier asks for it and why its `file content` line means nothing on the
+  first two.
+- **`mktextconv.sh`** — two files and a `diff.cooked.textconv` filter attached to one of
+  them, used by `diff_spec` alone. `git cat-file` runs no textconv filter, so the batched
+  content fetch has to leave such a path out and let the single-file fetch answer it. This
+  cannot live in `mkfixture`: a textconv driver changes what `git diff` prints for every
+  path it touches, so attaching one there would stop that fixture's binary file reading as
+  binary, and the cases that prove binary handling would pass with binary handling deleted.
+  Both kinds of path are in this one repository, which is the only shape where "left out of
+  the batch" can be told from "batched nothing at all".
 
 The sources are Lua and Markdown rather than TypeScript because Neovim core ships both
 parsers **and** their `highlights` queries. `syntax_spec` therefore exercises the real

--- a/tests/codereview/diff_spec.lua
+++ b/tests/codereview/diff_spec.lua
@@ -211,7 +211,82 @@ describe("reading file content and blobs", function()
   it("returns nil for a path that does not exist at that ref", function()
     assert.is_nil(git.file_content("src/fresh.lua", scope.before, root))
   end)
+end)
 
+-- One process for every side the render path is about to parse. The claim is not that this
+-- is faster -- timing lives in `perf.lua` -- but that it answers *the same thing* the
+-- single-file fetch does, for every kind of side a review contains, because the render path
+-- prefers it and falls back to the other one.
+describe("reading many files in one batch", function()
+  it("answers every side with what the single-file fetch answers", function()
+    local items = {}
+    -- A modification, a rename -- whose post-image name has no pre-image blob under that
+    -- name at all -- and the file with no trailing newline, which is what catches a reader
+    -- that ends a record where a line ends rather than where its declared length does.
+    for _, path in ipairs({ "src/main.lua", "src/newname.lua", "src/nonl.md" }) do
+      items[#items + 1] = { path = path, ref = scope.before }
+    end
+    local batched = git.file_contents(items, root)
+    for _, it in ipairs(items) do
+      local spec = git.spec(it.ref, it.path)
+      local got = batched[spec]
+      assert.is_not_nil(got, spec .. " was left uncovered by the batch")
+      -- `false` is the batch's spelling of the nil the single-file fetch answers with. The
+      -- two are the same answer; only the batch can afford to say it, which is the point.
+      assert.same(git.file_content(it.path, it.ref, root), got or nil, spec)
+    end
+  end)
+
+  -- `false`, not absent. Absent means "the batch did not cover this", which sends the
+  -- caller back to a process per file; a side git has already said does not exist has been
+  -- covered, and asking again buys the same nothing.
+  it("answers false for a path that does not exist at that ref", function()
+    local spec = git.spec(scope.before, "src/fresh.lua")
+    assert.same(false, git.file_contents({ { path = "src/fresh.lua", ref = scope.before } }, root)[spec])
+  end)
+
+  it("leaves a working-tree side out: no ref, no blob to batch", function()
+    assert.same({}, git.file_contents({ { path = "src/main.lua", ref = nil } }, root))
+  end)
+
+  it("takes the index as a ref like any other", function()
+    local staged = assert(git.resolve_scope("staged", root))
+    local spec = git.spec(staged.after, "src/routes.lua")
+    local batched = git.file_contents({ { path = "src/routes.lua", ref = staged.after } }, root)
+    assert.same(git.file_content("src/routes.lua", staged.after, root), batched[spec])
+  end)
+
+  -- The one case that cannot be answered from a batch at all: `cat-file` runs no textconv
+  -- filter, so a path with one attached would come back as the raw bytes the filter exists
+  -- to hide. It is left out instead, and its neighbour in the same repository is not --
+  -- which is what says the rule is about the path rather than about the repository.
+  describe("a repository with a textconv filter", function()
+    local tc = h.fixture("mktextconv")
+    local tc_scope = assert(git.resolve_scope("branch", tc))
+    local batched = git.file_contents({
+      { path = "src/filtered.bin", ref = tc_scope.before },
+      { path = "src/plain.lua", ref = tc_scope.before },
+    }, tc)
+
+    it("leaves the filtered path out of the batch entirely", function()
+      assert.is_nil(batched[git.spec(tc_scope.before, "src/filtered.bin")])
+    end)
+
+    -- Absent, so the caller fetches it the old way -- and that is what still runs the
+    -- filter. Without this the exclusion would be indistinguishable from dropping the file.
+    it("still reads the filtered path through the single-file fetch", function()
+      -- Filtered, and the blob behind it says RAW: what a batch would have answered with is
+      -- exactly what the filter is configured to hide.
+      assert.same("COOKED one\nCOOKED two\n", git.file_content("src/filtered.bin", tc_scope.before, tc))
+    end)
+
+    it("still batches every other path in that repository", function()
+      assert.same('local plain = "old"\n', batched[git.spec(tc_scope.before, "src/plain.lua")])
+    end)
+  end)
+end)
+
+describe("blobs", function()
   it("hashes every file to a blob", function()
     assert.is_truthy((by["src/main.lua"].blob or ""):match("^%x%x%x%x%x%x%x+$"))
   end)

--- a/tests/codereview/syntax_spec.lua
+++ b/tests/codereview/syntax_spec.lua
@@ -48,8 +48,32 @@ end)
 require("codereview").setup({})
 local view = require("codereview.view")
 
+-- What the open below costs in git invocations, counted through the two functions that make
+-- them. Snapshotted the moment the review is open, because later cases in this file clear
+-- the memo and repaint, and the claim is about one pass.
+local git = require("codereview.git")
+local fetch = { batches = 0, sides = 0, single = 0 }
+do
+  local one, many = git.file_content, git.file_contents
+  git.file_contents = function(items, ...)
+    fetch.batches, fetch.sides = fetch.batches + 1, fetch.sides + #items
+    return many(items, ...)
+  end
+  git.file_content = function(path, ref, ...)
+    -- A nil ref is read off the disk and spawns nothing, so it is not what this counts.
+    if ref then
+      fetch.single = fetch.single + 1
+    end
+    return one(path, ref, ...)
+  end
+end
+
+---@type { batches: integer, sides: integer, single: integer }
+local opened
+
 describe("replaying captures onto the diff", function()
   view.open("branch")
+  opened = vim.deepcopy(fetch)
   local V = view.current()
   local marks = h.syntax_marks(V)
 
@@ -119,6 +143,16 @@ end)
 
 describe("caching and laziness", function()
   local V = view.current()
+
+  -- The reason `apply` decides what is due before it paints any of it. Fetched one file at
+  -- a time, a review costs a git process per file that comes near the window -- which on a
+  -- wide change is a process per file in it. The count is what says the work has not moved
+  -- back: it stays at one however many files the pass brings into view.
+  it("fetches every side one pass needs in a single git call", function()
+    assert.is_true(opened.sides > 1, "the open had nothing to batch, so this proves nothing")
+    assert.same(1, opened.batches)
+    assert.same(0, opened.single)
+  end)
 
   it("memoises captures per file and side", function()
     assert.is_true(vim.tbl_count(V.syntax_cache) > 0)

--- a/tests/fixtures/mkbig.sh
+++ b/tests/fixtures/mkbig.sh
@@ -12,14 +12,23 @@
 # change from, and `bounded_spec` asks for 6 -- the smallest that renders a diff taller
 # than a window and the margin around it, which is the only size at which a bounded paint
 # can be told from an unbounded one.
+#
+# The fourth argument rewrites only that many lines per file instead of half of it, which
+# is a different shape rather than a smaller one. Half-rewritten files are each about 300
+# rendered rows, so only ever one of them is near the window at a time -- and anything that
+# costs a review per *file* in view is then invisible, however large it is. Two changed
+# lines is twenty rows a file, which puts a screenful of files in view at once, and that is
+# the only shape in which per-file work can be told from work done for all of them together.
 set -e
 # Hermetic: no user or system git config. Without this the fixture inherits things that
 # change what it is (commit.gpgsign, diff.renames, core.autocrlf, hooks) -- gpg signing in
 # particular fails outright on a machine with no key, which is every CI runner.
 export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
-R="${1:?usage: mkbig.sh <path> [files] [lines]}"
+R="${1:?usage: mkbig.sh <path> [files] [lines] [changed]}"
 FILES="${2:-60}"
 LINES="${3:-200}"
+# Empty means the default shape: every other line rewritten.
+CHANGED="${4:-}"
 rm -rf "$R"; mkdir -p "$R"; cd "$R"
 git init -q -b master
 git config user.email t@t.t; git config user.name T
@@ -35,10 +44,11 @@ git checkout -qb feature
 for f in $(seq 1 "$FILES"); do
   # Every other line changes, so the diff interleaves rather than collapsing into one
   # enormous hunk -- which is what the anchor map and the viewport-bounded syntax pass
-  # actually have to cope with.
-  awk -v n="$LINES" 'BEGIN {
+  # actually have to cope with. With a line budget it is the first few lines instead, so
+  # each file is one small hunk and the review is wide rather than tall.
+  awk -v n="$LINES" -v c="$CHANGED" 'BEGIN {
     for (i = 1; i <= n; i++) {
-      if (i % 2 == 0) printf "local value_%d = compute(%d, \"changed\")\n", i, i
+      if (c == "" ? i % 2 == 0 : i <= c + 0) printf "local value_%d = compute(%d, \"changed\")\n", i, i
       else printf "local value_%d = compute(%d, \"seed\")\n", i, i
     }
   }' > "src/mod_$f.lua"

--- a/tests/fixtures/mktextconv.sh
+++ b/tests/fixtures/mktextconv.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Rebuild the one fixture with a textconv filter configured.
+#
+# It is a repository of its own rather than two lines added to `mkfixture`, because a
+# textconv driver changes what `git diff` prints for every path it is attached to: the
+# binary file that fixture keeps would stop reading as binary, and the cases that prove
+# binary handling would pass with binary handling deleted. A filter fixture has to be a
+# repository only that filter can be told from.
+#
+# `git cat-file` runs no textconv filter and has no option to, so a path with one attached
+# cannot be answered out of a batch. Both kinds of path are here, in one repository, which
+# is the only shape in which "left out of the batch" can be told from "batched nothing".
+set -e
+# Hermetic: no user or system git config. Without this the fixture inherits things that
+# change what it is (commit.gpgsign, diff.renames, core.autocrlf, hooks) -- gpg signing in
+# particular fails outright on a machine with no key, which is every CI runner.
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+R="${1:?usage: mktextconv.sh <path>}"
+rm -rf "$R"; mkdir -p "$R"; cd "$R"
+git init -q -b master
+git config user.email t@t.t; git config user.name T
+
+mkdir -p src
+# `sed` and nothing else: the filter has to run on every machine this suite runs on, and
+# what it does only has to be visible, not useful.
+git config diff.cooked.textconv "sed s/RAW/COOKED/"
+printf '*.bin diff=cooked\n' > .gitattributes
+
+printf 'RAW one\nRAW two\n' > src/filtered.bin
+printf 'local plain = "old"\n' > src/plain.lua
+git add -A && git commit -qm base
+
+git checkout -qb feature
+printf 'RAW one\nRAW three\n' > src/filtered.bin
+printf 'local plain = "new"\n' > src/plain.lua
+git add -A && git commit -qm work
+
+echo "textconv fixture: $R"
+echo "  driver   : $(git config --get-regexp '^diff\..*\.textconv$')"
+echo "  filtered : $(printf 'src/filtered.bin\nsrc/plain.lua\n' | git check-attr diff --stdin | tr '\n' ';')"

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -11,7 +11,7 @@ M.root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
 ---
 ---Anything after the script name is passed to it after the path, which is how `mkbig` is
 ---asked for a diff of a particular height: it takes a file count and a line count.
----@param script "mkfixture"|"mktree"|"mkbig"|"mkcommits"|"mkcheckouts"
+---@param script "mkfixture"|"mktree"|"mkbig"|"mkcommits"|"mkcheckouts"|"mktextconv"
 ---@param ... string
 ---@return string dir
 function M.fixture(script, ...)
@@ -23,7 +23,7 @@ function M.fixture(script, ...)
 end
 
 ---Build a fixture and make it the current directory.
----@param script "mkfixture"|"mktree"|"mkbig"|"mkcommits"|"mkcheckouts"
+---@param script "mkfixture"|"mktree"|"mkbig"|"mkcommits"|"mkcheckouts"|"mktextconv"
 ---@param ... string
 ---@return string dir
 function M.cd_fixture(script, ...)

--- a/tests/perf.lua
+++ b/tests/perf.lua
@@ -7,18 +7,29 @@
 --
 -- Run with:  make perf
 --
--- Two tiers, because every cost here is linear in the size of the review and the small one
--- hides them. 60 files is the size the budget has always watched and the only tier that can
+-- Two tiers of one shape and a third of another, because neither size nor shape alone shows
+-- everything. 60 files is the size the budget has always watched and the only tier that can
 -- fail this command; at 300 files the same operations are large enough to read a change
--- from. The larger tier reports and never asserts: a second budget would be a second number
+-- from. The larger tiers report and never assert: a second budget would be a second number
 -- to tune per machine, on a file that is read rather than gated.
+--
+-- The third tier is the same 300 files with two changed lines each instead of half a file
+-- each. That is not a smaller review, it is a *wide* one: a file is twenty rows rather than
+-- three hundred, so a screenful holds a dozen files instead of one, and everything that
+-- costs a review per file in view -- which is the whole of the `file content` line -- can
+-- only be read there. On the deep tiers one file is near the window at a time, so that line
+-- reads the same whether content is fetched per file or for all of them at once.
 --
 -- The line to read first is `cursor move`. It is the body of the autocommand that fires on
 -- every CursorMoved, which a reviewer pays per row while holding `j` -- unlike open, scroll
 -- and repaint, which are paid at moments a reviewer expects to wait.
 --
--- Two things keep opening a review fast: syntax harvesting bounded by the viewport, and
--- batched blob hashing. If open regresses, suspect one of those two. The third cost is the
+-- Three things keep opening a review fast: syntax harvesting bounded by the viewport,
+-- batched blob hashing, and whole-file content fetched for everything one pass brings into
+-- view together rather than one process per file. If open regresses, suspect one of those
+-- three, and read the `file content` line for the third: it reports git *calls* beside the
+-- milliseconds, so work moved back to a process per file shows up as a count that has
+-- multiplied rather than as a number that is merely large. The last cost is the
 -- character-level spans, reported at the foot of each tier because they are paid once per
 -- git read and must never appear in the repaint line.
 local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
@@ -44,10 +55,15 @@ local MKBIG = vim.fs.joinpath(root, "tests", "fixtures", "mkbig.sh")
 ---only ever be one of the two. It costs about half a second per tier.
 ---@param files integer
 ---@param lines integer
+---@param changed integer|nil Lines rewritten per file; nil rewrites half of each
 ---@return string path
-local function build(files, lines)
-  local path = ("%s-big-%dx%d"):format(vim.fn.tempname(), files, lines)
-  local res = vim.system({ "bash", MKBIG, path, tostring(files), tostring(lines) }, { text = true }):wait(120000)
+local function build(files, lines, changed)
+  local path = ("%s-big-%dx%dx%s"):format(vim.fn.tempname(), files, lines, changed or "half")
+  local argv = { "bash", MKBIG, path, tostring(files), tostring(lines) }
+  if changed then
+    argv[#argv + 1] = tostring(changed)
+  end
+  local res = vim.system(argv, { text = true }):wait(120000)
   assert(res.code == 0, res.stderr)
   -- Through `print`, which `nvim -l` sends to stderr, rather than writing the script's own
   -- stdout: the whole report then arrives on one stream and stays in order however it is
@@ -69,6 +85,39 @@ local git = require("codereview.git")
 local diff = require("codereview.diff")
 local NS = vim.api.nvim_create_namespace("codereview")
 local PRIORITY = require("codereview.render").PRIORITY.syntax
+
+---What this tier spent inside git fetching whole-file content for the syntax pass.
+---
+---Wrapped here rather than counted in `git.lua`, which has no business carrying a counter
+---only this file reads. `blobs` is how many sides were asked for and `calls` is how many
+---invocations answered them: the two are equal when every file is fetched on its own, and
+---the gap between them is the whole point of the batch.
+local fetch = { ms = 0, blobs = 0, calls = 0 }
+do
+  local one, many = git.file_content, git.file_contents
+  ---@param items { path: string, ref: string|nil }[]
+  git.file_contents = function(items, ...)
+    fetch.calls, fetch.blobs = fetch.calls + 1, fetch.blobs + #items
+    local t0 = vim.uv.hrtime()
+    local res = many(items, ...)
+    fetch.ms = fetch.ms + (vim.uv.hrtime() - t0) / 1e6
+    return res
+  end
+  ---A nil ref is a working-tree read: no process, and nothing a batch was ever going to
+  ---take, so it is left out of both counts rather than flattering them.
+  ---@param path string
+  ---@param ref string|nil
+  git.file_content = function(path, ref, ...)
+    if ref == nil then
+      return one(path, ref, ...)
+    end
+    fetch.calls, fetch.blobs = fetch.calls + 1, fetch.blobs + 1
+    local t0 = vim.uv.hrtime()
+    local res = one(path, ref, ...)
+    fetch.ms = fetch.ms + (vim.uv.hrtime() - t0) / 1e6
+    return res
+  end
+end
 
 local function syntax_marks(buf)
   return #vim.tbl_filter(function(m)
@@ -100,14 +149,22 @@ local function cursor_moves(V)
   end)
 end
 
----Report one tier, and answer with the figures the two tiers are compared on.
+---Report one tier, and answer with the figures the tiers are compared on.
 ---@param files integer
 ---@param lines integer
 ---@param budget_ms integer|nil the ceiling this tier is judged against; nil means it only reports
----@return { open: number, move: number, repaint: number }
-local function tier(files, lines, budget_ms)
-  print(("\n=== %d files x %d lines ==="):format(files, lines))
-  vim.cmd("cd " .. vim.fn.fnameescape(build(files, lines)))
+---@param changed integer|nil Lines rewritten per file; nil rewrites half of each
+---@return { open: number, move: number, repaint: number, fetch: number }
+local function tier(files, lines, budget_ms, changed)
+  print(
+    ("\n=== %d files x %d lines, %s ==="):format(
+      files,
+      lines,
+      changed and ("%d changed"):format(changed) or "half rewritten"
+    )
+  )
+  vim.cmd("cd " .. vim.fn.fnameescape(build(files, lines, changed)))
+  fetch.ms, fetch.blobs, fetch.calls = 0, 0, 0
 
   local open_ms = ms(function()
     view.open("branch")
@@ -169,6 +226,11 @@ local function tier(files, lines, budget_ms)
       end
     end
   end
+  -- At the foot of the tier because it is a total for everything above it, and because
+  -- only open and the two scrolls can add to it: a repaint drops what it painted but keeps
+  -- the captures, and a cursor move stays inside a file already parsed. Either of those
+  -- moving this line means content is being re-fetched for files nothing needs re-read.
+  print(("file content:    %6.0f ms   (%d blobs in %d git calls)"):format(fetch.ms, fetch.blobs, fetch.calls))
   print(("parse:           %6.0f ms   (once per git read, not per repaint)"):format(plain_ms))
   print(("  spans          %6.0f ms   (+%.0f ms)"):format(spans_ms, spans_ms - plain_ms))
   print(("  lines spanned  %6d"):format(spanned))
@@ -176,11 +238,14 @@ local function tier(files, lines, budget_ms)
   -- Each tier gets its own review, on its own repository: whatever the next one measures, it
   -- must not be measuring what this one left open.
   view.close()
-  return { open = open_ms, move = moves_ms / MOVES, repaint = repaint_ms }
+  return { open = open_ms, move = moves_ms / MOVES, repaint = repaint_ms, fetch = fetch.ms }
 end
 
 local small = tier(60, 200, BUDGET_MS)
 local large = tier(300, 200, nil)
+-- Not kept: the side-by-side below is a comparison of two sizes at one shape, and this tier
+-- is the other shape. What it is here to report it reports on its own `file content` line.
+tier(300, 200, nil, 2)
 
 -- Side by side, because the point of the larger tier is the ratio: every one of these costs
 -- is linear in the size of the review, so five times the files should be about five times
@@ -192,6 +257,11 @@ print(("\n%-16s %12s %12s"):format("side by side", "60 files", "300 files"))
 print(("%-16s %9.0f ms %9.0f ms"):format("  open", small.open, large.open))
 print(("%-16s %9.1f ms %9.1f ms"):format("  cursor move", small.move, large.move))
 print(("%-16s %9.0f ms %9.0f ms"):format("  repaint", small.repaint, large.repaint))
+-- The one row here that must *not* scale with the review, and the deep tiers are where that
+-- is worth watching: content is fetched only for the files a pass brings near the window, so
+-- five times the files is the same handful of blobs. A figure that starts tracking the file
+-- count is content being fetched for files nothing is about to draw.
+print(("%-16s %9.0f ms %9.0f ms"):format("  file content", small.fetch, large.fetch))
 
 if small.open > BUDGET_MS then
   print(("\nFAIL: open took %.0f ms, over the %d ms budget"):format(small.open, BUDGET_MS))


### PR DESCRIPTION
The syntax pass reads the file behind a diff as that file comes near the window, one `git show --textconv` per side. A review of a wide change therefore paid a git process for every file in it, spread across the scrolls that brought them into view.

`syntax.apply` now decides which files are due before it paints any of them, so every side one pass brings into view goes out in a single `git cat-file --batch` — the shape the blob hashing beside it already uses.

## What the measurements said

The issue asked for this to be measured before any rule was written, and the answer turned out to depend on the *shape* of the review, not its size.

**300 files, two changed lines each** — the shape of a wide change:

| | before | after |
|---|---|---|
| open | 316 ms | **198 ms** |
| read through | 2.0 s | **0.9 s** |
| processes on open | 17 | **1** |
| processes reading through | 283 | **71** |

Before the change, 73% of the read-through was spent spawning `git show`.

**300 files, half of each rewritten** — the existing `mkbig` shape: no change, in either direction. A file whose diff is 300 rows is the only file near the window, so the batch holds one spec. Measured over 200 fetches across three rounds, a batch of one is not slower than the `git show` it replaced.

## The three decisions the issue asked for

**Textconv.** `cat-file` runs no textconv filter and has no option to, so such a path is left out of the batch and fetched the old way — not fetched raw and rendered as binary, which would degrade a working feature to speed up a highlighting nicety. The rule is per path rather than per repository: one `*.png diff=exif` line should not cost a repository the batch for its source files. It starts from config rather than attributes, because a repository that configures no textconv can have no textconv path, so the common case never runs `check-attr` at all. Both probes are memoised per checkout, and a probe that fails leaves every path out rather than being remembered as "no filters here".

**Failure mode.** The batch is a pre-warm, not a substitution. A side it does not cover — a working-tree side, a textconv path, or anything a dead batch never reached — is fetched singly, exactly as before. With every batch stubbed to return nothing, a 300-file review renders a byte-identical set of syntax extmarks from 300 single-file processes. A batch that dies costs a pass its head start, not its content.

**`make perf` reports it.** New `file content` line, per tier, with git *calls* beside the milliseconds. It needed a fixture the figure can actually move on: `mkbig.sh` takes a fourth argument for lines changed per file, and `perf.lua` has a third tier at 300 files × 2 changed lines. Verified against a simulated regression:

```
                       with the batch      work moved back
60 files, half           2 blobs /  2        2 blobs /  2
300 files, half          2 blobs /  2        2 blobs /  2
300 files, 2 changed    32 blobs /  2       32 blobs / 32
                              20 ms              163 ms
```

The two deep tiers read the same either way, which is exactly why the third one is there.

## Notes

- `git.spec(ref, path)` replaces four copies of the same `<ref>:<path>` concatenation. The batch keys what it fetched by that string and the caller looks its answer up by it, so a second spelling anywhere is a lookup that silently misses.
- The batch reads bytes, never `text = true`. Every record declares its length in bytes with the next starting right after them, so CRLF translation would shorten a body mid-stream and hand every following file the wrong content — silently, and well-formed, on the wrong code. Translation happens per body afterwards, which also keeps the answer identical to `git show`'s.
- `false` and absent are different answers: `false` is git saying there is no blob on that side, absent is the batch not having covered it. Collapsing them costs a process per added file per review.
- New fixture `mktextconv.sh`. It cannot live in `mkfixture`: a textconv driver changes what `git diff` prints for every path it touches, so attaching one there would stop that fixture's binary file reading as binary, and the cases proving binary handling would pass with binary handling deleted.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)