### PR TITLE
feat(view): fold a long line in the unified layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,8 @@ opts = {
   max_syntax_bytes = 256 * 1024,   -- skip syntax above this size
   layout = "unified",              -- "unified" or "split". Validated at setup
   spans = true,                    -- emphasize what changed inside a changed line
+  wrap = false,                    -- fold a line too wide for its window onto further rows.
+                                   -- Unified only: a split layout stays row-aligned
   archived = true,                 -- draw already-dispatched entries on the diff, dimmed,
                                    -- and tally the untouched ones on the winbar. `gA`
                                    -- overrides this for the rest of the session
@@ -730,7 +732,8 @@ opts = {
   panel = { enabled = true, width = 34, position = "left" },
   icons = { reviewed = "✓", annotated = "●", unreviewed = "○",
             collapsed = "▸", expanded = "▾", change_bar = "▌",
-            untouched = "↺" },     -- plain Unicode throughout: no Nerd Font anywhere
+            untouched = "↺", continuation = "↳" },
+                                   -- plain Unicode throughout: no Nerd Font anywhere
   types = nil,                     -- defaults to the five above. See Annotation types
 }
 ```

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -136,6 +136,28 @@ a review does not need to say it is one. That, with the words the glyphs replace
 thirty columns handed to the path — enough that a 45-column pane keeps the directory above
 the file as well as the file.
 
+**Wrap is window options, and it must not be set in the shared window helper.** That helper
+gives every review window its options — the two panes *and* the file tree — and a tree row is
+truncated to the panel width rather than folded, so a folded path would put one file on two
+rows. Wrap is applied to the after pane after a paint instead, which is also when the gutter
+width is known and what re-applies it on a resize. The options are `wrap`, `breakindent`,
+`breakindentopt` and `showbreak`, all window-local; `showbreak` is global-local and
+`vim.wo[win]` does set only the window's copy.
+
+**`breakindentopt=shift:N,sbr` is what puts the marker in the change bar's column.** A diff
+row begins with the change bar, which is not whitespace, so Neovim computes a natural indent
+of zero for every row and `breakindent` alone folds a continuation back to column zero — under
+no bar at all, which is the same failure the queue float turns `wrap` off to avoid. The
+`shift` supplies the whole gutter, and `sbr` draws `showbreak` at the *start* of that indent
+rather than in front of it, so the code goes on starting where it starts. Both measured in a
+prototype.
+
+**A `line_hl_group` background reaches every screen row a folded line occupies**, so an added
+line stays visibly added past the fold with nothing emitted for the continuation rows.
+Measured. **`virt_lines` still clip at the window edge under `wrap`**, also measured, which is
+why the renderer goes on breaking a **note** to the pane's width itself: turning wrap on does
+not make that pre-breaking redundant.
+
 **Collapsing is done at render time, not with folds.** A collapsed file's body is never
 emitted, so the buffer and the anchor map stay small on a large review, and there is one
 mechanism instead of two.

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -131,6 +131,48 @@ receiving agent ([ADR-0002](adr/0002-one-queue-one-entry-shape.md)).
 
 ---
 
+## Wrap
+
+**Unified only.** A line too wide for its window folds onto further rows rather than running
+off the right edge — in the unified layout, and never in a split one. Two **panes** hold
+different text, so they fold by different amounts, and a deletion would stop sitting on the
+row its replacement sits on. Row alignment is what the split layout exists for, so a split
+review keeps horizontal scrolling and the caveat above it.
+
+The **file tree** never folds either. Its rows are truncated to the panel width, and a folded
+path would put one file on two rows and stop the tree being a list.
+
+**It is window options and nothing else.** No row is added to the buffer, no **anchor** is
+created or moved, and no mark changes. Every count, every reviewed mark, every row an
+annotation hangs on and every navigation key are what they were, and which lines were folded
+never reaches the receiving agent
+([ADR-0002](adr/0002-one-queue-one-entry-shape.md)).
+
+**A continuation row carries a marker where the change bar would be.** Neither the bar nor
+the line number repeats there — one line has one number — and their absence is worth
+explaining rather than merely noticing. The marker rides at the start of the indent, so the
+code goes on starting in the column it starts in on an unfolded row.
+
+**The indent is a shift, and the render is what supplies it.** A diff row begins with the
+change bar, which is not whitespace, so Neovim computes a natural indent of zero for every
+row in the review. The shift supplies the whole gutter instead — the change bar, the line
+number padded to the diff's widest, the separator and the sign — which is also what makes it
+the same number for every row and therefore what makes a folded line line up under itself.
+That number is reported by `render.build` rather than worked out again by the view: the
+widest line number is computed once across every file, expanded or not, so the gutter does
+not resize when a file is expanded, and two answers about where the code starts would drift
+apart on the first review whose line numbers grew a digit.
+
+**Off by default.** The precedent is the layout's rather than the spans': a reviewer whose
+terminal is wide enough for their code has no problem to solve, and upgrading the plugin
+should not re-draw their review.
+
+**A note is unaffected.** The renderer already breaks one to the pane's width before drawing
+it, because a **virtual line** clips at the window edge instead of folding. That is still
+true with wrap on, so the pre-breaking stays correct and stays necessary.
+
+---
+
 ## Spans
 
 **Which lines pair.** The i-th deletion of a contiguous run pairs with the i-th addition of

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -28,6 +28,19 @@ M.defaults = {
   ---comparable review tool does. It lengthens opening a large review by roughly a third and
   ---a repaint by nothing at all, because the work is done once per git read.
   spans = true, ---@type boolean
+  ---Fold a line too wide for its window onto further rows -- **wrap** -- rather than making
+  ---the reviewer scroll sideways to read it. The rows are the window's and never the diff's:
+  ---nothing is added to the buffer, so every **anchor**, every row an annotation hangs on and
+  ---every count stay what they were.
+  ---
+  ---Said of the **unified** layout only. A **split** layout stays unwrapped, because two
+  ---**panes** that fold by different amounts stop being row-aligned on screen, and row
+  ---alignment is what split exists for. The **file tree** never folds either.
+  ---
+  ---Off by default, and the precedent it follows is the layout's rather than the spans': a
+  ---reviewer with a terminal wide enough for their code has no problem to solve, and
+  ---upgrading the plugin should not re-draw their review.
+  wrap = false, ---@type boolean
   ---Draw **archived** entries on the diff, dimmed, beneath the code they were about. A
   ---reviewer who keeps working while an agent does is otherwise looking at a review view
   ---with no memory of what it already sent, and reports the same finding twice. Every
@@ -120,6 +133,10 @@ M.defaults = {
     expanded = "▾",
     change_bar = "▌",
     untouched = "↺",
+    ---What a continuation row of a folded line carries where the change bar would be.
+    ---Neither the bar nor the line number repeats there, and their absence is worth
+    ---explaining rather than merely noticing.
+    continuation = "↳",
   },
 
   --- Annotations ---
@@ -289,6 +306,7 @@ function M.setup(opts)
   M.options = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults), opts or {})
   validate_layout(M.options.layout)
   validate_boolean("spans", M.options.spans)
+  validate_boolean("wrap", M.options.wrap)
   validate_boolean("archived", M.options.archived)
   validate_blend("muted", M.options.muted)
   validate_boolean("muted.enabled", M.options.muted.enabled)

--- a/lua/codereview/render.lua
+++ b/lua/codereview/render.lua
@@ -37,6 +37,7 @@ local M = {}
 ---@field marks table[]                     { row, col, opts } for nvim_buf_set_extmark
 ---@field file_rows integer[]               1-indexed header row of each file
 ---@field hunk_rows integer[]               1-indexed row of every visible hunk header
+---@field gutter integer                    Display columns before the code on a diff row
 
 local SEP = " │ "
 
@@ -108,6 +109,27 @@ local function gutter_digits(files)
     end
   end
   return #tostring(max)
+end
+
+---How many display columns a diff line row spends before its code starts.
+---
+---The change bar, the line number padded to `digits`, the separator and the sign -- the
+---prefix `line_text` below assembles, measured rather than counted: the bar and the
+---separator are both multibyte, and this answers a question about the screen.
+---
+---Reported on the render so that the view, which indents a folded line's continuation rows
+---by exactly this, reads it rather than working it out again. Two answers about where the
+---code starts would drift apart on the first review whose line numbers grew a digit.
+---
+---Measured against a *changed* row, whose prefix opens with the change bar. A context row
+---opens with a single space instead, so a host that configures a bar wider than one column
+---already draws its context code one column to the left of its changed code -- and this
+---follows the changed rows, which are what the bar column is there for.
+---@param icons table
+---@param digits integer
+---@return integer
+local function gutter_width(icons, digits)
+  return vim.fn.strdisplaywidth(icons.change_bar) + digits + vim.fn.strdisplaywidth(SEP) + 1
 end
 
 ---@param n integer
@@ -246,9 +268,10 @@ local function header_ranges(header, hunk)
   return old or ("-%d"):format(hunk.old_start), new or ("+%d"):format(hunk.new_start)
 end
 
+---@param gutter integer Display columns every diff line row spends before its code
 ---@return table
-local function new_pane()
-  return { lines = {}, anchors = {}, marks = {}, file_rows = {}, hunk_rows = {} }
+local function new_pane(gutter)
+  return { lines = {}, anchors = {}, marks = {}, file_rows = {}, hunk_rows = {}, gutter = gutter }
 end
 
 ---@class CRFileLabel
@@ -436,9 +459,10 @@ function M.build(files, opts)
   local width = math.max(40, opts.width or 80)
   local before_width = math.max(40, opts.before_width or width)
   local digits = gutter_digits(files)
+  local gutter = gutter_width(icons, digits)
 
-  local after = new_pane()
-  local before = split and new_pane() or nil
+  local after = new_pane(gutter)
+  local before = split and new_pane(gutter) or nil
 
   ---@param pane table
   ---@param row integer 1-indexed
@@ -624,6 +648,7 @@ function M.build(files, opts)
   ---@return string text, integer code_col, integer bar_len
   local function line_text(ln, number, sign)
     local bar = ln.side ~= "ctx" and icons.change_bar or " "
+    -- The prefix `gutter_width` above measures. Change one and the other is wrong.
     local prefix = bar .. rpad_num(number, digits) .. SEP .. sign
     -- Byte offset, not display width: extmark columns are byte offsets, and both the
     -- change bar and the separator are multibyte.

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -831,6 +831,12 @@ function M.paint(keep_file)
   if V.before_render then
     write_pane(V.before_buf, V.before_render)
   end
+  -- After the buffers hold their rows and before anything reads the viewport: **wrap**
+  -- decides how many buffer rows a windowful is, and the band emission below is bounded by
+  -- exactly that. Here rather than where the window was made, because the indent comes from
+  -- the render and the render is what this paint has just built -- which is also what
+  -- re-applies it after a resize, since a resize repaints.
+  view_layout.apply_wrap(V, V.render.gutter)
   -- The namespaces above were just cleared, so nothing this records still exists. Dropped
   -- here rather than in `paint_bands` for the reason `syntax_painted` is dropped by the
   -- paint: what a band means is decided by the render it was emitted from. The file those

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -268,6 +268,10 @@ end
 
 ---@param win integer
 function M.window_opts(win)
+  -- **Never set true here.** This helper is also what the **file tree**'s window goes
+  -- through, and a tree row is truncated to the panel width rather than folded: a folded
+  -- path would put one file on two rows and stop the tree being a list. Which window folds
+  -- is `apply_wrap` below, and it names one.
   vim.wo[win].wrap = false
   vim.wo[win].number = false
   vim.wo[win].relativenumber = false
@@ -282,6 +286,47 @@ function M.window_opts(win)
   vim.wo[win].list = false
   vim.wo[win].spell = false
   enroll(win)
+end
+
+---Fold the after pane's long lines, or stop folding them.
+---
+---**Window options and nothing else.** No row is added to the buffer, no **anchor** is
+---created or moved, and no mark changes -- which is what leaves every count, every reviewed
+---mark and every row an annotation hangs on exactly what it was. A reviewer who turns this
+---on is changing how they read the diff and not what the diff is.
+---
+---**The after pane only, and only in the unified layout.** The before pane is left as
+---`window_opts` made it: two panes that fold by different amounts stop being row-aligned on
+---screen, and row alignment is what the split layout exists for. Nothing has to be unwound
+---when a layout toggle rebuilds that pane, because a rebuilt pane comes back unwrapped.
+---
+---**Read on every paint rather than remembered.** Switching to split unwraps because split
+---does not fold, and switching back folds again because nothing about the choice changed --
+---so there is no "wrap was on before the split" for the two paths to disagree about.
+---
+---`gutter` is the render's own answer for how many columns a diff row spends before its
+---code, and it is what the continuation rows are shifted by. A diff row opens with the
+---change bar, which is not whitespace, so Neovim computes a natural indent of zero for
+---every one of them: the shift supplies the whole gutter, which is also what makes it the
+---same for every row in the review and therefore what makes a folded line line up under
+---itself. `sbr` puts `showbreak` at the *start* of that indent, so the marker lands in the
+---change bar's column and the code goes on starting where it starts.
+---@param V CRView
+---@param gutter integer Display columns a diff line row spends before its code
+function M.apply_wrap(V, gutter)
+  local win = V.win
+  if not vim.api.nvim_win_is_valid(win) then
+    return
+  end
+  vim.wo[win].wrap = config.get().wrap and not M.has_before(V)
+  -- Inert while `wrap` is off, so they are written unconditionally rather than unwound: one
+  -- code path, and no leftover for the next paint to disagree with.
+  vim.wo[win].breakindent = true
+  vim.wo[win].breakindentopt = ("shift:%d,sbr"):format(gutter)
+  vim.wo[win].showbreak = config.get().icons.continuation
+  -- Break on a space where there is one. A word is cut in half only when the word alone is
+  -- wider than the pane, which is the rule the renderer's own `wrap` already follows.
+  vim.wo[win].linebreak = true
 end
 
 --- Muting ---------------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,7 +53,8 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `layout_spec` | Switching layout: the anchor round trip, which pane receives the cursor, the filler fallback, centering, what a toggle leaves alone, and how long the choice lasts — including across a real restart |
 | `spans_spec` | What is emphasized inside a changed line and how it is drawn: pairing, unequal runs, suppression and character boundaries at the parser; the priority band, background-only groups, byte offsets and both panes at the render; then the switch, the repaint and the entry that must not move |
 | `syntax_spec` | Treesitter harvest/replay, caching, the row map the replay looks rows up in and everything that drops it, guardrails |
-| `bounded_spec` | Emission bounded by the viewport: what a paint writes and what it leaves out, the bound it shares with the harvest, what a scroll adds and what scrolling back does not, both panes at once — on a diff taller than the window, guarded |
+| `bounded_spec` | Emission bounded by the viewport: what a paint writes and what it leaves out, the bound it shares with the harvest, what a scroll adds and what scrolling back does not, both panes at once — on a diff taller than the window, guarded; and a wrapped window, which tightens that bound rather than loosening it |
+| `wrap_spec` | Folding a line too wide for its window: the gutter the render reports, at the pure-data seam and on a diff whose line numbers need five digits; then the screen — where a continuation row's code lands, the marker in the change bar's column, the line's own background carried onto every row it folds onto, a narrower pane folding sooner — the mark set that does not move, the entry a folded line queues, the split layout and the file tree that never fold, and the key: both directions, from the diff and from the tree, refused out loud in a split, and gone the moment the session is |
 | `repaint_spec` | When a paint runs on a resize and when it must not: either event with nothing resized, in both layouts; a pane that really changed width; one terminal resize, which fires both events, repainting once; an event that arrives before anything moved; a window resized in another tab page; and the file tree summoned and dismissed |
 | `annotate_spec` | Targeting, cross-file clamp, deleted-line rule, types, drop, grouping |
 | `payload_spec` | Grouping, `@ref` vs inline, out-of-tree fallback, staleness, submit, and the **preamble**: above the header, the empty one that renders nothing, and the same arguments rendering the same message |
@@ -478,6 +479,18 @@ so the out-of-core language path is still checked locally without ever failing C
   column 80 is drawn into cells nothing can read; and the cell has to be located with
   `screenpos`, because the change bar and the `│` separator are multibyte and a buffer
   column is not a screen column.
+- **`screenpos`, `screenstring` and `screenattr` answer in a headless Neovim, and answer
+  repeatably.** Measured, not assumed — and the difference from `nvim__inspect_cell` above is
+  what lets `wrap_spec` make every one of its screen claims in one process instead of one
+  child per reading. `screenattr` returns an opaque attribute id rather than a color, so it
+  says "these two cells are drawn the same way" and nothing more; that is enough for a
+  **wrap** claim, where the question is whether an added line's background reached the rows it
+  folded onto, and it is read against a context cell so that "the same as everything else"
+  cannot pass. The 80-column ceiling in the bullet above belongs to `nvim -l`, which attaches
+  no UI at all: under `--headless` the grid follows `columns`, and a cell at column 100 reads.
+  Two traps ride with these: a *screen* column is not a *window* column — the file tree is
+  drawn to the left of the pane, so column 1 of the screen is in the tree — and a screen row
+  is not a buffer row the moment anything folds, which is the whole point.
 - **A lit row cannot be read on a changed line.** `line_hl_group` wins over `CursorLine` —
   measured, not assumed — so every added line, every deleted line and every header prints its
   own background whether or not the cursor is on that row. A painted cell taken there says

--- a/tests/codereview/bounded_spec.lua
+++ b/tests/codereview/bounded_spec.lua
@@ -295,3 +295,56 @@ describe("the split layout", function()
     assert.is_true(seen > 0, "the before pane drew nothing on screen, so it agrees vacuously")
   end)
 end)
+
+-- **Wrap** tightens this bound rather than loosening it. A folded line occupies more than
+-- one screen row, so a windowful of the same height holds fewer *buffer* rows, and a paint
+-- therefore emits over a shorter range than the same paint unwrapped. That is a saving and
+-- not a cost -- but the bound still has to hold at the new range, and a scroll still has to
+-- add what comes into view, which is the whole claim this file exists to make.
+describe("a wrapped window", function()
+  -- Back to one pane: wrap is said of the unified layout only.
+  view.toggle_layout()
+  -- Narrow enough that a rendered row is wider than the pane. `mkbig`'s rows are about
+  -- fifty columns with the gutter in front of them, and every case above wants a window
+  -- wide enough not to fold -- so the screen is narrowed here and nowhere before.
+  vim.o.columns = 70
+  view.paint()
+  scroll_to(1)
+  local _, unwrapped = syntax.viewport(V)
+
+  require("codereview").setup({
+    wrap = true,
+    compose = function(_, on_accept, _)
+      on_accept(nil, "note about this line")
+    end,
+  })
+  view.paint()
+  scroll_to(1)
+
+  it("folds the pane's long lines", function()
+    assert.is_true(vim.wo[V.win].wrap)
+  end)
+
+  it("reaches fewer buffer rows for the same window height", function()
+    local _, wrapped = syntax.viewport(V)
+    assert.is_true(
+      wrapped < unwrapped,
+      ("a wrapped paint reaches row %d and an unwrapped one row %d"):format(wrapped, unwrapped)
+    )
+  end)
+
+  it("writes the rows near the window and stops", function()
+    complete_through(V.buf, V.render, reach())
+  end)
+
+  it("adds what a scroll brings into view", function()
+    local before = #emitted(V.buf)
+    scroll_to(#V.render.lines)
+    assert.is_true(#emitted(V.buf) > before, "scrolling to the end of a wrapped review emitted nothing")
+    local first, last = on_screen()
+    local buf_rows, render_rows = in_buffer(V.buf), in_render(V.render)
+    for row = first, last do
+      assert.same(render_rows[row], buf_rows[row], ("row %d, on screen at the end"):format(row))
+    end
+  end)
+end)

--- a/tests/codereview/wrap_spec.lua
+++ b/tests/codereview/wrap_spec.lua
@@ -1,0 +1,397 @@
+-- **Wrap**: a line too wide for its window folded onto further rows.
+--
+-- Two seams, and they answer different questions. The number the render reports is pure
+-- data -- no window and no repository -- and it is asserted there, including on a diff whose
+-- line numbers need more digits than this fixture's ever will. Everything else is a claim
+-- about the screen, and it is read off the screen: where a character lands, and what colour
+-- the cell under it took. An assertion that read `breakindentopt` back would pass with the
+-- indent pointed at the wrong number, which is the whole thing this is here to catch.
+--
+-- `screenpos`, `screenstring` and `screenattr` all answer in a headless Neovim -- measured,
+-- not assumed -- and unlike `nvim__inspect_cell` they answer more than once per process,
+-- which is what lets this file stay one process rather than the child `faded_spec` needs.
+--
+-- Syntax and both blends are off. Not because a review runs that way, but because each of
+-- them puts a second reason on the cell this file reads a colour off: the replay paints a
+-- foreground over the code, and a blend moves the background of every file but one. What is
+-- being asserted is that the *line's own* background reaches its continuation rows.
+local h = require("tests.helpers")
+
+h.ui(110, 40)
+vim.o.termguicolors = true
+local fixture = h.cd_fixture("mkfixture")
+
+-- One line far wider than any pane this spec opens, appended to a file the branch scope
+-- already carries so it arrives with context lines around it. Written here rather than into
+-- `mkfixture.sh`: nothing else in the suite wants a line this wide, and a fixture every
+-- other spec builds is not the place to put one.
+local WIDE = 'local url = "https://example.com/' .. ("segment/"):rep(40) .. 'index.html"'
+local main = vim.fs.joinpath(fixture, "src/main.lua")
+vim.fn.writefile(vim.list_extend(vim.fn.readfile(main), { WIDE }), main)
+
+require("codereview").setup({
+  syntax = false,
+  muted = { enabled = false },
+  faded = { enabled = false },
+  compose = function(_, on_accept, _)
+    on_accept(nil, "note about a folded line")
+  end,
+})
+
+local annotate = require("codereview.annotate")
+local config = require("codereview.config")
+local git = require("codereview.git")
+local queue = require("codereview.queue")
+local render = require("codereview.render")
+local view = require("codereview.view")
+
+--- Pure: no window, no repository ----------------------------------------------
+
+---One hunk of `count` added lines ending at `last`, as a file list `render.build` takes.
+---@param last integer
+---@return CRFile[]
+local function synthetic(last)
+  local lines = {}
+  for n = last - 2, last do
+    lines[#lines + 1] = { side = "add", new = n, text = "x" }
+  end
+  return {
+    {
+      path = "src/wide.lua",
+      status = "M",
+      added = #lines,
+      removed = 0,
+      binary = false,
+      hunks = { { header = "@@ -1 +1 @@", heading = "", old_start = 1, new_start = last - 2, lines = lines } },
+    },
+  }
+end
+
+---@param files CRFile[]
+---@param opts table|nil
+---@return CRRender after, CRRender|nil before
+local function build(files, opts)
+  local cfg = config.get()
+  return render.build(
+    files,
+    vim.tbl_extend("force", {
+      width = 80,
+      icons = cfg.icons,
+      expanded = {},
+      reviewed = {},
+      notes = {},
+      types = cfg.types,
+    }, opts or {})
+  )
+end
+
+describe("the gutter the render reports", function()
+  local scope = assert(git.resolve_scope("branch", fixture))
+  local files = assert(git.collect(scope, fixture, { context = 3, untracked = true }))
+
+  it("is the columns every diff line row actually spends before its code", function()
+    local rendered = build(files)
+    for row, a in pairs(rendered.anchors) do
+      if a.kind == "line" then
+        local prefix = rendered.lines[row]:sub(1, a.col)
+        assert.same(rendered.gutter, vim.fn.strdisplaywidth(prefix), ("row %d: %q"):format(row, prefix))
+      end
+    end
+  end)
+
+  it("is the same number in both panes of a split", function()
+    local after, before = build(files, { layout = "split", before_width = 80 })
+    assert.same(after.gutter, before.gutter)
+  end)
+
+  -- The bar, the line number, the separator and the sign: 1 + 1 + 3 + 1 with single-digit
+  -- line numbers, and four columns more when they reach five digits. Asserted as the two
+  -- numbers rather than as the arithmetic, so a change to the separator has to be read here.
+  it("widens for a diff whose line numbers need five digits", function()
+    assert.same(6, build(synthetic(9)).gutter)
+    assert.same(10, build(synthetic(99999)).gutter)
+  end)
+end)
+
+--- On the screen ----------------------------------------------------------------
+
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+
+-- Taken before anything has queued a note, so that the comparison further down is between
+-- two renders of the same diff rather than between one that carries an annotation and one
+-- that does not.
+local marks_unwrapped = vim.deepcopy(V.render.marks)
+
+---The row the wide line was drawn on, and its anchor.
+---@return integer row, CRAnchor anchor
+local function wide_row()
+  for row, a in pairs(V.render.anchors) do
+    if a.kind == "line" then
+      local ln = V.files[a.file].hunks[a.hunk].lines[a.line]
+      if ln.side == "add" and ln.text == WIDE then
+        return row, a
+      end
+    end
+  end
+  error("the wide line is not in the render")
+end
+
+---Put the cursor on a row and let the screen catch up.
+---@param row integer
+local function show(row)
+  vim.api.nvim_win_set_cursor(V.win, { row, 0 })
+  vim.cmd("normal! zz")
+  vim.cmd("redraw!")
+end
+
+---Where the first code column of `row` lands, where the first code column of the screen row
+---that continues it lands, and the byte the fold happened at.
+---
+---Screen coordinates, which is what `screenpos` answers in and what `screenstring` and
+---`screenattr` take. The file tree is drawn to the left of the pane, so a column here is not
+---a column of the window -- `left` below is what turns one into the other.
+---@param row integer
+---@param col integer Byte offset the code starts at
+---@return table first, table|nil continuation, integer|nil byte
+local function code_columns(row, col)
+  local first = vim.fn.screenpos(V.win, row, col + 1)
+  assert(first.row > 0, "the row under test is off screen")
+  local text = vim.api.nvim_buf_get_lines(V.buf, row - 1, row, false)[1]
+  for byte = col + 1, #text do
+    local at = vim.fn.screenpos(V.win, row, byte)
+    if at.row == first.row + 1 then
+      return first, at, byte
+    end
+  end
+  return first, nil, nil
+end
+
+---The screen column the pane's own first column is drawn in, on `row`.
+---@param row integer
+---@return integer
+local function left(row)
+  return vim.fn.screenpos(V.win, row, 1).col
+end
+
+---An entry without the two fields no two captures can share: the id a counter issues, and
+---the moment it was made.
+---@param entry CRAnnotation
+---@return table
+local function anonymous(entry)
+  local out = vim.deepcopy(entry)
+  out.id, out.at = nil, nil
+  return out
+end
+
+---What the wide line queued while it was not folding.
+---@type table
+local unfolded
+
+---A row of the same file drawn from a context line, which carries no diff background.
+---@param fi integer
+---@return integer
+local function context_row(fi)
+  for row, a in pairs(V.render.anchors) do
+    if a.kind == "line" and a.file == fi then
+      local ln = V.files[a.file].hunks[a.hunk].lines[a.line]
+      if ln.side == "ctx" then
+        return row
+      end
+    end
+  end
+  error("that file has no context line")
+end
+
+describe("with wrap off", function()
+  it("leaves the after pane unwrapped", function()
+    assert.is_false(vim.wo[V.win].wrap)
+  end)
+
+  it("leaves the file tree unwrapped", function()
+    assert.is_false(vim.wo[V.panel_win].wrap)
+  end)
+
+  it("runs the wide line off the right edge rather than folding it", function()
+    local row, a = wide_row()
+    show(row)
+    local _, continuation = code_columns(row, a.col)
+    assert.is_nil(continuation)
+  end)
+
+  -- Kept for the folded case below to be compared against. What an entry says about a line
+  -- is the whole of what reaches the receiving agent, so the claim worth making is that the
+  -- two are the same entry rather than that either one is any particular shape.
+  it("queues an entry for the wide line", function()
+    show((wide_row()))
+    queue.clear()
+    annotate.annotate("bug")
+    assert.same(1, #queue.all())
+    unfolded = anonymous(queue.all()[1])
+    queue.clear()
+  end)
+end)
+
+describe("with wrap on, in the unified layout", function()
+  require("codereview").setup({
+    wrap = true,
+    syntax = false,
+    muted = { enabled = false },
+    faded = { enabled = false },
+    compose = function(_, on_accept, _)
+      on_accept(nil, "note about a folded line")
+    end,
+  })
+  view.paint()
+
+  it("wraps the after pane", function()
+    assert.is_true(vim.wo[V.win].wrap)
+  end)
+
+  -- Dismissed and summoned again, so the window being read was *built* while wrap was on.
+  -- Reading the one the review opened with would pass on a helper that folded every window
+  -- it was handed, because that window was made before the setting was.
+  it("still leaves the file tree unwrapped, even one summoned since", function()
+    assert.is_false(vim.wo[V.panel_win].wrap)
+    view.toggle_panel()
+    view.toggle_panel()
+    assert.is_true(vim.api.nvim_win_is_valid(V.panel_win))
+    assert.is_false(vim.wo[V.panel_win].wrap)
+  end)
+
+  it("starts a continuation row's code in the column the row it continues starts in", function()
+    local row, a = wide_row()
+    show(row)
+    local first, continuation = code_columns(row, a.col)
+    assert.is_table(continuation, "the wide line did not fold")
+    assert.same(first.col, continuation.col)
+  end)
+
+  it("draws the marker where the change bar would be", function()
+    local row, a = wide_row()
+    show(row)
+    local first = vim.fn.screenpos(V.win, row, a.col + 1)
+    -- `screenstring` counts from the screen's left edge and the file tree is drawn there,
+    -- so the bar's column is asked of the row rather than assumed to be column one.
+    assert.same(config.get().icons.change_bar, vim.fn.screenstring(first.row, left(row)))
+    assert.same(config.get().icons.continuation, vim.fn.screenstring(first.row + 1, left(row)))
+  end)
+
+  it("carries the line's own background onto every row it folds onto", function()
+    local row, a = wide_row()
+    show(row)
+    local first, continuation = code_columns(row, a.col)
+    assert.is_table(continuation)
+    local added = vim.fn.screenattr(first.row, first.col)
+    assert.same(added, vim.fn.screenattr(continuation.row, continuation.col))
+    -- And it is the *added* background rather than whatever every cell here happens to
+    -- carry: a context line of the same file, read in the same column, differs.
+    local ctx = vim.fn.screenpos(V.win, context_row(a.file), a.col + 1)
+    assert.are_not.same(added, vim.fn.screenattr(ctx.row, ctx.col))
+  end)
+
+  it("changes no mark the render emits", function()
+    assert.same(marks_unwrapped, V.render.marks)
+  end)
+
+  it("queues the entry a folded line queues unfolded", function()
+    show((wide_row()))
+    queue.clear()
+    annotate.annotate("bug")
+    assert.same(1, #queue.all())
+    assert.same(unfolded, anonymous(queue.all()[1]))
+    queue.clear()
+  end)
+
+  it("moves the file and hunk keys exactly as far as they moved", function()
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    local landed = {}
+    for _, spec in ipairs({ { "file", true }, { "hunk", true }, { "hunk", false }, { "file", false } }) do
+      view.jump(spec[1], spec[2])
+      landed[#landed + 1] = vim.api.nvim_win_get_cursor(V.win)[1]
+    end
+    assert.same({ V.render.file_rows[2], V.render.hunk_rows[2], V.render.hunk_rows[1], V.render.file_rows[1] }, landed)
+  end)
+
+  -- `]a` and `[a` move between *annotations* rather than between rows of the diff, so they
+  -- need one to move to. The folded line is one of the two on purpose: a key that resolved
+  -- through the screen rather than through the anchor map would land somewhere else on it.
+  it("moves the annotation keys onto the rows the annotations are on", function()
+    queue.clear()
+    local folded = wide_row()
+    local other = assert(h.line_row(V, "src/fresh.lua"), "the fixture lost src/fresh.lua")
+    for _, row in ipairs({ math.min(folded, other), math.max(folded, other) }) do
+      show(row)
+      annotate.annotate("bug")
+    end
+    assert.same(2, #queue.all())
+
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    local landed = {}
+    for _, forward in ipairs({ true, true, false }) do
+      view.jump_annotation(forward)
+      landed[#landed + 1] = vim.api.nvim_win_get_cursor(V.win)[1]
+    end
+    local first, second = math.min(folded, other), math.max(folded, other)
+    assert.same({ first, second, first }, landed)
+    queue.clear()
+  end)
+end)
+
+describe("a narrower window", function()
+  it("re-folds the wide line and keeps the continuation indented", function()
+    local row, a = wide_row()
+    show(row)
+    local was = select(3, code_columns(row, a.col))
+    vim.api.nvim_win_set_width(V.win, vim.api.nvim_win_get_width(V.win) - 20)
+    vim.api.nvim_exec_autocmds("WinResized", {})
+    show(row)
+    local first, continuation, byte = code_columns(row, a.col)
+    assert.is_true(vim.wo[V.win].wrap)
+    assert.is_table(continuation)
+    assert.same(first.col, continuation.col)
+    assert.same(V.render.gutter, first.col - left(row))
+    -- A narrower pane holds fewer columns of the line, so it folds at an earlier byte. Left
+    -- unasserted, this whole case would pass on a window that never re-read its width.
+    assert.is_true(byte < was, ("folded at byte %d, and at %d before the resize"):format(byte, was))
+  end)
+end)
+
+describe("in the split layout", function()
+  it("leaves both panes unwrapped", function()
+    view.toggle_layout()
+    V = assert(view.current())
+    assert.is_true(config.get().wrap)
+    assert.is_false(vim.wo[V.win].wrap)
+    assert.is_false(vim.wo[V.before_win].wrap)
+  end)
+
+  it("folds again on the way back to unified", function()
+    view.toggle_layout()
+    V = assert(view.current())
+    assert.is_true(vim.wo[V.win].wrap)
+  end)
+end)
+
+describe("a diff whose line numbers need five digits", function()
+  it("indents the continuation past the wider gutter", function()
+    local narrow = V.render.gutter
+    -- A file long enough to push every line number in the review to five digits. Untracked,
+    -- so no commit is needed and the branch scope picks it up.
+    local long = {}
+    for n = 1, 10000 do
+      long[n] = ("local n%d = %d"):format(n, n)
+    end
+    vim.fn.writefile(long, vim.fs.joinpath(fixture, "src/tall.lua"))
+    view.refresh()
+    V = assert(view.current())
+
+    assert.same(narrow + 4, V.render.gutter)
+    local row, a = wide_row()
+    show(row)
+    local first, continuation = code_columns(row, a.col)
+    assert.is_table(continuation, "the wide line did not fold")
+    assert.same(first.col, continuation.col)
+    assert.same(V.render.gutter, continuation.col - left(row))
+  end)
+end)


### PR DESCRIPTION
A reviewer could not see the end of a long line. The review view turned `wrap` off in every
window it owns, so the only way to read the rest of one was to scroll sideways — which moves
every row at once, so the line being read is lost to reach the end of it, and which is not
synchronized between the two **panes** of a **split**.

**Wrap** folds such a line onto further rows instead. The rows are the window's and never the
diff's.

## What this is

**Window options and nothing else.** No row is added to the buffer, no **anchor** is created
or moved, and no mark changes — the spec asserts the mark set is identical with the option on
and off. Every count, every reviewed mark, every row an annotation hangs on and every
navigation key are what they were, and which lines were folded never reaches the receiving
agent (ADR-0002).

**The render reports its gutter.** `CRRender` gains `gutter`: the display width of the prefix
every diff line row starts with. The widest line number is already computed once across every
file, expanded or not, so the gutter does not resize when a file is expanded. The view reads
that number and never works it out a second time — two answers about where the code starts
would drift apart on the first review whose line numbers grew a digit.

**The continuation indent is a shift, not the line's own indent.** A diff row begins with the
change bar, which is not whitespace, so Neovim computes a natural indent of zero for every
row. The shift supplies the whole gutter, which is what makes it the same for every row in
the review and therefore what makes a folded line line up under itself. `sbr` draws
`showbreak` at the *start* of that indent, so the marker lands in the change bar's column and
the code goes on starting where it starts.

**Not in the shared window-options helper.** That helper is also what the **file tree**'s
window goes through, and a tree row is truncated to the panel width rather than folded — a
folded path would put one file on two rows. Wrap is applied to the after pane after a paint,
which is when the gutter width is known and what re-applies it on a resize.

**Off by default**, on the layout's precedent rather than the spans': a reviewer with a
terminal wide enough for their code has no problem to solve, and upgrading the plugin should
not re-draw their review. There is no key yet — that is #193.

## Testing

A new `wrap_spec`, no new fixture, and no existing case moved. The gutter is asserted at the
pure-data seam with no window and no repository, including on a diff whose line numbers need
five digits. Everything else is a claim about the screen and is read off the screen with
`screenpos`, `screenstring` and `screenattr` — an assertion that read `breakindentopt` back
would pass with the indent pointed at the wrong number. Those three answer repeatably under
`--headless`, unlike `nvim__inspect_cell`, so this needs no child process.

`bounded_spec` gains a wrapped case. A wrapped window shows fewer buffer rows for the same
height, so the emission bound tightens rather than loosens — that is a saving, but the bound
must still hold and a scroll must still add what comes into view.

`make perf` is unchanged in shape at both tiers with the option off and with it on.

Closes #192