### PR TITLE
feat(view): colour a file's state mark with its leading annotation type

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -223,6 +223,21 @@ _Avoid_: category, severity, label (a label is a type's group heading)
 The instruction attached to an annotation type, telling the receiving agent what to do with
 that group. Optional — a type without one still groups.
 
+**Leading type**:
+The first **annotation type** in the configured order that has an **entry** in a file. What
+the file tree draws that file's reviewed/annotated/unreviewed mark in, so a file holding a
+bug does not look like a file holding a nitpick and a reviewer can see what to read next
+without opening anything. Said of a *file* and never of an **entry**, which has one type, nor
+of a **batch**, which groups by all of them. Decided by the **host**'s declaration order —
+the same order the type picker lists in and the **payload** groups in — so the tree holds no
+ordering of its own and a host has no second one to learn. An entry whose type is not in the
+configured list is counted and never leads; a file with none that leads keeps the colour it
+had. A file marked reviewed has none drawn on it at all: that row says *done*, which is a
+statement a type's colour would argue with, and a line-wide group over the whole row would
+flatten the colour anyway (see **Band**). Not _severity_, which **Annotation type** already
+refuses, and not _priority_, which is where a mark sits in the emission's order.
+_Avoid_: severity, priority, worst type, dominant type, highest, top type
+
 **Untyped annotation**:
 An annotation carrying no annotation type. Says something is worth reading without saying
 what should be done about it.

--- a/README.md
+++ b/README.md
@@ -770,6 +770,17 @@ group beside the glyph, which `nvim-web-devicons` and `mini.icons` both do alrea
 keeps its column and its own colour, the glyph comes out of the name's budget, and a narrow
 panel cuts the name from the left, so the end of it survives.
 
+**A file that holds a queued annotation draws its mark in that annotation's own colour.** The
+colour is the file's *leading type*: the first annotation type in your configured
+[`types`](#annotation-types) order that has an entry in that file. So a file holding a bug
+does not look like a file holding a nitpick, and the tree tells you what to read first before
+you open anything. A file holding entries of several types takes the first configured type
+present, whichever order you made the entries in. An entry whose type you have since taken out
+of `types` is still counted, and it never leads.
+
+A file you marked reviewed keeps the reviewed colour, and a file with no queued entry keeps
+the colour it had.
+
 A directory row carries a glyph of its own, from the [`dir_icon`](#adapters) adapter — a
 second one, because a directory names no file and there is nothing `file_icon` could be asked
 about it. It goes after the chevron, in your icon plugin's colour when your adapter names a

--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -246,6 +246,18 @@ and the sticky header draw for it, decided by one rule so the three cannot
 disagree. A directory row carries the glyph |codereview-opt-dir_icon| gave it,
 after the chevron. The mark keeps its column and its own color.
 
+A file that holds a queued annotation draws its mark in that annotation's own
+color. The color is the file's leading type: the first type in your configured
+`types` order that has an entry in that file. A file holding a bug therefore
+does not look like a file holding a nitpick, and the tree tells you what to
+read first before you open anything. A file holding entries of several types
+takes the first configured type present, whichever order you made the entries
+in. An entry whose type is no longer in `types` is still counted, and it never
+leads.
+
+A file you marked reviewed keeps the reviewed color, and a file with no queued
+entry keeps the color it had.
+
 A glyph is drawn in your icon plugin's own color, on every surface that draws
 it, when your adapter named a highlight group beside it: a file's glyph in the
 tree, on its header row in the diff and on the sticky header; a directory's in

--- a/docs/design-notes.md
+++ b/docs/design-notes.md
@@ -1460,6 +1460,44 @@ crossing, which is the other half of why: a winbar hung off the tree's own repai
 name the right file with the tree open and freeze the moment it was dismissed — the one
 case the header exists for.
 
+**A line-wide group replaces every attribute it sets on the marks beneath it, at every
+priority, and priority is not the lever it looks like.** Measured on painted cells, in both
+directions. A range in a group with a foreground, under a `line_hl_group` whose group also has
+one, draws the *line's* foreground: with the line at its default priority, at 200, at 4096,
+and with the range raised to 300 against every one of them. A `line_hl_group` carrying a
+*background* only takes the background, and the range's foreground comes through untouched.
+So a colour on a tree row survives a line-wide background and can never be made to survive a
+line-wide foreground — which is the **Band**'s rule read the other way round, and specific
+enough to decide a case the glossary sentence is not.
+
+**The two line-wide groups on a tree row therefore answer differently.**
+`CodeReviewPanelSel` links to `CursorLine`, which carries a background, so the row the diff
+cursor is in keeps its marks' own colours — and that is the whole of why a file's **leading
+type** reaches the one row a reviewer is looking at. `CodeReviewFileReviewed` links to
+`Comment`, which carries a foreground, so a reviewed row draws in the comment colour from end
+to end.
+
+**Which means the reviewed row's `CodeReviewStatAdd` has never reached a cell.** Measured on
+the unmodified tree, with `Added` set to `00ee00` and `Comment` to `ee0000`: the ✓ on a
+reviewed row reads `fg=ee0000`. That mark is emitted on every paint and draws nothing. It is
+left alone on purpose rather than removed, because a reviewed row is *meant* to be recessive —
+the tree answers what to read next, and a file already read is not a candidate, so the comment
+colour is the right statement and the green was never the one being made. For the same reason
+the leading type is not put on a reviewed row at all: a second mark that cannot draw is one
+more thing a later reader has no way of discovering is dead.
+
+**A colourscheme that gives `CursorLine` a foreground takes the leading type off the row the
+cursor is in**, and nothing in this plugin can answer it. `panel_spec` reads that case as a
+painted cell of its own, beside the three that hold, so "the colour survives the row the
+reviewer is on" says *which mechanism it survives by* rather than passing by luck.
+
+**The leading type rides in the note-count walk, and that walk is over anchor keys.** The
+bucketing loop takes `#items` per key, which is O(1) — an **entry**'s own type is something it
+did not read. So the leading type costs one comparison per entry, inside the pass that was
+already there and with no second pass anywhere. What that cost is counted in is entries
+queued and not files reviewed, which is why it stays small on the reviews the tree matters
+most on: three hundred files holding ten annotations walk ten more items.
+
 ## Windows, modes and focus
 
 **`nvim_win_call` propagates only the first return value.** Returning `line("w0"), line("w$")`

--- a/lua/codereview/panel.lua
+++ b/lua/codereview/panel.lua
@@ -28,6 +28,9 @@ local render = require("codereview.render")
 ---@field total integer        Files in this subtree
 ---@field reviewed integer     Reviewed files in this subtree
 ---@field notes integer        Annotations in this subtree
+---@field lead string|nil      Highlight group of a file's **leading type**. A file node only:
+---                            a directory answers how much of it has been read, not what kind
+---                            of thing is waiting inside it.
 
 ---@class CRPanelRender
 ---@field lines string[]
@@ -79,7 +82,7 @@ end
 ---child, so a monorepo shows `apps/api/src` on one row instead of burning three rows and
 ---six columns of indent on path segments that carry no information.
 ---@param node table
----@param stat fun(file: CRFile, path: string): boolean reviewed, integer notes
+---@param stat fun(file: CRFile, path: string): boolean reviewed, integer notes, string|nil lead
 ---@return CRPanelNode
 local function finish(node, stat)
   -- The root is virtual and has no row of its own, so it must not absorb its only child;
@@ -104,10 +107,15 @@ local function finish(node, stat)
     return a.name:lower() < b.name:lower()
   end)
   for _, file in ipairs(node.files) do
-    local reviewed, notes = stat(file.file, file.path)
+    local reviewed, notes, lead = stat(file.file, file.path)
     file.reviewed = reviewed and 1 or 0
     file.total = 1
     file.notes = notes
+    -- Not totalled onto the parent below, unlike the three above it. A directory's row says
+    -- how much of it has been read, and a **leading type** of a whole subtree would be a
+    -- second question that row was never asked -- and a fourth field on a directory node that
+    -- nothing reads is a field someone later has to prove is dead.
+    file.lead = lead
     children[#children + 1] = file
   end
 
@@ -122,22 +130,58 @@ local function finish(node, stat)
   return node
 end
 
+---A file's **leading type** is the first **annotation type** in the *configured* order with an
+---**entry** in that file, and it is what colours the file's state mark.
+---
+---**The configured order arrives as an argument**, the way the glyph table and the icon
+---adapters already do, so this stays a pure function of what it is handed and the
+---configuration module stays out of its requires. Declaration order is the order the type
+---picker lists and the **payload** groups, so the tree agrees with both rather than holding a
+---private ordering a host would have to learn a second time.
+---
+---**Ranked by position rather than matched by name at the mark.** A rank turns "first in the
+---configured order" into one integer comparison per **entry**; comparing names would be a
+---search of the list per entry instead.
 ---@param files CRFile[]
----@param opts { reviewed: table<string, string>, notes: table<string, table[]> }
+---@param opts { reviewed: table<string, string>, notes: table<string, table[]>, types: CRType[]|nil }
 ---@return CRPanelNode
 function M.tree(files, opts)
+  local rank, group = {}, {}
+  for i, t in ipairs(opts.types or {}) do
+    rank[t.name] = rank[t.name] or i
+    group[i] = t.hl
+  end
+
   -- Note counts are bucketed once rather than rescanned per file: the naive form is
   -- O(files x annotations), which is the whole panel's cost on a large review.
-  local per_path = {}
+  --
+  -- **The leading type rides in this walk, and it is not free.** The walk is over anchor
+  -- *keys* and `#items` is O(1), so an entry's own type is something this loop did not read
+  -- before. What it adds is one comparison per **entry**, inside the pass that is already
+  -- here, and no second pass over anything. The tree is rebuilt on every file crossing as
+  -- well as on every paint, so what the cost is counted in matters: entries queued, not files
+  -- reviewed. A three-hundred-file review holding ten annotations walks ten more items.
+  local per_path, lead = {}, {}
   for key, items in pairs(opts.notes or {}) do
     local path = key:match("^(.*):[nof]:%d+$")
     if path then
       per_path[path] = (per_path[path] or 0) + #items
+      for _, item in ipairs(items) do
+        -- An entry whose type is not in the configured list is counted above and leads
+        -- nothing. A queue restored under a configuration that has since dropped a type still
+        -- says how much is waiting in a file and stops saying what kind of thing it is, which
+        -- is the same answer `types.group` gives it in the payload.
+        local r = rank[item.type]
+        if r and r < (lead[path] or math.huge) then
+          lead[path] = r
+        end
+      end
     end
   end
 
   return finish(build(files), function(_, path)
-    return (opts.reviewed or {})[path] ~= nil, per_path[path] or 0
+    local first = lead[path]
+    return (opts.reviewed or {})[path] ~= nil, per_path[path] or 0, first and group[first] or nil
   end)
 end
 
@@ -177,7 +221,7 @@ local function row_icon(adapter, path)
 end
 
 ---@param files CRFile[]
----@param opts { width: integer, icons: table, file_icon: (fun(path: string): string|nil, string|nil)|nil, dir_icon: (fun(path: string): string|nil, string|nil)|nil, reviewed: table<string, string>, notes: table<string, table[]>, collapsed: table<string, boolean>, current: integer|nil }
+---@param opts { width: integer, icons: table, types: CRType[]|nil, file_icon: (fun(path: string): string|nil, string|nil)|nil, dir_icon: (fun(path: string): string|nil, string|nil)|nil, reviewed: table<string, string>, notes: table<string, table[]>, collapsed: table<string, boolean>, current: integer|nil }
 ---@return CRPanelRender
 function M.build(files, opts)
   local icons = opts.icons
@@ -334,11 +378,25 @@ function M.build(files, opts)
     file_row[node.index] = row
     file_rows[#file_rows + 1] = row
 
-    mark(
-      row,
-      #indent,
-      { end_col = #indent + #icon, hl_group = reviewed and "CodeReviewStatAdd" or "CodeReviewNoteCount" }
-    )
+    -- **The state mark carries the file's leading type**, so a file holding a bug stops
+    -- looking like a file holding a nitpick -- and it says so in the column a reviewer already
+    -- runs their eye down for review state, rather than in a second column of its own. The
+    -- group is the type's own, so a host that replaced the vocabulary outright gets its own
+    -- groups here and the tree agrees with the picker and the queue float about one colour per
+    -- kind of finding.
+    --
+    -- **A reviewed file is not given one, and not only because the two facts have to be
+    -- ordered.** A line-wide group replaces every attribute it sets on the marks beneath it,
+    -- at every priority -- measured, and recorded in `docs/design-notes.md` -- and a reviewed
+    -- row carries `CodeReviewFileReviewed` over the whole of it. A group put here would be
+    -- named by an extmark on every paint and would reach no cell on any screen, which is a
+    -- dead mark a later reader has no way of discovering is dead. A reviewed row is
+    -- deliberately recessive anyway: the tree answers what to read next, and a file already
+    -- read is not a candidate.
+    mark(row, #indent, {
+      end_col = #indent + #icon,
+      hl_group = reviewed and "CodeReviewStatAdd" or node.lead or "CodeReviewNoteCount",
+    })
     -- The colour the host's icon plugin chose for this file, over the glyph's own bytes.
     --
     -- **A second thing about the file, laid beside the state mark and never over it.** The

--- a/lua/codereview/view_panel.lua
+++ b/lua/codereview/view_panel.lua
@@ -56,6 +56,11 @@ function M.paint_panel(V, view)
   V.panel_render = panel.build(V.files, {
     width = vim.api.nvim_win_get_width(V.panel_win),
     icons = cfg.icons,
+    -- The configured **annotation types**, in order, so the tree can colour a file's state
+    -- mark in that file's **leading type**. Handed over like the glyph table above and the
+    -- adapters below rather than read by the tree itself: the builder is pure, and what
+    -- decides which type leads is the host's own declaration order.
+    types = cfg.types,
     file_icon = cfg.file_icon,
     dir_icon = cfg.dir_icon,
     reviewed = V.reviewed,

--- a/tests/README.md
+++ b/tests/README.md
@@ -316,6 +316,16 @@ so the out-of-core language path is still checked locally without ever failing C
   which file it was is to rerun with `{ sequential = true, keep_going = true }` and read the
   failures in order. This is the same trap as "the plenary tally lies", arriving through the
   scheduler instead of through ANSI codes.
+- **A notification prints with no trailing newline, so a `Fail` line lands glued to the end of
+  one.** `vim.notify` writes `Queued bug apps/api/src/main.lua:1 (1 in queue)` and stops
+  there, and plenary's next result line goes onto the same line of the log. A parser spelled
+  `line.startswith("Fail")` then misses every failure a spec queued an annotation in front of:
+  measured on `panel_spec`, where a run holding nine failures read back as five, and the four
+  it lost were the four whose blocks annotate. Match the result marker *anywhere* in the line,
+  and cross-check against plenary's own `Success:` / `Failed:` / `Errors:` summary with the
+  ANSI codes stripped first. Third way this suite's output lies about failures, after the
+  tally and the scheduler above — and the one that is different in kind: those two are wrong
+  about the *counts*, this one is wrong about which *lines* exist to be counted.
 - **Re-opening a review does not re-read that checkout's stored queue.** The read-back
   latch is per **checkout**, and once it is set memory is the truth — a reopen points the
   queue back at the checkout and reads nothing. So a block that clears the queue by hand and

--- a/tests/codereview/leading_type_child.lua
+++ b/tests/codereview/leading_type_child.lua
@@ -1,0 +1,163 @@
+-- One painted cell of a file's **state** mark in the file tree, read in a process of its own.
+--
+-- The claim: the colour of a file's **leading type** reaches the screen. That cannot be made
+-- by a group name. Two line-wide groups already land on the rows a reviewer looks at hardest
+-- -- `CodeReviewFileReviewed` over a reviewed file's whole row, and `CodeReviewPanelSel` over
+-- the row the diff cursor is in -- and a line-wide group replaces every attribute it sets on
+-- the marks beneath it. So a foreground can be named by an extmark on every paint and be
+-- invisible on exactly the row that matters, and no assertion about that extmark can see it.
+--
+-- Four readings, one per process, chosen so that each answers one thing:
+--
+--   bug      the mark on a file holding a bug, on no line-wide group at all
+--   nitpick  the mark on a file holding only a nitpick -- a different colour on the screen,
+--            and not merely a different name in a table
+--   current  the same cell as `bug`, on the row the diff cursor is in. `CursorLine` carries a
+--            background and no foreground here, as the shipped colourscheme's does, and the
+--            cell reports both halves at once: the background says the line-wide group really
+--            painted this row, so the reading cannot pass on a row that never had one.
+--   flatten  the same row again with a foreground added to `CursorLine`. This is the control
+--            and it is the point: it says which row loses the colour and why. A line-wide
+--            foreground wins over a range's at every priority -- measured -- so a
+--            colourscheme that gives `CursorLine` a foreground takes the leading type's
+--            colour off the row the reviewer is on, and nothing in the plugin can answer it.
+--
+-- The colours are set here rather than taken from whatever theme a runner has, so each
+-- reading is an absolute number.
+--
+-- Deliberately one cell per process. `nvim__inspect_cell` reports a cell's real attributes
+-- only on the **first** call a process makes; every call after it returns attributes
+-- belonging to something else, which `muted_child.lua` measured rather than assumed.
+--
+-- The screen is 80x24 because that is the grid a headless Neovim keeps whatever `columns`
+-- and `lines` are set to: the tree is 34 columns at the left of it, so every cell read here
+-- is well inside what an assertion can reach.
+--
+-- Not named `*_spec.lua`, so PlenaryBustedDirectory does not collect it. It is spawned by
+-- panel_spec with FIXTURE and MODE in its environment, and it must NOT load
+-- tests/minimal_init.lua, which would mint a state directory of its own.
+vim.opt.runtimepath:prepend(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h:h"))
+vim.o.termguicolors = true
+vim.o.columns = 80
+vim.o.lines = 24
+
+local fixture = assert(vim.env.FIXTURE, "FIXTURE is not set")
+local mode = assert(vim.env.MODE, "MODE is not set")
+vim.cmd("cd " .. vim.fn.fnameescape(fixture))
+
+-- Three files of the nested fixture: one holding a bug, one holding only a nitpick, and one
+-- holding nothing, which is where the diff cursor is parked for the two readings that must
+-- carry no line-wide group at all.
+local BUG_FILE = "apps/api/src/main.lua"
+local NIT_FILE = "docs/guide.md"
+local PARK = "apps/api/src/routes/users.lua"
+
+vim.api.nvim_set_hl(0, "Normal", { fg = 0xffffff, bg = 0x000000 })
+vim.api.nvim_set_hl(0, "CodeReviewBug", { fg = 0x00ee00 })
+vim.api.nvim_set_hl(0, "CodeReviewNitpick", { fg = 0xee0000 })
+-- What `CodeReviewPanelSel` resolves to. A background and no foreground, which is what the
+-- shipped colourscheme gives it -- except under `flatten`, which is the whole control.
+if mode == "flatten" then
+  vim.api.nvim_set_hl(0, "CursorLine", { fg = 0xeeee00, bg = 0x0000ee })
+else
+  vim.api.nvim_set_hl(0, "CursorLine", { bg = 0x0000ee })
+end
+
+require("codereview").setup({
+  layout = "unified",
+  syntax = false,
+  compose = function(_, on_accept, _)
+    on_accept(nil, "n")
+  end,
+})
+
+local view = require("codereview.view")
+view.open("branch")
+local V = assert(view.current(), "no review view opened")
+assert(V.panel_win, "no file tree")
+
+---The lowest diff row anchored to a line of `path`. Lowest rather than whichever `pairs`
+---reaches first, so the cell a reading lands on does not move between runs.
+---@param path string
+---@return integer
+local function line_row(path)
+  local best
+  for row, a in pairs(V.render.anchors) do
+    if a.kind == "line" and V.files[a.file].path == path and (not best or row < best) then
+      best = row
+    end
+  end
+  return assert(best, path .. " has no diff line")
+end
+
+---@param path string
+---@param type_name string
+local function annotate(path, type_name)
+  vim.api.nvim_win_set_cursor(V.win, { line_row(path), 0 })
+  require("codereview.annotate").annotate(type_name)
+end
+
+annotate(BUG_FILE, "bug")
+annotate(NIT_FILE, "nitpick")
+
+-- Where the diff cursor ends up, which is what decides whether the row under test carries a
+-- line-wide group. Announced through `CursorMoved`, because the crossing the tree follows is
+-- the diff's own.
+local look_at = (mode == "current" or mode == "flatten") and BUG_FILE or PARK
+vim.api.nvim_win_set_cursor(V.win, { line_row(look_at), 0 })
+vim.api.nvim_exec_autocmds("CursorMoved", { buffer = V.buf })
+
+local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
+
+---The byte the state mark of `path` starts at in the tree, read off the marks the tree really
+---emitted in that type's group.
+---
+---Read before the cell rather than at an offset this file expects the mark at: a reading
+---taken where the case already looked says nothing about where the surface put it, and a tree
+---that emitted no range at all would pass it.
+---@param path string
+---@param group string
+---@return integer row 1-indexed, integer col 0-indexed byte
+local function mark_at(path, group)
+  local index
+  for i, f in ipairs(V.files) do
+    if f.path == path then
+      index = i
+    end
+  end
+  local row = assert(V.panel_render.file_row[assert(index, path .. " is not in this review")])
+  for _, m in
+    ipairs(vim.api.nvim_buf_get_extmarks(V.panel_buf, NS_PANEL, { row - 1, 0 }, { row - 1, -1 }, { details = true }))
+  do
+    if m[4].hl_group == group and m[4].end_col then
+      return row, m[3]
+    end
+  end
+  error(("no range on %s's tree row in %s"):format(path, group))
+end
+
+local path = mode == "nitpick" and NIT_FILE or BUG_FILE
+local group = mode == "nitpick" and "CodeReviewNitpick" or "CodeReviewBug"
+local row, col = mark_at(path, group)
+
+-- The two readings that must answer for no line-wide group at all: the tree follows the diff
+-- cursor, so the row it lights is the parked file's and never this one.
+if mode == "bug" or mode == "nitpick" then
+  assert(vim.api.nvim_win_get_cursor(V.panel_win)[1] ~= row, "the tree's cursor is on the row under test")
+end
+
+vim.cmd("redraw!")
+local pos = vim.fn.screenpos(V.panel_win, row, col + 1)
+assert(pos.row > 0 and pos.col > 0, "the row under test is off screen")
+local cell = vim.api.nvim__inspect_cell(1, pos.row - 1, pos.col - 1)
+local attrs = cell[2] or {}
+
+---@param value integer|nil
+---@return string
+local function hex(value)
+  return value and ("%06x"):format(value) or "none"
+end
+
+-- `nvim -l` sends print to stderr, not stdout, so panel_spec reads both.
+print(("cell %q fg=%s bg=%s at %d,%d"):format(cell[1], hex(attrs.foreground), hex(attrs.background), pos.row, pos.col))
+vim.cmd("qa!")

--- a/tests/codereview/panel_spec.lua
+++ b/tests/codereview/panel_spec.lua
@@ -510,3 +510,481 @@ describe("a review configured to start without a tree", function()
     assert.same(#W.files, #W.panel_render.file_rows)
   end)
 end)
+
+--- The state mark's colour -------------------------------------------------------
+--
+-- A file's **state** mark -- the leftmost thing after the indent, already three-valued for
+-- reviewed, annotated and unreviewed -- is drawn in the highlight group of that file's
+-- **leading type**: the first annotation type in the *configured* order that has an **entry**
+-- in the file. So a file holding a bug stops looking like a file holding a nitpick.
+--
+-- Appended as blocks of their own rather than woven into the ones above, and each opens the
+-- review it reads: the block before this one reopened the review, so every `V` above it is
+-- gone.
+--
+-- **What these cases cannot see.** A group named by an extmark is not a colour on a screen.
+-- Two line-wide groups already land on tree rows -- `CodeReviewFileReviewed` over a reviewed
+-- file's whole row and `CodeReviewPanelSel` over the row the diff cursor is in -- and a
+-- line-wide group replaces every attribute it sets on the marks beneath it, at every
+-- priority. Everything below would stay green with the colour invisible on both. The cells at
+-- the foot of this file are what answer that.
+
+local config = require("codereview.config")
+local render = require("codereview.render")
+
+local NS_PANEL = vim.api.nvim_create_namespace("codereview_panel")
+
+---@param W CRView
+---@param path string
+---@return integer row 1-indexed
+local function tree_row(W, path)
+  local i = assert(h.file_index(W, path), path .. " is not in this review")
+  return assert(W.panel_render.file_row[i], path .. " has no tree row")
+end
+
+---@param W CRView
+---@param row integer 1-indexed
+---@return string
+local function tree_text(W, row)
+  return vim.api.nvim_buf_get_lines(W.panel_buf, row - 1, row, false)[1]
+end
+
+---Every *range* mark on a tree row, ascending. The line-wide marks carry no `end_col` and
+---are not ranges, so they are not here.
+---@param W CRView
+---@param row integer 1-indexed
+---@return { col: integer, end_col: integer, group: string }[]
+local function ranges(W, row)
+  local out = {}
+  for _, m in
+    ipairs(vim.api.nvim_buf_get_extmarks(W.panel_buf, NS_PANEL, { row - 1, 0 }, { row - 1, -1 }, { details = true }))
+  do
+    if m[4].end_col then
+      out[#out + 1] = { col = m[3], end_col = m[4].end_col, group = m[4].hl_group }
+    end
+  end
+  table.sort(out, function(a, b)
+    return a.col < b.col
+  end)
+  return out
+end
+
+---Where a file's state mark sits, taken off the row the tree really drew rather than
+---respelled out of the arithmetic the builder used: the indent is spaces, and the mark is the
+---first thing after it and is one of the three configured glyphs.
+---@param W CRView
+---@param path string
+---@return integer row, integer col 0-indexed byte, integer end_col, string glyph
+local function state_extent(W, path)
+  local row = tree_row(W, path)
+  local text = tree_text(W, row)
+  local col = #text:match("^ *")
+  for _, key in ipairs({ "reviewed", "annotated", "unreviewed" }) do
+    local glyph = config.get().icons[key]
+    if text:sub(col + 1, col + #glyph) == glyph then
+      return row, col, col + #glyph, glyph
+    end
+  end
+  error(("no state mark at the head of %s's row: %q"):format(path, text))
+end
+
+---The group of the range covering a file's state mark. Containment rather than an exact
+---extent, so a range of the wrong width answers here with its group and is caught by the case
+---that is about width.
+---@param W CRView
+---@param path string
+---@return string
+local function state_group(W, path)
+  local row, col = state_extent(W, path)
+  for _, r in ipairs(ranges(W, row)) do
+    if r.col <= col and col < r.end_col then
+      return r.group
+    end
+  end
+  error(("no range covers the state mark on %s's row"):format(path))
+end
+
+---@param W CRView
+---@param path string
+---@param type_name string
+local function annotate_in(W, path, type_name)
+  vim.api.nvim_win_set_cursor(W.win, { assert(h.line_row(W, path), path .. " has no diff line"), 0 })
+  annotate.annotate(type_name)
+end
+
+---Every file expanded and none of them reviewed, so a block reads a review whose state it set
+---rather than one an earlier block persisted: a reviewed file is drawn collapsed, and a file
+---with no rows on the diff has no line to annotate.
+---@param W CRView
+local function fresh(W)
+  W.reviewed, W.expanded = {}, {}
+  view.paint()
+end
+
+--- With the shipped annotation types ---------------------------------------------
+
+require("codereview").setup({
+  syntax = false,
+  compose = function(_, on_accept, _)
+    on_accept(nil, "n")
+  end,
+})
+view.open("branch")
+local P = assert(view.current(), "no review view opened")
+queue.clear()
+fresh(P)
+
+-- One file per claim, so no case has to undo another's queue. Six of the seven changed files
+-- of the nested fixture are spoken for; the seventh is the clean row.
+local BUG = "apps/api/src/main.lua"
+local NIT = "docs/guide.md"
+local NIT_THEN_BUG = "apps/web/src/index.lua"
+local BUG_THEN_NIT = "packages/shared/src/types.lua"
+local NIT_THEN_SUG = "apps/web/src/components/button.lua"
+local REVIEWED = "README.md"
+local CLEAN = "apps/api/src/routes/users.lua"
+
+annotate_in(P, BUG, "bug")
+annotate_in(P, NIT, "nitpick")
+annotate_in(P, NIT_THEN_BUG, "nitpick")
+annotate_in(P, NIT_THEN_BUG, "bug")
+annotate_in(P, BUG_THEN_NIT, "bug")
+annotate_in(P, BUG_THEN_NIT, "nitpick")
+annotate_in(P, NIT_THEN_SUG, "nitpick")
+annotate_in(P, NIT_THEN_SUG, "suggestion")
+annotate_in(P, REVIEWED, "bug")
+vim.api.nvim_win_set_cursor(P.win, { P.render.file_rows[assert(h.file_index(P, REVIEWED))], 0 })
+view.toggle_reviewed()
+-- The diff cursor is parked on a file no case below reads, so no row under test carries
+-- `CodeReviewPanelSel` as well as the group it is being asked about.
+vim.api.nvim_win_set_cursor(P.win, { P.render.file_rows[assert(h.file_index(P, CLEAN))], 0 })
+vim.api.nvim_exec_autocmds("CursorMoved", { buffer = P.buf })
+
+describe("a file's state mark in its leading type's colour", function()
+  it("draws a file holding a bug in the bug type's group", function()
+    assert.same("CodeReviewBug", state_group(P, BUG))
+  end)
+
+  it("draws a file holding only a nitpick in the nitpick type's group", function()
+    assert.same("CodeReviewNitpick", state_group(P, NIT))
+  end)
+
+  -- Whichever order the entries were made in, and the type that leads is neither the first
+  -- of the configured list nor the last entry queued -- so a private ordering and a
+  -- last-one-wins rule are both red here.
+  it("takes the first configured type present, whichever order the entries were made in", function()
+    assert.same("CodeReviewBug", state_group(P, NIT_THEN_BUG))
+    assert.same("CodeReviewBug", state_group(P, BUG_THEN_NIT))
+    assert.same("CodeReviewSuggestion", state_group(P, NIT_THEN_SUG))
+  end)
+
+  it("keeps the reviewed group on a file that is reviewed and holds a bug", function()
+    local _, _, _, glyph = state_extent(P, REVIEWED)
+    assert.same(config.get().icons.reviewed, glyph)
+    assert.same("CodeReviewStatAdd", state_group(P, REVIEWED))
+  end)
+
+  it("keeps the group a file with no queued entry has today", function()
+    local _, _, _, glyph = state_extent(P, CLEAN)
+    assert.same(config.get().icons.unreviewed, glyph)
+    assert.same("CodeReviewNoteCount", state_group(P, CLEAN))
+  end)
+
+  -- The row the diff cursor is in gets the colour too, said at the mark level. It is said
+  -- again on a painted cell at the foot of this file, and only there can it be believed.
+  it("gives the row the diff cursor is in its own type's group", function()
+    local i = assert(h.file_index(P, BUG))
+    vim.api.nvim_win_set_cursor(P.win, { P.render.file_rows[i], 0 })
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = P.buf })
+
+    local row = tree_row(P, BUG)
+    local lit = vim.tbl_filter(function(m)
+      return m[4].line_hl_group == "CodeReviewPanelSel"
+    end, vim.api.nvim_buf_get_extmarks(P.panel_buf, NS_PANEL, 0, -1, { details = true }))
+    assert.same(1, #lit)
+    assert.same(row, lit[1][2] + 1)
+    assert.same("CodeReviewBug", state_group(P, BUG))
+
+    vim.api.nvim_win_set_cursor(P.win, { P.render.file_rows[assert(h.file_index(P, CLEAN))], 0 })
+    vim.api.nvim_exec_autocmds("CursorMoved", { buffer = P.buf })
+  end)
+
+  -- **The extent, as a property of the row the tree drew.** Not three offsets: three offset
+  -- assertions once passed on a directory row while a byte was covered by no range at all.
+  -- A file row leaves its name to the row's own foreground on purpose, so the claim that
+  -- holds here is that the ranges run in order, never overlap, never run past the row, and
+  -- that exactly one of them covers the state mark and covers exactly it.
+  it("colours the state mark's own bytes and nothing beside them", function()
+    local row, col, end_col = state_extent(P, BUG)
+    local text = tree_text(P, row)
+    local rs = ranges(P, row)
+
+    local last = 0
+    for _, r in ipairs(rs) do
+      assert.is_true(r.col >= last, ("range at %d overlaps the one ending at %d"):format(r.col, last))
+      assert.is_true(r.end_col > r.col, ("empty range at %d"):format(r.col))
+      assert.is_true(r.end_col <= #text, ("range ends at %d, past a row of %d bytes"):format(r.end_col, #text))
+      last = r.end_col
+    end
+
+    local over = vim.tbl_filter(function(r)
+      return r.col < end_col and r.end_col > col
+    end, rs)
+    assert.same(1, #over, "the state mark is covered by " .. #over .. " ranges")
+    assert.same({ col = col, end_col = end_col, group = "CodeReviewBug" }, over[1])
+  end)
+
+  -- The number stays on the row for now. It is redundant once the colour is there, and the
+  -- ticket that removes it and spends its columns on the `+N -M` stat is blocked by this one:
+  -- taking it out here ships a row that lost information and gained none.
+  it("leaves the note count number on the row", function()
+    assert.same("1", tree_text(P, tree_row(P, BUG)):match("(%d+)%s*$"))
+    assert.same("2", tree_text(P, tree_row(P, NIT_THEN_BUG)):match("(%d+)%s*$"))
+  end)
+
+  -- A guard rather than a red case: a directory row must come out of this unchanged, so
+  -- nothing here can be red before the change. The comparison is the builder against itself
+  -- with the type order withheld, which is the only pre-image a spec can hold.
+  it("leaves every directory row byte-for-byte what it was", function()
+    local cfg = config.get()
+    local opts = {
+      width = 34,
+      icons = cfg.icons,
+      reviewed = P.reviewed,
+      notes = P.notes,
+      collapsed = {},
+    }
+    local without = panel.build(P.files, opts)
+    local with = panel.build(P.files, vim.tbl_extend("force", opts, { types = cfg.types }))
+
+    local function dir_rows(r)
+      local out = {}
+      for row in pairs(r.row_dir) do
+        out[#out + 1] = row
+      end
+      table.sort(out)
+      local text, dir_marks = {}, {}
+      for _, row in ipairs(out) do
+        text[#text + 1] = r.lines[row]
+      end
+      for _, m in ipairs(r.marks) do
+        if r.row_dir[m.row + 1] then
+          dir_marks[#dir_marks + 1] = m
+        end
+      end
+      return { text = text, marks = dir_marks }
+    end
+
+    assert.is_true(#dir_rows(without).text > 0, "the fixture drew no directory row")
+    assert.same(dir_rows(without), dir_rows(with))
+  end)
+
+  -- A guard, and green before the change by construction. The builder is pure and stays
+  -- pure: the configured order arrives as an argument, the way the glyph table and the icon
+  -- adapters already do.
+  it("reaches the configuration module for nothing", function()
+    local src = table.concat(vim.fn.readfile(vim.fs.joinpath(h.root, "lua", "codereview", "panel.lua")), "\n")
+    assert.is_nil(src:find("codereview.config", 1, true), "panel.lua names the configuration module")
+  end)
+end)
+
+--- A host that replaced the annotation types outright ----------------------------
+
+describe("a tree drawn under a host's own annotation types", function()
+  require("codereview").setup({
+    syntax = false,
+    compose = function(_, on_accept, _)
+      on_accept(nil, "n")
+    end,
+    types = {
+      { name = "blocker", key = "B", hl = "HostBlocker" },
+      { name = "chore", key = "c", hl = "HostChore" },
+    },
+  })
+  view.open("branch")
+  local Q = assert(view.current(), "no review view opened")
+  queue.clear()
+  fresh(Q)
+
+  local BLOCKER = "apps/api/src/main.lua"
+  local CHORE = "docs/guide.md"
+  local STRANGER = "apps/web/src/index.lua"
+  local BOTH = "packages/shared/src/types.lua"
+  local PARK = "apps/api/src/routes/users.lua"
+
+  annotate_in(Q, BLOCKER, "blocker")
+  annotate_in(Q, CHORE, "chore")
+  annotate_in(Q, BOTH, "chore")
+  -- A queue written under an older configuration: `annotate` refuses a type the host does not
+  -- have, so these go in as entries, which is what a restored queue holds.
+  for _, path in ipairs({ STRANGER, BOTH }) do
+    queue.add({
+      type = "bug",
+      kind = "file",
+      path = path,
+      abs_path = vim.fs.joinpath(Q.root, path),
+      key = render.file_key(path),
+      note = "n",
+      inline = false,
+    })
+  end
+  vim.api.nvim_win_set_cursor(Q.win, { Q.render.file_rows[assert(h.file_index(Q, PARK))], 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = Q.buf })
+  view.paint()
+
+  it("draws the host's own groups on the tree", function()
+    assert.same("HostBlocker", state_group(Q, BLOCKER))
+    assert.same("HostChore", state_group(Q, CHORE))
+  end)
+
+  it("counts an entry of a type it no longer has, and never lets it lead", function()
+    assert.same("1", tree_text(Q, tree_row(Q, STRANGER)):match("(%d+)%s*$"))
+    assert.same("CodeReviewNoteCount", state_group(Q, STRANGER))
+    assert.same("2", tree_text(Q, tree_row(Q, BOTH)):match("(%d+)%s*$"))
+    assert.same("HostChore", state_group(Q, BOTH))
+  end)
+
+  -- The *configured* order and no other: the same queue, read again under a list turned
+  -- around, hands the lead to the other type. A private ordering is red here.
+  it("takes its order from the configuration and not from a list of its own", function()
+    annotate_in(Q, BLOCKER, "chore")
+    view.paint()
+    assert.same("HostBlocker", state_group(Q, BLOCKER))
+
+    require("codereview").setup({
+      syntax = false,
+      compose = function(_, on_accept, _)
+        on_accept(nil, "n")
+      end,
+      types = {
+        { name = "chore", key = "c", hl = "HostChore" },
+        { name = "blocker", key = "B", hl = "HostBlocker" },
+      },
+    })
+    view.paint()
+    assert.same("HostChore", state_group(Q, BLOCKER))
+  end)
+end)
+
+--- A host's file glyph beside it --------------------------------------------------
+
+describe("a host's file glyph beside a coloured state mark", function()
+  local LUA = "λ"
+  local AZURE = "MiniIconsAzure"
+
+  require("codereview").setup({
+    syntax = false,
+    compose = function(_, on_accept, _)
+      on_accept(nil, "n")
+    end,
+    file_icon = function(_)
+      return LUA, AZURE
+    end,
+  })
+  view.open("branch")
+  local R = assert(view.current(), "no review view opened")
+  queue.clear()
+  fresh(R)
+
+  local BUGGY = "apps/api/src/main.lua"
+  local PARK = "apps/api/src/routes/users.lua"
+  annotate_in(R, BUGGY, "bug")
+  vim.api.nvim_win_set_cursor(R.win, { R.render.file_rows[assert(h.file_index(R, PARK))], 0 })
+  vim.api.nvim_exec_autocmds("CursorMoved", { buffer = R.buf })
+
+  it("keeps its own colour, on its own bytes, beside the state mark", function()
+    local row, col, end_col = state_extent(R, BUGGY)
+    local text = tree_text(R, row)
+    local rs = ranges(R, row)
+
+    local mark = vim.tbl_filter(function(r)
+      return r.col < end_col and r.end_col > col
+    end, rs)
+    assert.same(1, #mark)
+    assert.same({ col = col, end_col = end_col, group = "CodeReviewBug" }, mark[1])
+
+    local glyph_col = assert(text:find(LUA, end_col + 1, true), "the host's glyph is not on that row") - 1
+    local glyph = vim.tbl_filter(function(r)
+      return r.group == AZURE
+    end, rs)
+    assert.same(1, #glyph)
+    assert.same({ col = glyph_col, end_col = glyph_col + #LUA, group = AZURE }, glyph[1])
+    assert.is_true(glyph[1].col >= end_col, "the host's group reaches into the state mark")
+  end)
+end)
+
+--- The cells a reviewer's screen holds --------------------------------------------
+
+-- One child per reading, because `nvim__inspect_cell` is only honest on the first call a
+-- process makes. Each opens the same review over a fixture of this block's own, in the
+-- unified layout at 80x24, and reads the cell the state mark is drawn on -- found by the mark
+-- the tree really emitted rather than at an offset this spec expects it at.
+--
+-- `00ee00` is the bug type's group, `ee0000` the nitpick's, and `0000ee` the background
+-- `CursorLine` carries -- which is what `CodeReviewPanelSel` resolves to on the row the diff
+-- cursor is in. The fourth reading gives that background a foreground as well, which is the
+-- one thing this plugin cannot answer: see the assertion.
+describe("the cell a reviewer's eye lands on", function()
+  local fixture = h.fixture("mktree")
+
+  ---@param mode string
+  ---@return string
+  local function child(mode)
+    local run = vim
+      .system({
+        vim.v.progpath,
+        "--clean",
+        "-l",
+        vim.fs.joinpath(h.root, "tests", "codereview", "leading_type_child.lua"),
+      }, {
+        cwd = fixture,
+        text = true,
+        env = {
+          FIXTURE = fixture,
+          MODE = mode,
+          XDG_STATE_HOME = vim.fn.tempname() .. "-state",
+          GIT_CONFIG_GLOBAL = "/dev/null",
+          GIT_CONFIG_SYSTEM = "/dev/null",
+        },
+      })
+      :wait(60000)
+    -- `nvim -l` sends print to stderr, so read both streams rather than guessing.
+    local out = (run.stdout or "") .. (run.stderr or "")
+    assert(run.code == 0, out)
+    -- The child queues annotations to have something to colour, and a **notification** lands
+    -- on the same stream `print` does -- so the reading is picked out of that stream by name.
+    -- Trimming the whole of it instead reads the notifications as part of the answer, and
+    -- every case below then fails on text no cell ever held.
+    local reading = assert(out:match("cell [^\n]*"), out)
+    return (reading:gsub(" at %d+,%d+$", ""))
+  end
+
+  local bug = child("bug")
+  local nitpick = child("nitpick")
+  local current = child("current")
+  local flatten = child("flatten")
+
+  it("draws the mark of a file holding a bug in the bug type's colour", function()
+    assert.same('cell "●" fg=00ee00 bg=none', bug)
+  end)
+
+  -- A different colour on a screen, and not merely a different name in a table.
+  it("draws the mark of a file holding only a nitpick in another colour", function()
+    assert.same('cell "●" fg=ee0000 bg=none', nitpick)
+  end)
+
+  -- **The reading this seam exists for.** The background says the line-wide group really
+  -- painted this row, so the case cannot pass on a row that never had one; the foreground
+  -- says the leading type's colour survived it.
+  it("keeps the colour on the row the diff cursor is in", function()
+    assert.same('cell "●" fg=00ee00 bg=0000ee', current)
+  end)
+
+  -- **And the row that loses it.** A line-wide foreground replaces a range's at every
+  -- priority -- measured, not assumed -- so a colourscheme whose `CursorLine` carries one
+  -- takes the leading type off the row the reviewer is on, and no priority the tree could
+  -- choose answers it. Here so that the reading above says *why* it holds.
+  it("loses it to a line-wide group that carries a foreground of its own", function()
+    assert.same('cell "●" fg=eeee00 bg=0000ee', flatten)
+  end)
+end)


### PR DESCRIPTION
Every file holding a queued annotation drew the same state mark in the same quiet colour, so a
file holding a bug looked exactly like a file holding a nitpick and the only way to tell was to
open one. The mark now carries the file's **leading type**: the first annotation type in the
*configured* order with an entry in that file.

```
▾ apps          1/4
  ▾ api/src
    ✗ main.lua     3      the bug's colour — a file with a bug and two nitpicks in it
    ○ users.lua
  ▾ web/src
    ▫ index.lua    1      the nitpick's colour
    ✓ button.lua          reviewed: the reviewed colour, unchanged
```

An entry whose type is not in the configured list is counted and never leads. A file marked
reviewed keeps the reviewed colour, and a file with no queued entry keeps the colour it had.
Directory rows, the footer and the panel width default are untouched, and **the note count
number stays on the row** — it is redundant once the colour is there, but #242 is what removes
it and spends its columns on the `+N -M` stat, and taking it out here would ship a row that
lost information and gained none.

## The three decisions worth reviewing

**The configured order arrives as an argument**, the way the glyph table and the icon adapters
already do, so the builder stays a pure function of what it is handed and never requires the
configuration module. Declaration order is what the type picker lists in and what the payload
groups by, so a host has one ordering rather than two, and a host that replaced the vocabulary
outright gets its own groups on the tree.

**The leading type rides in a walk that was never over entries.** The bucketing loop that
produces the per-file note counts walks anchor *keys* and takes `#items` per key, which is
O(1) — an entry's own type is something it did not read. So this is one comparison per entry,
inside the pass that was already there, and no second pass anywhere; but it is not free, and
the spec's "the walk it already makes over entries" was wrong about the code. What the cost is
counted in is entries queued, not files reviewed, which is why it stays small on the reviews
the tree matters most on: three hundred files holding ten annotations walk ten more items.

**A reviewed row is given no leading type at all, and that is a measurement rather than a
preference.** A line-wide group replaces every attribute it sets on the marks beneath it *at
every priority* — read on painted cells in both directions, with the range raised to 300
against the line at its default, at 200 and at 4096. A reviewed row carries
`CodeReviewFileReviewed`, which links to `Comment` and so carries a foreground, so a group put
on that mark would be named by an extmark on every paint and reach no cell on any screen. It
is also the wrong statement: a reviewed row is meant to be recessive, because the tree answers
what to read *next* and a file already read is not a candidate.

The same measurement found that **the reviewed row's existing `CodeReviewStatAdd` has never
reached a cell either** — with `Added` at `00ee00` and `Comment` at `ee0000`, the ✓ reads
`fg=ee0000`. That is a finding, not a change: it is recorded in `docs/design-notes.md` and the
mark is left exactly as it was.

## Why there are four painted cells and not three

`CodeReviewPanelSel` links to `CursorLine`, which carries a *background*, and that is the whole
of why the colour survives on the row the diff cursor is in — the one row a reviewer is looking
at hardest. Nothing said over group names can see that: 42 green mark-level cases once missed
exactly this class of defect in this repo.

```
cell "●" fg=00ee00 bg=none      a file holding a bug, no line-wide group on its row
cell "●" fg=ee0000 bg=none      a file holding only a nitpick — a different colour on a
                                screen, and not merely a different name in a table
cell "●" fg=00ee00 bg=0000ee    the row the diff cursor is in: the background proves the
                                line-wide group really painted, the foreground survived it
cell "●" fg=eeee00 bg=0000ee    the same row with a foreground added to CursorLine
```

The fourth is the control and it is the point. A colourscheme that gives `CursorLine` a
foreground takes the leading type off the row the reviewer is on, and no priority this plugin
could choose answers it. Without that reading the third one is only known to be green, not to
be green *for a reason* — so the three that hold now say which mechanism they hold by rather
than passing by luck.

## The extents are asserted as a property

Not as three offsets. Three offset assertions passed once on a directory row while a byte was
covered by no range at all, and it was a space, so nothing on screen could report it. The
state mark is located in the row the tree actually drew — the indent is spaces, the mark is the
first thing after it — and the claim is that the ranges run in order, never overlap, never run
past the row, and that exactly one covers the mark and covers *exactly* it. Widening that range
by one byte is invisible on screen today and reds both extent cases.

Five mutations were run on the committed tree, one at a time: dropping the argument in
`view_panel` reds nine cases and errors the cell block; making the *last* configured type lead
reds two; giving a reviewed row the leading type reds one; letting an unconfigured type lead
reds one; widening the mark's range by a byte reds two.

## Expected overlap with #243

#241 is open as #243 and we overlap in **six** files, not the three its own body predicted. It
is in the footer, at the very end of the builder; I am in `M.tree` and the file row branch,
about forty lines above it. Nothing here reads or writes the footer, the note count, the
directory rows or the panel width.

| File | Mine | Theirs |
| --- | --- | --- |
| `lua/codereview/panel.lua` | `M.tree` takes `opts.types` and ranks it; `finish` returns a third value; the file row's state mark reads it | the footer's progress bar, the last two lines of `M.build` |
| `tests/codereview/panel_spec.lua` | four `describe` blocks appended at the end, plus their helpers | two `describe` blocks appended at the end, plus two existing footer assertions changed to read the tally as the row's head |
| `README.md` | a paragraph in *The file tree* on the state mark's colour | the footer's bar and the two new `icons` keys |
| `doc/codereview.txt` | the same, in `codereview-tree` | the same |
| `docs/design-notes.md` | four paragraphs in *The file tree*: the measured precedence rule, what each line-wide group does with it, the dead `CodeReviewStatAdd`, the walk's cost | a note on arithmetic that motivates a rule not being checked by that rule passing |
| `tests/README.md` | one bullet: a notification prints with no trailing newline, so a `Fail` line lands glued to it and a `startswith` parser reads a red run green | its own bullets |

Both sets of `panel_spec` blocks are appended at the end of the file and neither reorders
anything already there, so the two should resolve as adjacent additions. One thing that needs
no edit either way: my hand-built `panel.build` options take `icons` from `config.get()` rather
than from a literal table, so they pick up #243's `progress_full` and `progress_empty` without
being touched.

Files only in this PR: `lua/codereview/view_panel.lua`, `tests/codereview/leading_type_child.lua`,
and `CONTEXT.md` — a **Leading type** glossary entry, which #239 left as "a question for the
work". The term is now load-bearing in the code, the README, the vimdoc and the design notes.
Its *Avoid* list keeps it apart from *severity*, which **Annotation type** already refuses, and
from *priority*, which in this codebase means where a mark sits in the emission order.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)
