### PR TITLE
feat(view): toggle wrap for the session with gw

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ to close the review.
 | `gc` | List the commits on the branch, and check the ones to review |
 | `gA` | Show or hide archived entries, for the rest of the session |
 | `gS` | Switch the review to another checkout of this repository |
+| `gw` | Fold long lines, or stop folding them, for the rest of the session |
 | `<CR>` | Open the real file here, in a new tab |
 | `gd` | Read this file in your own diff tool ([`open_diff`](#adapters) only) |
 | `Q` | Read the queue |
@@ -146,7 +147,7 @@ The composer opens in insert mode. `<C-s>` and `<C-t>` work in insert and normal
 | `<C-p>` | Jump to a file by name |
 | `<Tab>` | Back to the diff |
 | `gp` | Dismiss the tree and land back in the diff |
-| `gl` `gb` `gc` `gA` `gS` | The same as in the diff |
+| `gl` `gb` `gc` `gA` `gS` `gw` | The same as in the diff |
 | `q` | Close |
 
 If you jump to a file that was collapsed because it is reviewed, the plugin expands it. You
@@ -618,6 +619,35 @@ captured: a deleted line on the left, and the post-image line on the right.
 **`gl` switches layouts** without losing your place, from either pane or from the file tree.
 You can therefore reach for side-by-side on the one reformatted file, without editing your
 configuration. The choice lasts the rest of the session, and it resets when Neovim exits.
+
+### Long lines
+
+A line wider than the pane runs off the right edge, and reading the end of it means scrolling
+sideways — which moves every row at once, so you lose the line you were reading to reach the
+end of it.
+
+**`gw` folds it instead**, onto as many further rows as it needs. It works from the diff and
+from the file tree, and pressing it again stops the folding.
+
+```
+▌ 42 │ +const url = buildEndpoint(config.host, config.port, "/api/v2/reviews", {
+↳         retries: 3, timeout: 30_000 })
+```
+
+A continuation row is indented to the column the code starts at, and carries `↳` where the
+change bar would be — neither the bar nor the line number repeats, because it is one line.
+Nothing is added to the buffer: annotations, reviewed marks, counts and every navigation key
+are exactly what they were.
+
+It is off until you ask for it, and `wrap = true` has it on from the first review. The choice
+`gw` makes lasts the rest of the session and is written nowhere — it says how wide *this*
+terminal is, which is not something to restore into a different one tomorrow.
+
+**A split layout never folds**, and `gw` says so rather than doing nothing: two panes that
+fold by different amounts stop being row-aligned, and row alignment is what split is for.
+`gl` back to unified folds again.
+
+[Why unified only, and where the indent comes from](docs/rationale.md#wrap)
 
 [What `gl` carries across, how the chrome splits, and the one behavior that differs](docs/rationale.md#the-split-layout)
 

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -171,6 +171,8 @@ Buffer-local, inside the review view:
                      session -- see |codereview-archived|
     gS               Switch the review to another checkout of this
                      repository -- see |:CodeReviewSwitch|
+    gw               Fold a line too wide for the pane onto further rows,
+                     or stop folding -- see |codereview-wrap|
     <CR>             Open the real file here, in a new tab
     gd               Read this file in the host's own diff tool --
                      bound only with |codereview-opt-open_diff| wired
@@ -220,6 +222,8 @@ In the file tree:                                         *codereview-tree*
                      session -- see |codereview-archived|
     gS               Switch the review to another checkout of this
                      repository -- see |:CodeReviewSwitch|
+    gw               Fold a line too wide for the pane onto further rows,
+                     or stop folding -- see |codereview-wrap|
     q                Close the review
 
 The tree collapses single-child directory chains, so a monorepo shows
@@ -433,6 +437,45 @@ is what decides at the start of every session. It is deliberately not written
 to the state file -- that file is per repository and a layout preference is
 not, and a stored preference would silently override a `layout` you had since
 changed.
+
+Wrap                                                        *codereview-wrap*
+
+A line wider than the pane runs off the right edge, and reading the end of it
+means scrolling sideways -- which moves every row at once, so the line being
+read is lost to reach the end of it. Horizontal scrolling is not synchronized
+between two panes either, and never will be: that means |scrollopt|, a global
+option this plugin does not own.
+
+`gw` folds such a line onto as many further rows as it needs, from the diff
+and from the file tree alike. Pressing it again stops the folding. >
+    ▌ 42 │ +const url = buildEndpoint(config.host, config.port, "/api", {
+    ↳         retries: 3, timeout: 30_000 })
+<
+The rows are the window's and never the diff's. Nothing is added to the
+buffer, so every anchor, every row an annotation hangs on, every reviewed mark
+and every count stay what they were, and `]h`, `[h`, `]f`, `[f`, `]a` and `[a`
+move exactly as they did. A continuation row is indented to the column the
+code starts at and carries `icons.continuation` where the change bar would be:
+neither the bar nor the line number repeats, because it is one line.
+
+The mechanism is |'wrap'|, |'breakindent'|, |'breakindentopt'| and
+|'showbreak'|, all window-local, set on the after pane after a paint. The
+continuation indent is a `shift` rather than the line's own indent: a diff row
+begins with the change bar, which is not whitespace, so Neovim computes a
+natural indent of zero for every row. The shift supplies the whole gutter
+instead, which is what makes it the same for every row in the review.
+
+It is off until asked for; `wrap = true` has it on from the first review. What
+`gw` says lasts the rest of the session and is written nowhere -- it answers a
+question about how wide this terminal is right now, which is not something to
+restore into a different one tomorrow.
+
+The split layout never folds, and `gw` says so rather than doing nothing: two
+panes that fold by different amounts stop being row-aligned on screen, and row
+alignment is what the split layout is for. `gl` back to unified folds again --
+the switch is read on every paint, so nothing stores what it was before the
+split. The file tree never folds either; its rows are truncated to the panel
+width.
 
 The sticky header                                  *codereview-sticky-header*
 
@@ -1108,6 +1151,7 @@ Defaults: >
       max_syntax_bytes = 256 * 1024,
       layout = "unified",
       spans = true,
+      wrap = false,
       archived = true,
       muted = { enabled = true, strength = 0.5 },
       faded = { enabled = true, strength = 0.35 },
@@ -1116,7 +1160,7 @@ Defaults: >
       icons = {
         reviewed = "✓", annotated = "●", unreviewed = "○",
         collapsed = "▸", expanded = "▾", change_bar = "▌",
-        untouched = "↺",
+        untouched = "↺", continuation = "↳",
       },
       types = nil,
       send = nil, pick_target = nil, pick_file = nil,
@@ -1131,6 +1175,12 @@ diff colors individually -- never the whole view.
 default. On a 12,000-line diff it lengthens opening a review by roughly a
 third and a repaint by nothing at all, because the work is done once per git
 read rather than every time the view is drawn.
+
+`wrap` folds a line too wide for its window onto further rows
+(|codereview-wrap|). It is off by default: a reviewer whose terminal is wide
+enough for their code has no problem to solve, and upgrading the plugin should
+not re-draw their review. `gw` overrides it for the rest of the session, in
+both directions, and writes nothing here. Said of the unified layout only.
 
 `archived` draws already-dispatched entries on the diff and tallies the
 untouched ones on the winbar (|codereview-archived|, |codereview-touched|).

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -167,6 +167,24 @@ apart on the first review whose line numbers grew a digit.
 terminal is wide enough for their code has no problem to solve, and upgrading the plugin
 should not re-draw their review.
 
+**`gw` overrides that for the session, and writes nothing.** The mechanism is `gA`'s: a value
+beside the configured one rather than over it, so a host's own `setup()` call goes on
+describing what the host asked for. Not persisted, and for a sharper reason than the layout's
+— wrap answers a question about how wide this terminal is right now. A **scope** is kept per
+**checkout** because it says what the review *is*; wrap says no such thing, and a choice made
+about one terminal size restored into a different one tomorrow is a worse answer than no
+memory at all.
+
+**In a split layout the key reports that it does nothing.** Silence reads as a broken key, and
+the reviewer's next move is to press it again. The message names the layout, so the key is
+real and the layout is why. It refuses before touching the switch, so returning to unified
+finds the setting you left.
+
+**A layout toggle re-decides rather than remembers.** Wrap is read on every paint, so `gl` to
+split unwraps because split does not fold, and `gl` back folds again because the override
+never moved. Nothing stores "wrap was on before the split", so there is no second copy of the
+answer for the two paths to disagree about.
+
 **A note is unaffected.** The renderer already breaks one to the pane's width before drawing
 it, because a **virtual line** clips at the window edge instead of folding. That is still
 true with wrap on, so the pre-breaking stays correct and stays necessary.

--- a/lua/codereview/config.lua
+++ b/lua/codereview/config.lua
@@ -369,4 +369,43 @@ function M.toggle_archived()
   return archived_override
 end
 
+--- The wrap switch at runtime --------------------------------------------------
+
+---What `gw` has said about **wrap**, for the rest of this editing session.
+---
+---The archived flag's arrangement above, copied rather than generalised: two module locals
+---and four short functions read as what they are, where one indirection over a table of
+---overrides would have to be understood before either switch could be.
+---
+---Deliberately not persisted, and for a sharper reason than the layout's. Wrap answers a
+---question about how wide *this terminal is right now*. A **scope** is kept per **checkout**
+---because it says what the review is; wrap says no such thing, and a choice made about one
+---terminal size restored into a different one tomorrow is a worse answer than no memory at
+---all.
+---@type boolean|nil nil until the key has been pressed, when configuration decides
+local wrap_override = nil
+
+---Whether a line too wide for its window is folded onto further rows.
+---
+---Read on every paint, which is what makes the switch re-decide rather than remember:
+---moving to the **split** layout unwraps because split does not fold, and moving back folds
+---again because nothing about the choice changed.
+---@return boolean
+function M.wrap()
+  if wrap_override == nil then
+    return M.get().wrap
+  end
+  return wrap_override
+end
+
+---Fold long lines, or stop folding them, for the rest of this editing session.
+---
+---Both directions from wherever the switch stands now, so a reviewer whose configuration
+---has wrap on can turn it off.
+---@return boolean on Whether lines are now folded
+function M.toggle_wrap()
+  wrap_override = not M.wrap()
+  return wrap_override
+end
+
 return M

--- a/lua/codereview/keymaps.lua
+++ b/lua/codereview/keymaps.lua
@@ -125,10 +125,16 @@ function M.diff(buf, view)
     -- the configured switch for the session rather than editing it.
     ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
     -- `gS` for the **switch**, from the same `g` family, and it reads as the reserved word.
-    -- `gw` was rejected because it would teach "worktree", which the glossary avoids; `gC`
-    -- and `gB` because they are confusable with the commit list and the last batch. It is
-    -- free in a nomodifiable buffer for the reason `a` became the annotation prefix.
+    -- `gC` and `gB` were rejected because they are confusable with the commit list and the
+    -- last batch, and `gw` because it would teach "worktree", which the glossary avoids --
+    -- it now says **wrap** below, which the glossary does keep. It is free in a nomodifiable
+    -- buffer for the reason `a` became the annotation prefix.
     ["gS"] = { view.switch, "Switch the review to another checkout" },
+    -- `gw` for **wrap**, from the same `g` family. Lowercase, unlike `gA`, because nothing
+    -- shadows it: `gw` is the format operator, which is dead in a nomodifiable buffer for
+    -- the reason `a` became the annotation prefix. It overrides the configured switch for
+    -- the session rather than editing it.
+    ["gw"] = { view.toggle_wrap, "Fold long lines, or stop folding them" },
     ["<CR>"] = { view.open_file, "Open the real file here" },
     ["Q"] = { view.review_queue, "Review the queue" },
     -- `gy`, not `Y`: yank is not dead in this buffer the way append is, and pulling a code
@@ -221,6 +227,9 @@ function M.panel(buf, view)
     ["gc"] = { view.commit_list, "List the commits on the branch, and trim the review" },
     ["gA"] = { view.toggle_archived, "Show or hide archived entries" },
     ["gS"] = { view.switch, "Switch the review to another checkout" },
+    -- Bound in the tree as well as in the diff, as every view-wide key is: a reviewer
+    -- standing here who wants the diff folded should not have to move first.
+    ["gw"] = { view.toggle_wrap, "Fold long lines, or stop folding them" },
     ["R"] = { view.panel_toggle_reviewed, "Toggle reviewed (whole subtree on a directory)" },
     ["q"] = { view.close, "Close the review" },
   })

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1907,6 +1907,40 @@ function M.toggle_archived()
   M.paint()
 end
 
+--- Wrap --------------------------------------------------------------------------
+
+-- The switch and the override in front of it are `config`'s, for the reason the archived
+-- flag's are: the choice outlives this view, so every review opened afterwards has to agree
+-- with it. What is left here is the name `keymaps.lua` binds to `gw` in the diff and in the
+-- tree, the repaint that makes the answer immediate, and the one sentence a layout that
+-- cannot honour the key owes the reviewer.
+
+---Fold long lines, or stop folding them, for the rest of the Neovim session.
+---
+---**Refused in the split layout, out loud.** Two **panes** that fold by different amounts
+---stop being row-aligned on screen, and row alignment is what split exists for -- so the key
+---is real and the layout is why, which is a sentence rather than a silence. A key that did
+---nothing quietly reads as a broken key, and the reviewer's next move is to press it again.
+---
+---Refused *before* the override is touched, so a reviewer who moves back to the unified
+---layout finds the setting they left rather than one a refused keystroke changed behind
+---their back.
+---
+---Nothing stores "wrap was on before the split": the switch is read on every paint, so `gl`
+---to split unwraps because split does not fold and `gl` back folds again because the
+---override never moved.
+function M.toggle_wrap()
+  if view_layout.has_before(V) then
+    info("Wrap is for the unified layout. `gl` returns to it")
+    return
+  end
+  config.toggle_wrap()
+  -- Repainted rather than left to the next reason to repaint, because a reviewer who
+  -- presses a key is asking about the diff in front of them. Nothing is re-rendered that a
+  -- resize does not re-render, and the window options this ends in are four writes.
+  M.paint()
+end
+
 --- Switching checkout -----------------------------------------------------------
 
 -- The switch is `checkout.lua`'s: the listing, the picker in front of it and the open it

--- a/lua/codereview/view_layout.lua
+++ b/lua/codereview/view_layout.lua
@@ -318,7 +318,7 @@ function M.apply_wrap(V, gutter)
   if not vim.api.nvim_win_is_valid(win) then
     return
   end
-  vim.wo[win].wrap = config.get().wrap and not M.has_before(V)
+  vim.wo[win].wrap = config.wrap() and not M.has_before(V)
   -- Inert while `wrap` is off, so they are written unconditionally rather than unwound: one
   -- code path, and no leftover for the next paint to disagree with.
   vim.wo[win].breakindent = true

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,6 +42,7 @@ Use `make test-file`, not `:PlenaryBustedFile` — that command spawns a child *
 | `codereview/interactive_init.lua` | The config `interactive_spec` drives, picker stub included — deliberately not a spec. |
 | `codereview/trim_child.lua` | Spawned twice by `trim_spec` — once to trim two branches and exit, once to report what a later session's branch review holds — deliberately not a spec. |
 | `codereview/winbar_child.lua` | Spawned four times by `split_spec` to read one cell of a pane's winbar — three inside the path for the muting, one on the file's added count for the color — deliberately not a spec. |
+| `codereview/wrap_child.lua` | Spawned by `wrap_spec` to fold long lines, queue a note and exit, so the next session can be asked what it starts from — deliberately not a spec. |
 | `perf.lua` | Timing report at two sizes, 60 files and 300: what opening, scrolling, one `CursorMoved` and a repaint cost, plus the parse-time cost of intra-line spans reported on its own so a change moving that work into the render is visible. Not part of `make test`. |
 
 | Spec | Covers |
@@ -491,6 +492,11 @@ so the out-of-core language path is still checked locally without ever failing C
   Two traps ride with these: a *screen* column is not a *window* column — the file tree is
   drawn to the left of the pane, so column 1 of the screen is in the tree — and a screen row
   is not a buffer row the moment anything folds, which is the whole point.
+- **luassert's `assert` returns three values, not one.** `local win = assert(V.panel_win)`
+  is fine, because a single-value context truncates. `vim.api.nvim_set_current_win(assert(V.panel_win))`
+  is not: the call position keeps all three, the API is handed three arguments, and it refuses
+  with `Expected 1 argument` — which reads exactly like the assertion failing on a nil. Wrap
+  the call in parentheses, or take the value into a local first.
 - **A lit row cannot be read on a changed line.** `line_hl_group` wins over `CursorLine` —
   measured, not assumed — so every added line, every deleted line and every header prints its
   own background whether or not the cursor is on that row. A painted cell taken there says

--- a/tests/codereview/wrap_child.lua
+++ b/tests/codereview/wrap_child.lua
@@ -1,0 +1,54 @@
+-- The first half of wrap_spec's restart proof: a Neovim that folds long lines and exits.
+--
+-- Deliberately a separate process, for the reason `archived_child.lua` beside it is one.
+-- "The override dies with the session" is a claim about what a *new* Neovim starts with, and
+-- no assertion made in the process that pressed the key can settle it: a module local
+-- cleared by hand says nothing about what reached the disk, and an assertion made here would
+-- pass however the override were stored.
+--
+-- It also queues an annotation, which the store genuinely does carry. That is what lets the
+-- next session prove the channel between the two is live before concluding the switch is not
+-- on it: without it, "the choice did not come back" would be satisfied by nothing coming
+-- back at all.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- wrap_spec with XDG_STATE_HOME and FIXTURE in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.columns = 110
+vim.o.lines = 40
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+-- Configured **off**, so that the state below is one only the key can have reached.
+require("codereview").setup({
+  wrap = false,
+  syntax = false,
+  compose = function(_, on_accept, _)
+    on_accept(nil, "queued by the session that folded")
+  end,
+})
+
+local config = require("codereview.config")
+local state = require("codereview.state")
+local view = require("codereview.view")
+
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+assert(vim.wo[V.win].wrap == false, "the child did not open unfolded")
+
+require("codereview.annotate").annotate("bug")
+assert(#require("codereview.queue").all() == 1, "the child queued nothing for the store to carry")
+
+view.toggle_wrap()
+assert(config.wrap() == true, "the child never reached the folded state")
+assert(vim.wo[view.current().win].wrap == true, "the child's pane is not folding")
+assert(config.get().wrap == false, "the child wrote the configured value")
+
+-- Resolved, because the state store is keyed on the root git answers with, and git answers
+-- with symlinks resolved.
+local root = assert(vim.uv.fs_realpath(fixture))
+-- Printed so a failing wrap_spec can show what the session that pressed the key believed it
+-- did. `nvim -l` sends this to stderr, not stdout.
+print(("wrap on; state file: %s"):format(state.path(root)))
+vim.cmd("qa!")

--- a/tests/codereview/wrap_spec.lua
+++ b/tests/codereview/wrap_spec.lua
@@ -241,6 +241,12 @@ describe("with wrap on, in the unified layout", function()
     compose = function(_, on_accept, _)
       on_accept(nil, "note about a folded line")
     end,
+    -- Answering with the checkout the review is already in. What the key cases below ask of
+    -- a **switch** is whether arriving anywhere leaves the setting alone, and one checkout
+    -- is enough to arrive at.
+    pick_checkout = function(_, cb)
+      cb(fixture)
+    end,
   })
   view.paint()
 
@@ -393,5 +399,172 @@ describe("a diff whose line numbers need five digits", function()
     assert.is_table(continuation, "the wide line did not fold")
     assert.same(first.col, continuation.col)
     assert.same(V.render.gutter, continuation.col - left(row))
+  end)
+end)
+
+--- The key beside the switch ----------------------------------------------------
+
+-- `gw` overrides the configured switch for the rest of this Neovim, in both directions.
+--
+-- Last in this file, and deliberately. The override is module state rather than view state,
+-- so it outlives every review opened here and nothing above may inherit it -- and "unset
+-- means the configured value" is only observable while this process has not yet pressed the
+-- key.
+--
+-- The layout intersection is here rather than in `layout_spec`: it belongs to the surface
+-- that is new, and two files driving one toggle is how a suite starts failing for reasons
+-- neither file can see.
+
+---Normal-mode mappings bound to a buffer, as a set.
+---
+---Through `vim.keycode` on both sides: the API reports a key in its own notation rather than
+---the one it was bound with, so comparing the strings as written can silently never match.
+---@param buf integer
+---@return table<string, boolean>
+local function bound(buf)
+  local lhs = {}
+  for _, m in ipairs(vim.api.nvim_buf_get_keymap(buf, "n")) do
+    lhs[vim.keycode(m.lhs)] = true
+  end
+  return lhs
+end
+
+---Feed a key with the cursor in a window, and answer with the pane afterwards.
+---@param win integer
+---@param keys string
+local function feed_in(win, keys)
+  vim.api.nvim_set_current_win(win)
+  h.feed(keys)
+  V = assert(view.current())
+end
+
+describe("a session that folded long lines and exited", function()
+  -- Shares this process's throwaway XDG_STATE_HOME and nothing else, and runs with `--clean`
+  -- so no user config and no minimal_init can hand it a different one.
+  local child = vim
+    .system({
+      vim.v.progpath,
+      "--clean",
+      "-l",
+      vim.fs.joinpath(h.root, "tests", "codereview", "wrap_child.lua"),
+    }, {
+      cwd = fixture,
+      text = true,
+      env = { XDG_STATE_HOME = vim.env.XDG_STATE_HOME, FIXTURE = fixture },
+    })
+    :wait(60000)
+
+  local root = assert(vim.uv.fs_realpath(fixture))
+  local function stored()
+    return table.concat(vim.fn.readfile(require("codereview.state").path(root)), "\n")
+  end
+
+  it("exits cleanly", function()
+    assert.same(0, child.code, (child.stderr or "") .. (child.stdout or ""))
+  end)
+
+  -- Without this the case below is vacuous: "the choice did not come back" would be
+  -- satisfied by there being no channel between the two sessions at all.
+  it("leaves what it queued in the store both sessions share", function()
+    assert.is_truthy(stored():find("queued by the session that folded", 1, true), stored())
+  end)
+
+  it("writes nothing about the switch into it", function()
+    assert.is_nil(stored():find("wrap", 1, true), stored())
+  end)
+
+  -- Configuration is what decides at the start of every session, so a choice about how wide
+  -- one terminal is cannot quietly become durable state restored into a different one.
+  it("starts this session from the configured value instead", function()
+    assert.same(config.get().wrap, config.wrap())
+  end)
+end)
+
+describe("the key beside the switch", function()
+  view.refresh()
+  V = assert(view.current())
+
+  it("is bound in the diff and in the tree", function()
+    assert.is_true(bound(V.buf)[vim.keycode("gw")] == true, "gw is not bound in the diff")
+    assert.is_true(bound(assert(V.panel_buf))[vim.keycode("gw")] == true, "gw is not bound in the tree")
+  end)
+
+  it("stops the folding when the lines were folding", function()
+    assert.is_true(vim.wo[V.win].wrap, "the review did not open folded")
+    feed_in(V.win, "gw")
+    assert.is_false(vim.wo[V.win].wrap)
+    local row, a = wide_row()
+    show(row)
+    assert.is_nil(select(2, code_columns(row, a.col)))
+  end)
+
+  it("leaves the configured value where the host set it", function()
+    assert.is_true(config.get().wrap)
+  end)
+
+  it("folds again from the file tree, without moving to the diff first", function()
+    feed_in(V.panel_win, "gw")
+    assert.is_true(vim.wo[V.win].wrap)
+    local row, a = wide_row()
+    show(row)
+    assert.is_table(select(2, code_columns(row, a.col)))
+  end)
+
+  it("keeps the choice across a repaint", function()
+    view.paint()
+    assert.is_true(vim.wo[V.win].wrap)
+  end)
+
+  -- Each of these repaints for its own reasons, and none of them is a statement about how
+  -- wide the terminal is.
+  it("is left alone by every other view-wide key", function()
+    local moves = {
+      { "reading the diff again", view.refresh },
+      {
+        "cycling scope",
+        function()
+          view.set_scope(nil)
+        end,
+      },
+      { "switching checkout", view.switch },
+      { "toggling archived entries", view.toggle_archived },
+      { "dismissing the tree", view.toggle_panel },
+      { "summoning it again", view.toggle_panel },
+    }
+    for _, move in ipairs(moves) do
+      move[2]()
+      V = assert(view.current())
+      assert.is_true(config.wrap(), "the switch moved on " .. move[1])
+      assert.is_true(vim.wo[V.win].wrap, "the pane stopped folding on " .. move[1])
+    end
+  end)
+end)
+
+describe("gw in a split layout", function()
+  view.toggle_layout()
+  V = assert(view.current())
+
+  it("says what it does rather than doing it quietly", function()
+    local messages, restore = h.capture_notify()
+    feed_in(V.win, "gw")
+    restore()
+    assert.is_true(h.notified(messages, "Wrap is for the unified layout"), vim.inspect(messages))
+  end)
+
+  it("leaves both panes unwrapped", function()
+    assert.is_false(vim.wo[V.win].wrap)
+    assert.is_false(vim.wo[V.before_win].wrap)
+  end)
+
+  -- A refusal and not a silent write: a reviewer who returns to the unified layout finds
+  -- the setting they left, not one a refused keystroke moved behind their back.
+  it("has not touched the switch", function()
+    assert.is_true(config.wrap())
+  end)
+
+  it("folds again on the way back to unified, with nothing having stored that", function()
+    view.toggle_layout()
+    V = assert(view.current())
+    assert.is_true(vim.wo[V.win].wrap)
   end)
 end)


### PR DESCRIPTION
Stacked on #201, which is where **wrap** itself lands. Review that one first; this PR's diff
against its base is the key alone.

A reviewer who meets one wide line had to edit their configuration to fold it, and restart the
review to go back. `gw` folds and unfolds, from the diff and from the **file tree** alike — as
every other view-wide key is bound, because a reviewer standing in the tree who wants the diff
folded should not have to move first.

## What this is

**The archived flag's mechanism, copied rather than generalised.** A module local in `config`
beside the configured value, nil until the key touches it, a reader that falls back to
configuration, and a toggle that flips whatever the reader answers. Two module locals and four
short functions read as what they are, where one indirection over a table of overrides would
have to be understood before either switch could be.

**Nothing is written to disk.** Wrap answers a question about how wide *this terminal is right
now*. A **scope** is kept per **checkout** because it says what the review *is*; wrap says no
such thing, and a choice made about one terminal size restored into a different one tomorrow
is a worse answer than no memory at all.

**In a split layout the key reports that it does nothing.** Silence would read as a broken
key, and the reviewer's next move is to press it again — so the message names the layout, and
the key is real and the layout is why. It refuses *before* touching the switch, so returning
to unified finds the setting the reviewer left rather than one a refused keystroke moved
behind their back.

**A layout toggle re-decides rather than remembers.** The switch is read on every paint, so
`gl` to split unwraps because split does not fold, and `gl` back folds again because the
override never moved. Nothing stores "wrap was on before the split", so there is no second
copy of the answer for the two paths to disagree about.

`gS`'s comment said `gw` was rejected because it would teach "worktree", which the glossary
avoids. It now says **wrap**, which the glossary does keep, so the comment says that instead.

## Testing

The cases live in `wrap_spec`, including the layout intersection: that belongs to the surface
that is new, and two files driving one toggle is how a suite starts failing for reasons
neither file can see.

"The override dies with the session" is a claim about what a *new* Neovim starts with, and no
assertion made in the process that pressed the key can settle it. So `wrap_child.lua` folds,
queues a note and exits, exactly as `archived_child.lua` does — the note is what proves the
channel between the two sessions is live before concluding the switch is not on it.

Closes #193