### PR TITLE
fix(view): say which file has no annotations, not that none exist

### DIFF
--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -233,15 +233,27 @@ layouts and with files collapsed rather than argued. The half that is easy to dr
 rewrite is the `[f`-from-inside-a-file one: both rules agree from a header row, so a case that
 presses `[f` only from headers passes with it wrong.
 
-**The hunk keys and the annotation keys stop at the drawn file for free, so there is no
-`if solo` to find.** `hunk_rows` and the anchor map are both built inside the render's file
-walk, which solo gates one file up, so a soloed render can only describe the file it drew:
-`]h` at that file's last hunk finds no next row and reports it, and `]a` reaches that file's
-notes and no other's. A reader looking for the branch that makes this happen will not find
-one, and adding one would be a second mechanism saying what the first already says. The
-**queue** is untouched by it — notes on files that are not drawn are still in it and still
-submit, so what these keys reach is a question about rows rather than about what a reviewer
-has written.
+**The hunk keys and the annotation keys stop at the drawn file for free, so no `if solo`
+decides what they reach.** `hunk_rows` and the anchor map are both built inside the render's
+file walk, which solo gates one file up, so a soloed render can only describe the file it
+drew: `]h` at that file's last hunk finds no next row and reports it, and `]a` reaches that
+file's notes and no other's. A reader looking for the branch that makes *that* happen will
+not find one, and adding one would be a second mechanism saying what the first already says.
+The **queue** is untouched by it — notes on files that are not drawn are still in it and
+still submit, so what these keys reach is a question about rows rather than about what a
+reviewer has written.
+
+**The one `soloed()` branch in `jump_annotation` chooses the sentence, not the rows.** There
+is now a branch to find, and this is all it does. Nothing found is a fact about the drawn
+file, while *No annotations yet* is a claim about the review, so a reviewer with six
+annotations in files that are not drawn read it as their work being gone (#215). The message
+narrows and names `Q`; the key goes on collecting from the anchors. Do not read that branch
+as permission to add a second one — the moment `if soloed()` decides what `]a` can *reach*,
+the paragraph above stops being true. Two things it leans on, neither of them visible from
+the branch itself: `soloed()` answers nil on an empty **scope**, which is what keeps an empty
+review on the wide sentence with no case of its own; and the queue is read through `V.notes`,
+the same snapshot the absence was judged against, so the two halves of the sentence cannot
+disagree about what was searched.
 
 **`R` still collapses the file it marks under solo; the advance was added beside the collapse
 rather than in place of it.** Reviewed means collapsed is one rule, it is persisted, and solo

--- a/lua/codereview/view.lua
+++ b/lua/codereview/view.lua
@@ -1292,7 +1292,37 @@ function M.jump_annotation(forward)
 
   local rows = vim.tbl_keys(owner)
   if #rows == 0 then
-    info("No annotations yet")
+    -- **The sentence says what was searched.** Under **solo** the anchors name one file, so
+    -- nothing found is a fact about that file -- while *No annotations yet* is a claim about
+    -- the review, which a reviewer holding six annotations in other files reads as their work
+    -- being gone. This branch chooses the sentence and never what the key reaches: `]a` and
+    -- `[a` go on collecting from the anchors, for the reason `]h` and `[h` stop at the drawn
+    -- file (ADR-0009), and the **queue float** is the surface that moves over every
+    -- annotation. The pointer follows `gw`'s refusal, which names the layout and then the key
+    -- that returns to it: a message ending at "there is nothing here" reads as a broken key.
+    --
+    -- Asked of `soloed()` rather than of `config.solo()`, because it is the answer the paint
+    -- was handed, so the keys and the sentence cannot come to disagree about what was drawn.
+    -- **The empty scope leans on that**: `soloed()` is nil with no files, so a review with
+    -- nothing in it keeps the wide sentence over an empty anchor map exactly as it did before
+    -- this branch existed. A `soloed()` that ever answered an index there would move this
+    -- silently, and nothing here would report it.
+    --
+    -- The queue is read through `V.notes`, which the absence above was judged against, so
+    -- both halves of the sentence read one snapshot of it. An empty queue keeps the wide
+    -- sentence: nothing found and nothing written is the honest case, and *yet* is true.
+    --
+    -- **"In this file" is what the key could reach, not what exists about the file.** An
+    -- annotation whose key matches no anchor -- stale, or on a file collapsed because it is
+    -- reviewed -- is about the drawn file and is still called absent here. That is not a bug
+    -- to be fixed later: the message is about a key, `Q` does reach that annotation, and
+    -- telling "elsewhere" from "here but unanchored" needs the counting this deliberately
+    -- does not do.
+    if soloed() and next(V.notes) ~= nil then
+      info("No annotations in this file. `Q` reviews the queue")
+    else
+      info("No annotations yet")
+    end
     return
   end
   table.sort(rows)

--- a/tests/codereview/solo_spec.lua
+++ b/tests/codereview/solo_spec.lua
@@ -652,6 +652,69 @@ describe("]a and [a", function()
     queue.clear()
     view.paint(fi)
   end)
+
+  -- The sentence beside the keys. What the keys reach is unchanged; what they *say* when they
+  -- reach nothing was a claim about the review made from a fact about one file, and a
+  -- reviewer with annotations in other files read it as their work being gone (#215).
+  it("says this file has none, and names the key that reviews the queue", function()
+    unreview()
+    queue.clear()
+    -- One annotation, and it is in a file this case will not draw.
+    local elsewhere = assert(h.file_index(V, "src/routes.lua"))
+    show(elsewhere)
+    vim.api.nvim_win_set_cursor(V.win, { assert(h.line_row(V, V.files[elsewhere].path)), 0 })
+    annotate.annotate("bug")
+    local bare = assert(h.file_index(V, "src/main.lua"))
+    show(bare)
+    assert.same(1, #queue.all())
+
+    local header = assert(V.render.file_rows[bare])
+    for _, key in ipairs({ "]a", "[a" }) do
+      vim.api.nvim_win_set_cursor(V.win, { header, 0 })
+      local said = press(V.win, key)
+      assert.is_true(h.notified(said, "No annotations in this file"), key .. ": " .. vim.inspect(said))
+      assert.is_true(h.notified(said, "`Q` reviews the queue"), key .. ": " .. vim.inspect(said))
+      -- Neither key drew another file, and neither moved off the one that is drawn.
+      assert.same({ bare }, files_drawn(V.render))
+      assert.same(header, vim.api.nvim_win_get_cursor(V.win)[1])
+    end
+    -- The queue is a rendering choice's business in neither direction: the annotation made
+    -- above is still in it, unread by any of this.
+    assert.same(1, #queue.all())
+    queue.clear()
+    view.paint(bare)
+  end)
+
+  -- The honest case keeps its honest answer. Nothing found and nothing written is not a
+  -- narrow fact, so *yet* is true and the sentence does not move.
+  it("keeps the wide sentence when the queue holds nothing either", function()
+    queue.clear()
+    local bare = assert(h.file_index(V, "src/main.lua"))
+    show(bare)
+    assert.same(0, #queue.all())
+    vim.api.nvim_win_set_cursor(V.win, { assert(V.render.file_rows[bare]), 0 })
+    local said = press(V.win, "]a")
+    assert.is_true(h.notified(said, "No annotations yet"), vim.inspect(said))
+  end)
+
+  -- And with solo off the keys searched every file, so nothing found really does mean nothing
+  -- written. This is the sentence a reviewer has always had, and a fix for how solo reads must
+  -- not change how everyone else reads.
+  it("keeps the wide sentence with solo off and nothing written anywhere", function()
+    queue.clear()
+    config.get().solo = false
+    view.paint(1)
+    vim.api.nvim_win_set_cursor(V.win, { 1, 0 })
+    local said = press(V.win, "]a")
+    local drawn = #files_drawn(V.render)
+    -- Read, put the option back, and only then assert, so a failure here does not leave solo
+    -- off under every case below this one.
+    config.get().solo = true
+    view.paint(1)
+
+    assert.is_true(drawn > 1, "solo did not come off, so this case searched one file")
+    assert.is_true(h.notified(said, "No annotations yet"), vim.inspect(said))
+  end)
 end)
 
 -- **`R` is the one key whose meaning solo changes** rather than merely repainting for.


### PR DESCRIPTION
A reviewer with **solo** on reads a file that carries no **annotation**, presses `]a`, and is
told *"No annotations yet"* while the **queue** holds six. The sentence is a claim about the
review and the fact behind it is about one file: solo made it narrow, and it kept speaking as
if it were still wide. A reviewer who trusts it concludes their work is gone.

## The keys do not change

`]a` and `[a` go on collecting from the render's **anchors**, which under solo name one file.
That is ADR-0009 holding, and it is the reasoning that made `]h` and `[h` stop at the drawn
file's last hunk rather than repaint the view to reach a hunk elsewhere. The **queue float**
already lists every annotation and already draws another file when its jump goes there.

Only the sentence moves, and only where it lies.

## Three cases, two sentences

| | Sentence |
| --- | --- |
| Solo off, nothing found | unchanged — the keys searched every file, so *yet* is true |
| Solo on, nothing found, queue empty | unchanged — the reviewer really has written nothing |
| Solo on, nothing found, queue holds one elsewhere | `` No annotations in this file. `Q` reviews the queue `` |

One branch, in the one place that reports the absence. It is asked of `soloed()` — the answer
the paint was handed — so the keys and the sentence cannot come to disagree about what was
searched; and of `V.notes`, the snapshot the absence was judged against, so both halves of the
sentence read one queue. The pointer follows `gw`'s refusal, which names the layout and then
the key that returns to it: a message ending at "there is nothing here" reads as a broken key.

## What is recorded beside the branch

Three things a later reader cannot see from the code. That the branch chooses the *sentence*
and never what the key reaches. That the empty **scope** leans on `soloed()` answering nil
with no files — one that ever answered an index there would move this silently. And that "in
this file" is what the key could reach, so an annotation whose key matches no anchor is about
the drawn file and is still called absent, which is deliberate rather than a bug awaiting a
fix.

`docs/design-notes.md` claimed *"A reader looking for the branch that makes this happen will
not find one"*. That became false, so its claim is now scoped to what the keys **reach**, and
a new paragraph names the branch that exists and what it must not grow into.

## Tests

Three cases in `solo_spec`'s existing `]a` and `[a` group, asserted through the
notify-capturing helper. The branch is mutation-checked in both directions:

| Mutation | Result |
| --- | --- |
| narrow sentence unconditional | 2 red — both wide-sentence cases |
| narrow sentence never chosen | 1 red — the new case |

Two criteria are satisfied by construction rather than by a case that could not fail: an empty
scope, because `soloed()` returns nil before anything indexes the file list; and the **split**
layout, because the branch reads no layout and the message is layout-blind. Both constructions
are written down where they are relied on.

`README.md` and `doc/codereview.txt` are unchanged: no key moves, no option is added, and
neither file quotes a notification. `doc/codereview.txt` already told the reader that the
queue is not filtered by solo — this is that fact arriving at the moment it is needed.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)